### PR TITLE
LOOP-1057: more "backward compatibility" before the DeviceAlerts land

### DIFF
--- a/LoopKit/DeviceManager/DeviceManager.swift
+++ b/LoopKit/DeviceManager/DeviceManager.swift
@@ -23,7 +23,6 @@ public protocol DeviceManagerDelegate: DeviceAlertHandler {
     func deviceManager(_ manager: DeviceManager, logEventForDeviceIdentifier deviceIdentifier: String?, type: DeviceLogEntryType, message: String, completion: ((Error?) -> Void)?)
 }
 
-
 public protocol DeviceManager: CustomDebugStringConvertible, DeviceAlertResponder {
     typealias RawStateValue = [String: Any]
 
@@ -61,5 +60,17 @@ public extension DeviceManager {
     var managerIdentifier: String {
         return Self.managerIdentifier
     }
-
 }
+
+#if !USE_NEW_ALERT_FACILITY
+public extension DeviceManager {
+    // Temporary default implementation
+    func acknowledgeAlert(typeIdentifier: DeviceAlert.TypeIdentifier) -> Void { }
+}
+public extension DeviceManagerDelegate {
+    // Temporary default implementation
+    func issueAlert(_ alert: DeviceAlert) { }
+    func removePendingAlert(identifier: DeviceAlert.Identifier) { }
+    func removeDeliveredAlert(identifier: DeviceAlert.Identifier) { }
+}
+#endif

--- a/LoopKit/Notification/LoopNotificationCategory.swift
+++ b/LoopKit/Notification/LoopNotificationCategory.swift
@@ -18,4 +18,7 @@ public enum LoopNotificationCategory: String {
     case pumpExpired
     case pumpFault
     case alert
+    #if !USE_NEW_ALERT_FACILITY
+    case cgmAlert
+    #endif
 }

--- a/LoopKit/Notification/LoopNotificationUserInfoKey.swift
+++ b/LoopKit/Notification/LoopNotificationUserInfoKey.swift
@@ -11,4 +11,7 @@ public enum LoopNotificationUserInfoKey: String {
     case bolusStartDate
     case alertTypeId
     case managerIDForAlert
+    #if !USE_NEW_ALERT_FACILITY
+    case cgmAlertID
+    #endif
 }


### PR DESCRIPTION
I forgot to add some more "backward compatibility" for the existing dependencies before the `DeviceAlert` stuff lands.
Thanks to  @mpangburn  for the heads-up.