### PR TITLE
[LOOP 949] Access control to support unified carb + bolus flow

### DIFF
--- a/LoopKit/CarbKit/CarbStore.swift
+++ b/LoopKit/CarbKit/CarbStore.swift
@@ -794,42 +794,77 @@ extension CarbStore {
         // To know COB at the requested start date, we need to fetch samples that might still be absorbing
         let foodStart = start.addingTimeInterval(-maximumAbsorptionTimeInterval)
         getCachedCarbSamples(start: foodStart, end: end) { (samples) in
-            let carbsOnBoard: [CarbValue]
-
-            if let velocities = effectVelocities, let carbRatioSchedule = self.carbRatioScheduleApplyingOverrideHistory, let insulinSensitivitySchedule = self.insulinSensitivityScheduleApplyingOverrideHistory {
-                carbsOnBoard = samples.map(
-                    to: velocities,
-                    carbRatio: carbRatioSchedule,
-                    insulinSensitivity: insulinSensitivitySchedule,
-                    absorptionTimeOverrun: self.absorptionTimeOverrun,
-                    defaultAbsorptionTime: self.defaultAbsorptionTimes.medium,
-                    delay: self.delay,
-                    initialAbsorptionTimeOverrun: self.settings.initialAbsorptionTimeOverrun,
-                    absorptionModel: self.settings.absorptionModel,
-                    adaptiveAbsorptionRateEnabled: self.settings.adaptiveAbsorptionRateEnabled,
-                    adaptiveRateStandbyIntervalFraction: self.settings.adaptiveRateStandbyIntervalFraction
-                ).dynamicCarbsOnBoard(
-                    from: start,
-                    to: end,
-                    defaultAbsorptionTime: self.defaultAbsorptionTimes.medium,
-                    absorptionModel: self.settings.absorptionModel,
-                    delay: self.delay,
-                    delta: self.delta
-                )
-            } else {
-                carbsOnBoard = samples.carbsOnBoard(
-                    from: start,
-                    to: end,
-                    defaultAbsorptionTime: self.defaultAbsorptionTimes.medium,
-                    absorptionModel: self.settings.absorptionModel,
-                    delay: self.delay,
-                    delta: self.delta
-                )
-            }
-
+            let carbsOnBoard = self.carbsOnBoard(from: samples, startingAt: start, endingAt: end, effectVelocities: effectVelocities)
             completion(carbsOnBoard)
         }
     }
+
+    /// Computes a timeline of unabsorbed carbohydrates
+    /// - Parameters:
+    ///   - start: The earliest date of values to retrieve
+    ///   - end: The latest date of values to retrieve, if provided
+    ///   - effectVelocities: A timeline of glucose effect velocities, ordered by start date
+    /// - Returns: A timeline of unabsorbed carbohydrates
+    public func carbsOnBoard<Sample: CarbEntry>(
+        from samples: [Sample],
+        startingAt start: Date,
+        endingAt end: Date? = nil,
+        effectVelocities: [GlucoseEffectVelocity]? = nil
+    ) -> [CarbValue] {
+        if  let velocities = effectVelocities,
+            let carbRatioSchedule = carbRatioScheduleApplyingOverrideHistory,
+            let insulinSensitivitySchedule = insulinSensitivityScheduleApplyingOverrideHistory
+        {
+            return samples.map(
+                to: velocities,
+                carbRatio: carbRatioSchedule,
+                insulinSensitivity: insulinSensitivitySchedule,
+                absorptionTimeOverrun: absorptionTimeOverrun,
+                defaultAbsorptionTime: defaultAbsorptionTimes.medium,
+                delay: delay,
+                initialAbsorptionTimeOverrun: settings.initialAbsorptionTimeOverrun,
+                absorptionModel: settings.absorptionModel,
+                adaptiveAbsorptionRateEnabled: settings.adaptiveAbsorptionRateEnabled,
+                adaptiveRateStandbyIntervalFraction: settings.adaptiveRateStandbyIntervalFraction
+            ).dynamicCarbsOnBoard(
+                from: start,
+                to: end,
+                defaultAbsorptionTime: defaultAbsorptionTimes.medium,
+                absorptionModel: settings.absorptionModel,
+                delay: delay,
+                delta: delta
+            )
+        } else {
+            return samples.carbsOnBoard(
+                from: start,
+                to: end,
+                defaultAbsorptionTime: defaultAbsorptionTimes.medium,
+                absorptionModel: settings.absorptionModel,
+                delay: delay,
+                delta: delta
+            )
+        }
+    }
+
+    /// Computes the single carbs on-board value occuring just prior or equal to the specified date
+    /// - Parameters:
+    ///   - date: The date of the value to retrieve
+    ///   - effectVelocities: A timeline of glucose effect velocities, ordered by start date
+    /// - Returns: The carbs on-board value
+    public func carbsOnBoard<Sample: CarbEntry>(
+        from samples: [Sample],
+        at date: Date,
+        effectVelocities: [GlucoseEffectVelocity]? = nil
+    ) throws -> CarbValue {
+        let values = carbsOnBoard(from: samples, startingAt: date.addingTimeInterval(-delta), endingAt: date, effectVelocities: effectVelocities)
+
+        guard let value = values.closestPrior(to: date) else {
+            throw CarbStoreError.noData
+        }
+
+        return value
+    }
+
 
     /// Retrieves a timeline of effect on blood glucose from carbohydrates
     ///
