### PR TITLE
Fix DIY build

### DIFF
--- a/LoopKit/DeviceManager/CGMManager.swift
+++ b/LoopKit/DeviceManager/CGMManager.swift
@@ -20,7 +20,7 @@ public enum CGMResult {
 }
 
 
-public protocol CGMManagerDelegate: class, DeviceManagerDelegate {
+public protocol CGMManagerDelegate: DeviceManagerDelegate {
     /// Asks the delegate for a date with which to filter incoming glucose data
     ///
     /// - Parameter manager: The manager instance

--- a/LoopKit/DeviceManager/DeviceManager.swift
+++ b/LoopKit/DeviceManager/DeviceManager.swift
@@ -50,3 +50,8 @@ public extension DeviceManager {
         return Self.managerIdentifier
     }
 }
+
+public extension DeviceManager {
+    // Default implementation of DeviceAlertResponder
+    func acknowledgeAlert(alertIdentifier: DeviceAlert.AlertIdentifier) -> Void { }
+}


### PR DESCRIPTION
Puts back the default implementation of DeviceAlertResponder (I was not aware that DIY had another DeviceManager).