### PR TITLE
Consider effects of future target range overrides

### DIFF
--- a/LoopKit/GlucoseRangeSchedule.swift
+++ b/LoopKit/GlucoseRangeSchedule.swift
@@ -133,7 +133,7 @@ public struct GlucoseRangeSchedule: DailySchedule, Equatable {
     /// Returns the underlying values in `unit`
     /// Consider using quantity(at:) instead
     public func value(at time: Date) -> DoubleRange {
-        if let override = override, override.isActive(at: time) || override.isActive() {
+        if let override = override, time >= override.start && Date() < override.end {
             return override.value
         }
 

--- a/LoopKit/GlucoseRangeSchedule.swift
+++ b/LoopKit/GlucoseRangeSchedule.swift
@@ -133,7 +133,7 @@ public struct GlucoseRangeSchedule: DailySchedule, Equatable {
     /// Returns the underlying values in `unit`
     /// Consider using quantity(at:) instead
     public func value(at time: Date) -> DoubleRange {
-        if let override = override, override.isActive() {
+        if let override = override, override.isActive(at: time) || override.isActive() {
             return override.value
         }
 


### PR DESCRIPTION
Over the summer, a bug fix for target range overrides introduced a small regression that stopped target range overrides scheduled in the future from having an effect until they become active. This patch ensures dosing decisions consider the target range of a future override in advance.