### PR TITLE
Show dose progress estimator for MockPumpManager

### DIFF
--- a/MockKit/MockPumpManager.swift
+++ b/MockKit/MockPumpManager.swift
@@ -121,7 +121,8 @@ public final class MockPumpManager: TestingPumpManager {
             device: MockPumpManager.device,
             pumpBatteryChargeRemaining: state.pumpBatteryChargeRemaining,
             basalDeliveryState: basalDeliveryState(for: state),
-            bolusState: .none)
+            bolusState: bolusState(for: state)
+        )
     }
 
     public var pumpBatteryChargeRemaining: Double? {


### PR DESCRIPTION
Include bolus state in MockPumpManager status. 
The `bolusState(for:)` function was already implemented, but unused.