### PR TITLE
Make ActivityIndicator public

### DIFF
--- a/LoopKitUI/Views/ActivityIndicator.swift
+++ b/LoopKitUI/Views/ActivityIndicator.swift
@@ -8,16 +8,21 @@
 
 import SwiftUI
 
-struct ActivityIndicator: UIViewRepresentable {
+public struct ActivityIndicator: UIViewRepresentable {
 
     @Binding var isAnimating: Bool
     let style: UIActivityIndicatorView.Style
+    
+    public init(isAnimating: Binding<Bool>, style: UIActivityIndicatorView.Style) {
+        self._isAnimating = isAnimating
+        self.style = style
+    }
 
-    func makeUIView(context: UIViewRepresentableContext<ActivityIndicator>) -> UIActivityIndicatorView {
+    public func makeUIView(context: UIViewRepresentableContext<ActivityIndicator>) -> UIActivityIndicatorView {
         return UIActivityIndicatorView(style: style)
     }
 
-    func updateUIView(_ uiView: UIActivityIndicatorView, context: UIViewRepresentableContext<ActivityIndicator>) {
+    public func updateUIView(_ uiView: UIActivityIndicatorView, context: UIViewRepresentableContext<ActivityIndicator>) {
         isAnimating ? uiView.startAnimating() : uiView.stopAnimating()
     }
 }


### PR DESCRIPTION
Make UIActivityIndicatorView SwiftUI wrapper view ActivityIndicator public, to support showing progress during suspend resume for https://tidepool.atlassian.net/browse/LOOP-355