@@ -841,60 +876,80 @@ extension CarbStore {
     ///   - effectVelocities: A timeline of glucose effect velocities, ordered by start date
     ///   - completion: A closure called once the effects have been retrieved
     ///   - result: An array of effects, in chronological order
-    public func getGlucoseEffects(start: Date, end: Date? = nil, effectVelocities: [GlucoseEffectVelocity]? = nil, completion: @escaping(_ result: CarbStoreResult<[GlucoseEffect]>) -> Void) {
+    public func getGlucoseEffects(start: Date, end: Date? = nil, effectVelocities: [GlucoseEffectVelocity]? = nil, completion: @escaping(_ result: CarbStoreResult<(samples: [StoredCarbEntry], effects: [GlucoseEffect])>) -> Void) {
         queue.async {
-            guard let carbRatioSchedule = self.carbRatioScheduleApplyingOverrideHistory, let insulinSensitivitySchedule = self.insulinSensitivityScheduleApplyingOverrideHistory else {
+            guard self.carbRatioSchedule != nil, self.insulinSensitivitySchedule != nil else {
                 completion(.failure(.notConfigured))
                 return
             }
 
             // To know glucose effects at the requested start date, we need to fetch samples that might still be absorbing
             let foodStart = start.addingTimeInterval(-self.maximumAbsorptionTimeInterval)
-            let defaultAbsorptionTimes = self.defaultAbsorptionTimes
-            let absorptionTimeOverrun = self.absorptionTimeOverrun
-            let delay = self.delay
-            let delta = self.delta
             
             self.getCachedCarbSamples(start: foodStart, end: end) { (samples) in
-                let effects: [GlucoseEffect]
-
-                if let effectVelocities = effectVelocities {
-                    effects = samples.map(
-                        to: effectVelocities,
-                        carbRatio: carbRatioSchedule,
-                        insulinSensitivity: insulinSensitivitySchedule,
-                        absorptionTimeOverrun: absorptionTimeOverrun,
-                        defaultAbsorptionTime: defaultAbsorptionTimes.medium,
-                        delay: delay,
-                        initialAbsorptionTimeOverrun: self.settings.initialAbsorptionTimeOverrun,
-                        absorptionModel: self.settings.absorptionModel,
-                        adaptiveAbsorptionRateEnabled: self.settings.adaptiveAbsorptionRateEnabled,
-                        adaptiveRateStandbyIntervalFraction: self.settings.adaptiveRateStandbyIntervalFraction
-                    ).dynamicGlucoseEffects(
-                        from: start,
-                        to: end,
-                        carbRatios: carbRatioSchedule,
-                        insulinSensitivities: insulinSensitivitySchedule,
-                        defaultAbsorptionTime: defaultAbsorptionTimes.medium,
-                        absorptionModel: self.settings.absorptionModel,
-                        delay: delay,
-                        delta: delta
-                    )
-                } else {
-                    effects = samples.glucoseEffects(
-                        from: start,
-                        to: end,
-                        carbRatios: carbRatioSchedule,
-                        insulinSensitivities: insulinSensitivitySchedule,
-                        defaultAbsorptionTime: defaultAbsorptionTimes.medium,
-                        absorptionModel: self.settings.absorptionModel,
-                        delay: delay,
-                        delta: delta
-                    )
+                do {
+                    let effects = try self.glucoseEffects(of: samples, startingAt: start, endingAt: end, effectVelocities: effectVelocities)
+                    completion(.success((samples: samples, effects: effects)))
+                } catch let error as CarbStoreError {
+                    completion(.failure(error))
+                } catch {
+                    fatalError()
                 }
-
-                completion(.success(effects))
             }
+        }
+    }
+
+    /// Computes a timeline of effects on blood glucose from carbohydrates
+    /// - Parameters:
+    ///   - start: The earliest date of effects to retrieve
+    ///   - end: The latest date of effects to retrieve, if provided
+    ///   - effectVelocities: A timeline of glucose effect velocities, ordered by start date
+    public func glucoseEffects<Sample: CarbEntry>(
+        of samples: [Sample],
+        startingAt start: Date,
+        endingAt end: Date? = nil,
+        effectVelocities: [GlucoseEffectVelocity]? = nil
+    ) throws -> [GlucoseEffect] {
+        guard
+            let carbRatioSchedule = carbRatioScheduleApplyingOverrideHistory,
+            let insulinSensitivitySchedule = insulinSensitivityScheduleApplyingOverrideHistory
+        else {
+            throw CarbStoreError.notConfigured
+        }
+
+        if let effectVelocities = effectVelocities {
+            return samples.map(
+                to: effectVelocities,
+                carbRatio: carbRatioSchedule,
+                insulinSensitivity: insulinSensitivitySchedule,
+                absorptionTimeOverrun: absorptionTimeOverrun,
+                defaultAbsorptionTime: defaultAbsorptionTimes.medium,
+                delay: delay,
+                initialAbsorptionTimeOverrun: settings.initialAbsorptionTimeOverrun,
+                absorptionModel: settings.absorptionModel,
+                adaptiveAbsorptionRateEnabled: settings.adaptiveAbsorptionRateEnabled,
+                adaptiveRateStandbyIntervalFraction: settings.adaptiveRateStandbyIntervalFraction
+            ).dynamicGlucoseEffects(
+                from: start,
+                to: end,
+                carbRatios: carbRatioSchedule,
+                insulinSensitivities: insulinSensitivitySchedule,
+                defaultAbsorptionTime: defaultAbsorptionTimes.medium,
+                absorptionModel: settings.absorptionModel,
+                delay: delay,
+                delta: delta
+            )
+        } else {
+            return samples.glucoseEffects(
+                from: start,
+                to: end,
+                carbRatios: carbRatioSchedule,
+                insulinSensitivities: insulinSensitivitySchedule,
+                defaultAbsorptionTime: defaultAbsorptionTimes.medium,
+                absorptionModel: settings.absorptionModel,
+                delay: delay,
+                delta: delta
+            )
         }
     }
 

--- a/LoopKitUI/CarbKit/CarbEntryEditViewController.swift
+++ b/LoopKitUI/CarbKit/CarbEntryEditViewController.swift
@@ -342,7 +342,7 @@ extension CarbEntryEditViewController: DatePickerTableViewCellDelegate {
 
 
 extension CarbEntryEditViewController: FoodTypeShortcutCellDelegate {
-    func foodTypeShortcutCellDidUpdateSelection(_ cell: FoodTypeShortcutCell) {
+    public func foodTypeShortcutCellDidUpdateSelection(_ cell: FoodTypeShortcutCell) {
         var absorptionTime: TimeInterval?
 
         switch cell.selectionState {
@@ -372,7 +372,7 @@ extension CarbEntryEditViewController: FoodTypeShortcutCellDelegate {
 
 
 extension CarbEntryEditViewController: EmojiInputControllerDelegate {
-    func emojiInputControllerDidAdvanceToStandardInputMode(_ controller: EmojiInputController) {
+    public func emojiInputControllerDidAdvanceToStandardInputMode(_ controller: EmojiInputController) {
         if let cell = tableView.cellForRow(at: IndexPath(row: Row.foodType.rawValue, section: 0)) as? TextFieldTableViewCell, let textField = cell.textField as? CustomInputTextField, textField.customInput != nil {
             let customInput = textField.customInput
             textField.customInput = nil
@@ -382,7 +382,7 @@ extension CarbEntryEditViewController: EmojiInputControllerDelegate {
         }
     }
 
-    func emojiInputControllerDidSelectItemInSection(_ section: Int) {
+    public func emojiInputControllerDidSelectItemInSection(_ section: Int) {
         guard !absorptionTimeWasEdited, section < orderedAbsorptionTimes.count else {
             return
         }

--- a/LoopKitUI/CarbKit/CarbEntryValidationNavigationDelegate.swift
+++ b/LoopKitUI/CarbKit/CarbEntryValidationNavigationDelegate.swift
@@ -8,11 +8,13 @@
 
 import Foundation
 
-class CarbEntryNavigationDelegate {
+public class CarbEntryNavigationDelegate {
     private lazy var validationTitle = LocalizedString("Warning", comment: "Title of an alert containing a validation warning")
     private lazy var dismissActionTitle = LocalizedString("com.loudnate.LoopKit.errorAlertActionTitle", value: "OK", comment: "The title of the action used to dismiss an error alert")
 
-    func showAbsorptionTimeValidationWarning(for viewController: UIViewController, maxAbsorptionTime: TimeInterval) {
+    public init() {}
+
+    public func showAbsorptionTimeValidationWarning(for viewController: UIViewController, maxAbsorptionTime: TimeInterval) {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.minute]
         formatter.unitsStyle = .full
@@ -29,7 +31,7 @@ class CarbEntryNavigationDelegate {
         viewController.present(alert, animated: true)
     }
 
-    func showMaxQuantityValidationWarning(for viewController: UIViewController, maxQuantityGrams: Double) {
+    public func showMaxQuantityValidationWarning(for viewController: UIViewController, maxQuantityGrams: Double) {
         let message = String(
             format: LocalizedString("The maximum allowed amount is %@ grams", comment: "Alert body displayed for quantity greater than max (1: maximum quantity in grams)"),
             NumberFormatter.localizedString(from: NSNumber(value: maxQuantityGrams), number: .none)

--- a/LoopKitUI/CarbKit/CustomInputTextField.swift
+++ b/LoopKitUI/CarbKit/CustomInputTextField.swift
@@ -7,11 +7,11 @@
 
 import UIKit
 
-class CustomInputTextField: UITextField {
+public class CustomInputTextField: UITextField {
 
-    var customInput: UIInputViewController?
+    public var customInput: UIInputViewController?
 
-    override var inputViewController: UIInputViewController? {
+    public override var inputViewController: UIInputViewController? {
         return customInput
     }
 

--- a/LoopKitUI/CarbKit/DecimalTextFieldTableViewCell.swift
+++ b/LoopKitUI/CarbKit/DecimalTextFieldTableViewCell.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class DecimalTextFieldTableViewCell: TextFieldTableViewCell {
+public class DecimalTextFieldTableViewCell: TextFieldTableViewCell {
 
     @IBOutlet weak var titleLabel: UILabel!
     
@@ -19,7 +19,7 @@ class DecimalTextFieldTableViewCell: TextFieldTableViewCell {
         return formatter
     }()
 
-    var number: NSNumber? {
+    public var number: NSNumber? {
         get {
             return numberFormatter.number(from: textField.text ?? "")
         }
@@ -34,7 +34,7 @@ class DecimalTextFieldTableViewCell: TextFieldTableViewCell {
 
     // MARK: - UITextFieldDelegate
 
-    override func textFieldDidEndEditing(_ textField: UITextField) {
+    public override func textFieldDidEndEditing(_ textField: UITextField) {
         if let number = number {
             textField.text = numberFormatter.string(from: number)
         } else {

--- a/LoopKitUI/CarbKit/FoodEmojiDataSource.swift
+++ b/LoopKitUI/CarbKit/FoodEmojiDataSource.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2017 LoopKit Authors. All rights reserved.
 //
 
-func CarbAbsorptionInputController() -> EmojiInputController {
+public func CarbAbsorptionInputController() -> EmojiInputController {
     return EmojiInputController.instance(withEmojis: FoodEmojiDataSource())
 }
 

--- a/LoopKitUI/CarbKit/FoodTypeShortcutCell.swift
+++ b/LoopKitUI/CarbKit/FoodTypeShortcutCell.swift
@@ -7,31 +7,36 @@
 
 import UIKit
 
-protocol FoodTypeShortcutCellDelegate: class {
+public protocol FoodTypeShortcutCellDelegate: class {
     func foodTypeShortcutCellDidUpdateSelection(_ cell: FoodTypeShortcutCell)
 }
 
 
-class FoodTypeShortcutCell: UITableViewCell {
+public class FoodTypeShortcutCell: UITableViewCell {
 
     @IBOutlet var buttonStack: UIStackView!
 
-    enum SelectionState: Int {
+    public enum SelectionState: Int {
         case fast
         case medium
         case slow
         case custom
     }
 
-    var selectionState = SelectionState.medium {
+    public var selectionState = SelectionState.medium {
         didSet {
             updateButtons()
         }
     }
 
-    weak var delegate: FoodTypeShortcutCellDelegate?
+    public weak var delegate: FoodTypeShortcutCellDelegate?
 
-    override func layoutSubviews() {
+    public var selectedEmoji: String {
+        let selectedButton = buttonStack.arrangedSubviews[selectionState.rawValue] as! UIButton
+        return selectedButton.title(for: .normal)!
+    }
+
+    public override func layoutSubviews() {
         super.layoutSubviews()
 
         contentView.layoutMargins.left = separatorInset.left

--- a/LoopKitUI/View Controllers/AddEditOverrideTableViewController.swift
+++ b/LoopKitUI/View Controllers/AddEditOverrideTableViewController.swift
@@ -598,7 +598,7 @@ extension AddEditOverrideTableViewController: TextFieldTableViewCellDelegate {
 }
 
 extension AddEditOverrideTableViewController: EmojiInputControllerDelegate {
-    func emojiInputControllerDidAdvanceToStandardInputMode(_ controller: EmojiInputController) {
+    public func emojiInputControllerDidAdvanceToStandardInputMode(_ controller: EmojiInputController) {
         guard
             let indexPath = indexPath(for: .symbol),
             let cell = tableView.cellForRow(at: indexPath) as? LabeledTextFieldTableViewCell,

--- a/LoopKitUI/View Controllers/EmojiInputController.swift
+++ b/LoopKitUI/View Controllers/EmojiInputController.swift
@@ -8,13 +8,13 @@
 import UIKit
 
 
-class EmojiInputController: UIInputViewController, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout, IdentifiableClass {
+public class EmojiInputController: UIInputViewController, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout, IdentifiableClass {
 
     @IBOutlet private weak var collectionView: UICollectionView!
 
     @IBOutlet private weak var sectionIndex: UIStackView!
 
-    weak var delegate: EmojiInputControllerDelegate?
+    public weak var delegate: EmojiInputControllerDelegate?
 
     var emojis: EmojiDataSource!
 
@@ -26,7 +26,7 @@ class EmojiInputController: UIInputViewController, UICollectionViewDataSource, U
         return controller
     }
 
-    override func viewDidLoad() {
+    public override func viewDidLoad() {
         super.viewDidLoad()
 
         inputView = view as? UIInputView
@@ -81,15 +81,15 @@ class EmojiInputController: UIInputViewController, UICollectionViewDataSource, U
 
     // MARK: - UICollectionViewDataSource
 
-    func numberOfSections(in collectionView: UICollectionView) -> Int {
+    public func numberOfSections(in collectionView: UICollectionView) -> Int {
         return emojis.sections.count
     }
 
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return emojis.sections[section].items.count
     }
 
-    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+    public func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         let cell = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: kind == UICollectionView.elementKindSectionHeader ? EmojiInputHeaderView.className : "Footer", for: indexPath)
 
         if let cell = cell as? EmojiInputHeaderView {
@@ -99,7 +99,7 @@ class EmojiInputController: UIInputViewController, UICollectionViewDataSource, U
         return cell
     }
 
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: EmojiInputCell.className, for: indexPath) as! EmojiInputCell
 
         cell.label.text = emojis.sections[indexPath.section].items[indexPath.row]
@@ -111,7 +111,7 @@ class EmojiInputController: UIInputViewController, UICollectionViewDataSource, U
 
     // MARK: - UICollectionViewDelegate
 
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         collectionView.deselectItem(at: indexPath, animated: true)
         inputView?.playInputClick​()
         textDocumentProxy.insertText(emojis.sections[indexPath.section].items[indexPath.row])
@@ -121,7 +121,7 @@ class EmojiInputController: UIInputViewController, UICollectionViewDataSource, U
 }
 
 
-protocol EmojiInputControllerDelegate: class {
+public protocol EmojiInputControllerDelegate: class {
     func emojiInputControllerDidAdvanceToStandardInputMode(_ controller: EmojiInputController)
 
     func emojiInputControllerDidSelectItemInSection(_ section: Int)
@@ -129,7 +129,7 @@ protocol EmojiInputControllerDelegate: class {
 
 // MARK: - Default Implementations
 extension EmojiInputControllerDelegate {
-    func emojiInputControllerDidSelectItemInSection(_ section: Int) { }
+    public func emojiInputControllerDidSelectItemInSection(_ section: Int) { }
 }
 
 extension UIInputView: UIInputViewAudioFeedback {

--- a/LoopKitUI/View Controllers/SetupTableViewController.swift
+++ b/LoopKitUI/View Controllers/SetupTableViewController.swift
@@ -77,7 +77,7 @@ open class SetupTableFooterView: UIView {
 
     public let primaryButton = SetupButton(type: .custom)
 
-    fileprivate override init(frame: CGRect) {
+    public override init(frame: CGRect) {
         let buttonStack = UIStackView(arrangedSubviews: [primaryButton])
 
         super.init(frame: frame)


### PR DESCRIPTION
- Expose a few UI elements publicly for use in the carb entry view controller, which has moved to Loop from LoopKit in order to simplify flow to the bolus screen.
- Refactor the pure carb effect and COB computations out of functions which also query for samples, to allow the bolus prediction chart in Loop to make computations without storing a carb entry.