### PR TITLE
LOOP-981: Adds 'connection' DeviceLogEntryType

### DIFF
--- a/LoopKit/DeviceManager/DeviceLog/DeviceLogEntryType.swift
+++ b/LoopKit/DeviceManager/DeviceLog/DeviceLogEntryType.swift
@@ -14,4 +14,5 @@ public enum DeviceLogEntryType: String {
     case error
     case delegate
     case delegateResponse
+    case connection
 }

--- a/LoopKit/DeviceManager/DeviceLog/DeviceLogEntryType.swift
+++ b/LoopKit/DeviceManager/DeviceLog/DeviceLogEntryType.swift
@@ -9,10 +9,16 @@
 import Foundation
 
 public enum DeviceLogEntryType: String {
+    /// Log entry related to data or commands sent to the device.
     case send
+    /// Log entry related to data or events received from the device.
     case receive
+    /// Log entry related to any errors from the device's SDK or the device itself.
     case error
+    /// Log entry related to a delegate call from the device's SDK (for example, acknowledgement of receiving a command).
     case delegate
+    /// Log entry related to a response from a delegate call (for example, acknowledgement of executing a command).
     case delegateResponse
+    /// Log entry related to any device connection activities (e.g. scanning, connecting, disconnecting, reconnecting, etc.).
     case connection
 }

--- a/LoopKit/DeviceManager/DeviceLog/DeviceLogEntryType.swift
+++ b/LoopKit/DeviceManager/DeviceLog/DeviceLogEntryType.swift
@@ -21,4 +21,6 @@ public enum DeviceLogEntryType: String {
     case delegateResponse
     /// Log entry related to any device connection activities (e.g. scanning, connecting, disconnecting, reconnecting, etc.).
     case connection
+    /// Log entry related to any alert activity (e.g. changing alert configuration, posting alerts, acknowledging alerts).  Note: entry may not be strictly device-related.
+    case alert
 }

--- a/LoopKit/DeviceManager/DeviceLog/DeviceLogEntryType.swift
+++ b/LoopKit/DeviceManager/DeviceLog/DeviceLogEntryType.swift
@@ -21,6 +21,4 @@ public enum DeviceLogEntryType: String {
     case delegateResponse
     /// Log entry related to any device connection activities (e.g. scanning, connecting, disconnecting, reconnecting, etc.).
     case connection
-    /// Log entry related to any alert activity (e.g. changing alert configuration, posting alerts, acknowledging alerts).  Note: entry may not be strictly device-related.
-    case alert
 }


### PR DESCRIPTION
This adds a new `DeviceLogEntryType` called `.connection`, to cover all communications related to connecting/disconnecting/reconnecting/scanning/etc. for a device.

See also https://github.com/tidepool-org/dexcom-icgm-loop-plugin/pull/24