### PR TITLE
UI/LOOP-953/new-transmitter-workflow

### DIFF
--- a/LoopKitUI/Views/GuideNavigationButton.swift
+++ b/LoopKitUI/Views/GuideNavigationButton.swift
@@ -10,13 +10,13 @@ import SwiftUI
 
 public struct GuideNavigationButton<Destination>: View where Destination: View {
     @Binding var navigationLinkIsActive: Bool
-    private let label: LocalizedStringKey
+    private let label: String
     private let buttonPressedAction: (() -> Void)?
     private let buttonStyle: GuideButtonStyle.ButtonType
     private let destination: () -> Destination
     
     public init(navigationLinkIsActive: Binding<Bool>,
-                label: LocalizedStringKey,
+                label: String,
                 buttonPressedAction: (() -> Void)? = nil,
                 buttonStyle: GuideButtonStyle.ButtonType = .primary,
                 @ViewBuilder destination: @escaping () -> Destination)

--- a/LoopKitUI/Views/InstructionList.swift
+++ b/LoopKitUI/Views/InstructionList.swift
@@ -9,9 +9,9 @@
 import SwiftUI
 
 public struct InstructionList: View {
-    let instructions: [LocalizedStringKey]
+    let instructions: [String]
     
-    public init(instructions: [LocalizedStringKey]) {
+    public init(instructions: [String]) {
         self.instructions = instructions
     }
     
@@ -36,9 +36,9 @@ public struct InstructionList: View {
 struct InstructionList_Previews: PreviewProvider {
     static var previews: some View {
         let instructions = [
-            LocalizedStringKey("This is the first step."),
-            LocalizedStringKey("This second step is a bit more tricky and needs more description to support the user, albeit it could be more concise."),
-            LocalizedStringKey("With this final step, the task will be accomplished.")
+            "This is the first step.",
+            "This second step is a bit more tricky and needs more description to support the user, albeit it could be more concise.",
+            "With this final step, the task will be accomplished."
         ]
         return InstructionList(instructions: instructions)
     }

--- a/LoopKitUI/Views/LabeledNumberInput.swift
+++ b/LoopKitUI/Views/LabeledNumberInput.swift
@@ -37,7 +37,7 @@ public struct LabeledNumberInput: View {
         )
     }
     
-    public init(value: Binding<Double?>, label: String, placeholder: String = "Value", allowFractions: Bool = false) {
+    public init(value: Binding<Double?>, label: String, placeholder: String = NSLocalizedString("Value", comment: "Placeholder text until value is entered") , allowFractions: Bool = false) {
         _value = value
         self.label = label
         self.placeholder = placeholder


### PR DESCRIPTION
Since these common elements are used by plugins, the localization should come from the plugin, not LoopKit.

Note the exception in `LabeledNumberInput.swift`, since the default placeholder string is provided by `LoopKit`.