### PR TITLE
Support unstored entry injection in glucose effect computation

### DIFF
--- a/LoopKit/CarbKit/CarbEntry.swift
+++ b/LoopKit/CarbKit/CarbEntry.swift
@@ -6,9 +6,25 @@
 //  Copyright © 2016 Nathan Racklyeft. All rights reserved.
 //
 
-import Foundation
+import HealthKit
 
 
 public protocol CarbEntry: SampleValue {
     var absorptionTime: TimeInterval? { get }
+}
+
+public struct AnyCarbEntry: CarbEntry {
+    public var startDate: Date
+    public var quantity: HKQuantity
+    public var absorptionTime: TimeInterval?
+
+    public init(startDate: Date, quantity: HKQuantity, absorptionTime: TimeInterval?) {
+        self.startDate = startDate
+        self.quantity = quantity
+        self.absorptionTime = absorptionTime
+    }
+
+    public init<Entry: CarbEntry>(_ entry: Entry) {
+        self.init(startDate: entry.startDate, quantity: entry.quantity, absorptionTime: entry.absorptionTime)
+    }
 }

--- a/LoopKit/CarbKit/CarbStore.swift
+++ b/LoopKit/CarbKit/CarbStore.swift
@@ -868,11 +868,15 @@ extension CarbStore {
                 .map(AnyCarbEntry.init(_:)))
             
             self.getCachedCarbSamples(start: foodStart, end: end) { (samples) in
-                let effects: [GlucoseEffect]
+                var samples = samples.map(AnyCarbEntry.init(_:))
+                if !unstoredEntries.isEmpty {
+                    samples.append(contentsOf: unstoredEntries)
+                    samples.sort(by: { $0.startDate < $1.startDate })
+                }
 
-                let allSamples = (samples.map(AnyCarbEntry.init(_:)) + unstoredEntries).sorted(by: { $0.startDate < $1.startDate })
+                let effects: [GlucoseEffect]
                 if let effectVelocities = effectVelocities {
-                    effects = allSamples.map(
+                    effects = samples.map(
                         to: effectVelocities,
                         carbRatio: carbRatioSchedule,
                         insulinSensitivity: insulinSensitivitySchedule,
@@ -894,7 +898,7 @@ extension CarbStore {
                         delta: delta
                     )
                 } else {
-                    effects = allSamples.glucoseEffects(
+                    effects = samples.glucoseEffects(
                         from: start,
                         to: end,
                         carbRatios: carbRatioSchedule,

--- a/LoopKit/InsulinKit/DoseStore.swift
+++ b/LoopKit/InsulinKit/DoseStore.swift
@@ -1272,9 +1272,12 @@ extension DoseStore {
             switch result {
             case .failure(let error):
                 completion(.failure(error))
-            case .success(let doses):
-                let allDoses = (doses + unstoredDoses).sorted(by: { $0.startDate < $1.startDate })
-                let trimmedDoses = allDoses.map { (dose) -> DoseEntry in
+            case .success(var doses):
+                if !unstoredDoses.isEmpty {
+                    doses.append(contentsOf: unstoredDoses)
+                    doses.sort(by: { $0.startDate < $1.startDate })
+                }
+                let trimmedDoses = doses.map { (dose) -> DoseEntry in
                     guard dose.type != .bolus else {
                         return dose
                     }


### PR DESCRIPTION
To create charts in a redesigned carb+bolus flow demonstrating glucose predictions for carb and/or dose entries which haven't actually been stored, we'll need to inject additional entries into carb/insulin effect computations.

Breaking out this mini-PR since it's independent of UI changes.