### PR TITLE
LOOP-1167: play back delivered and pending alerts on re-launch 

### DIFF
--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		1DA649AB2445174400F61E75 /* DeviceAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649AA2445174400F61E75 /* DeviceAlert.swift */; };
 		1DABAD3A2453615200ACF708 /* IssueAlertTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DABAD392453615200ACF708 /* IssueAlertTableViewController.swift */; };
 		1DD3DEB624451C3300BD8E40 /* DeviceAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649AA2445174400F61E75 /* DeviceAlert.swift */; };
+		1DFB99D6245CB2E900DCC8C9 /* DeviceAlertTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFB99D5245CB2E900DCC8C9 /* DeviceAlertTests.swift */; };
 		1F5DAB1D2118C95700048054 /* LocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5DAB1C2118C95700048054 /* LocalizedString.swift */; };
 		1F5DAB1F2118C95700048054 /* LocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5DAB1C2118C95700048054 /* LocalizedString.swift */; };
 		1F5DAB202118C95700048054 /* LocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5DAB1C2118C95700048054 /* LocalizedString.swift */; };
@@ -745,6 +746,7 @@
 		1D841AAC24577EE10069DBFF /* DeviceAlertSoundPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceAlertSoundPlayer.swift; sourceTree = "<group>"; };
 		1DA649AA2445174400F61E75 /* DeviceAlert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceAlert.swift; sourceTree = "<group>"; };
 		1DABAD392453615200ACF708 /* IssueAlertTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueAlertTableViewController.swift; sourceTree = "<group>"; };
+		1DFB99D5245CB2E900DCC8C9 /* DeviceAlertTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceAlertTests.swift; sourceTree = "<group>"; };
 		1F50C31F212B20D300C18FAB /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		1F50C320212B20D300C18FAB /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Main.strings; sourceTree = "<group>"; };
 		1F50C321212B20D300C18FAB /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/CarbKit.strings; sourceTree = "<group>"; };
@@ -1807,6 +1809,7 @@
 				43D8FE411C7291900073BE78 /* CarbMathTests.swift */,
 				437AFF192039F149008C4892 /* CarbStoreTests.swift */,
 				891A3FD6224BE62100378B27 /* DailyValueScheduleTests.swift */,
+				1DFB99D5245CB2E900DCC8C9 /* DeviceAlertTests.swift */,
 				A99C7374233993FE00C80963 /* DiagnosticLogTests.swift */,
 				43A067121F245A2F00E9E90F /* DoseStoreTests.swift */,
 				A971C8A323C6B1890099BEFC /* DosingDecisionStoreTests.swift */,
@@ -2972,6 +2975,7 @@
 				434113BE20F2C72000D05747 /* CachedCarbObjectTests.swift in Sources */,
 				43260F6E21C4BF7A00DD6837 /* UUID.swift in Sources */,
 				A971C8A223C6B17D0099BEFC /* SettingsStoreTests.swift in Sources */,
+				1DFB99D6245CB2E900DCC8C9 /* DeviceAlertTests.swift in Sources */,
 				4303C4941E2D665F00ADEDC8 /* TimeZone.swift in Sources */,
 				4322B76D202F9EF20002837D /* GlucoseMathTests.swift in Sources */,
 				43025DAF1D5AB2E300106C28 /* NSTimeInterval.swift in Sources */,

--- a/LoopKit/DeviceAlert.swift
+++ b/LoopKit/DeviceAlert.swift
@@ -129,6 +129,8 @@ extension DeviceAlert: Codable {
 
 extension DeviceAlert.Content: Codable { }
 extension DeviceAlert.Identifier: Codable { }
+// These Codable implementations of enums with associated values cannot be synthesized (yet) in Swift.
+// The code below follows a pattern described by https://medium.com/@hllmandel/codable-enum-with-associated-values-swift-4-e7d75d6f4370
 extension DeviceAlert.Trigger: Codable {
     private enum CodingKeys: String, CodingKey {
       case base, delayInterval, repeatInterval
@@ -164,6 +166,42 @@ extension DeviceAlert.Trigger: Codable {
         case .repeating(let repeatInterval):
             try container.encode(Base.repeating, forKey: .base)
             try container.encode(repeatInterval, forKey: .repeatInterval)
+        }
+    }
+}
+
+extension DeviceAlert.Sound: Codable {
+    private enum CodingKeys: String, CodingKey {
+      case base, name
+    }
+    private enum Base: String, Codable {
+      case silence, vibrate, sound
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let base = try container.decode(Base.self, forKey: .base)
+        switch base {
+        case .silence:
+            self = .silence
+        case .vibrate:
+            self = .vibrate
+        case .sound:
+            let name = try container.decode(String.self, forKey: .name)
+            self = .sound(name: name)
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .silence:
+            try container.encode(Base.silence, forKey: .base)
+        case .vibrate:
+            try container.encode(Base.vibrate, forKey: .base)
+        case .sound(let name):
+            try container.encode(Base.sound, forKey: .base)
+            try container.encode(name, forKey: .name)
         }
     }
 }

--- a/LoopKit/DeviceAlert.swift
+++ b/LoopKit/DeviceAlert.swift
@@ -25,7 +25,7 @@ public protocol DeviceAlertResponder: class {
 }
 
 /// Structure that represents an Alert that is issued from a Device.
-public struct DeviceAlert {
+public struct DeviceAlert: Equatable {
     /// Representation of an alert Trigger
     public enum Trigger: Equatable {
         /// Trigger the alert immediately
@@ -36,7 +36,7 @@ public struct DeviceAlert {
         case repeating(repeatInterval: TimeInterval)
     }
     /// Content of the alert, either for foreground or background alerts
-    public struct Content {
+    public struct Content: Equatable  {
         public let title: String
         public let body: String
         /// Should this alert be deemed "critical" for the User?  Handlers will determine how that is manifested.
@@ -51,7 +51,7 @@ public struct DeviceAlert {
             self.isCritical = isCritical
         }
     }
-    public struct Identifier: Hashable {
+    public struct Identifier: Equatable, Hashable {
         /// Unique device manager identifier from whence the alert came, and to which alert acknowledgements should be directed.
         public let managerIdentifier: String
         /// Per-alert-type identifier, for instance to group alert types.  This is the identifier that will be used to acknowledge the alert.

--- a/LoopKitTests/DeviceAlertTests.swift
+++ b/LoopKitTests/DeviceAlertTests.swift
@@ -1,0 +1,104 @@
+//
+//  DeviceAlertTests.swift
+//  LoopKitTests
+//
+//  Created by Rick Pasetto on 5/1/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import XCTest
+@testable import LoopKit
+
+class DeviceAlertTests: XCTestCase {
+    let identifier = DeviceAlert.Identifier(managerIdentifier: "managerIdentifier1", alertIdentifier: "alertIdentifier1")
+    let foregroundContent = DeviceAlert.Content(title: "title1", body: "body1", acknowledgeActionButtonLabel: "acknowledgeActionButtonLabel1", isCritical: false)
+    let backgroundContent = DeviceAlert.Content(title: "title2", body: "body2", acknowledgeActionButtonLabel: "acknowledgeActionButtonLabel2", isCritical: false)
+
+    func testIdentifierValue() {
+        XCTAssertEqual("managerIdentifier1.alertIdentifier1", identifier.value)
+    }
+    
+    func testDeviceAlertImmediateEncodable() {
+        let alert = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
+        let str = try? alert.encodeToString()
+    XCTAssertEqual("{\"trigger\":\"immediate\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}", str)
+    }
+    
+    func testDeviceAlertDelayedEncodable() {
+        let alert = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 1.0))
+        let str = try? alert.encodeToString()
+    XCTAssertEqual("{\"trigger\":{\"delayed\":{\"delayInterval\":1}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}", str)
+    }
+    
+    func testDeviceAlertRepeatingEncodable() {
+        let alert = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .repeating(repeatInterval: 2.0))
+        let str = try? alert.encodeToString()
+    XCTAssertEqual("{\"trigger\":{\"repeating\":{\"repeatInterval\":2}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}", str)
+    }
+    
+    func testDeviceAlertSilentSoundEncodable() {
+        let alert = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .silence)
+        let str = try? alert.encodeToString()
+        XCTAssertEqual("{\"trigger\":\"immediate\",\"sound\":\"silence\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}", str)
+    }
+
+    func testDeviceAlertVibrateSoundEncodable() {
+        let alert = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .vibrate)
+        let str = try? alert.encodeToString()
+        XCTAssertEqual("{\"trigger\":\"immediate\",\"sound\":\"vibrate\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}", str)
+    }
+
+    func testDeviceAlertSoundEncodable() {
+        let alert = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .sound(name: "soundName"))
+        let str = try? alert.encodeToString()
+        XCTAssertEqual("{\"trigger\":\"immediate\",\"sound\":{\"sound\":{\"name\":\"soundName\"}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}", str)
+    }
+
+    func testDeviceAlertImmediateDecodable() {
+        let str = "{\"trigger\":\"immediate\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
+        let expected = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
+        let alert = try? DeviceAlert.decode(from: str)
+        XCTAssertEqual(expected, alert)
+    }
+
+    func testDeviceAlertDelayedDecodable() {
+        let str = "{\"trigger\":{\"delayed\":{\"delayInterval\":1}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
+        let expected = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 1.0))
+        let alert = try? DeviceAlert.decode(from: str)
+        XCTAssertEqual(expected, alert)
+    }
+
+    func testDeviceAlertRepeatingDecodable() {
+        let str = "{\"trigger\":{\"repeating\":{\"repeatInterval\":2}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
+        let expected = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .repeating(repeatInterval: 2.0))
+        let alert = try? DeviceAlert.decode(from: str)
+        XCTAssertEqual(expected, alert)
+    }
+
+    func testDeviceAlertSilentSoundDecodable() {
+        let str = "{\"trigger\":\"immediate\",\"sound\":\"silence\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
+        let expected = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .silence)
+        let alert = try? DeviceAlert.decode(from: str)
+        XCTAssertEqual(expected, alert)
+    }
+
+    func testDeviceAlertVibrateSoundDecodable() {
+        let str = "{\"trigger\":\"immediate\",\"sound\":\"vibrate\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
+        let expected = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .vibrate)
+        let alert = try? DeviceAlert.decode(from: str)
+        XCTAssertEqual(expected, alert)
+    }
+
+    func testDeviceAlertSoundDecodable() {
+        let str = "{\"trigger\":\"immediate\",\"sound\":{\"sound\":{\"name\":\"soundName\"}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
+        let expected = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .sound(name: "soundName"))
+        let alert = try? DeviceAlert.decode(from: str)
+        XCTAssertEqual(expected, alert)
+    }
+    
+    func testDeviceAlertSoundFilename() {
+        XCTAssertNil(DeviceAlert.Sound.silence.filename)
+        XCTAssertNil(DeviceAlert.Sound.vibrate.filename)
+        XCTAssertEqual("foo", DeviceAlert.Sound.sound(name: "foo").filename)
+    }
+}

--- a/MockKitUI/View Controllers/IssueAlertTableViewController.swift
+++ b/MockKitUI/View Controllers/IssueAlertTableViewController.swift
@@ -15,6 +15,8 @@ final class IssueAlertTableViewController: UITableViewController {
   
     let cgmManager: MockCGMManager
 
+    static let delay = TimeInterval(30)
+    
     private enum AlertRow: Int, CaseIterable, CustomStringConvertible {
         case immediate = 0
         case delayed
@@ -24,19 +26,19 @@ final class IssueAlertTableViewController: UITableViewController {
        
         var description: String {
             switch self {
-            case .immediate: return "Immediate"
-            case .delayed: return "Delayed 5 seconds"
-            case .repeating: return "Repeating every 8 seconds"
-            case .issueLater: return "10 seconds Later"
-            case .buzz: return "Vibrate"
+            case .immediate: return "Issue an immediate alert"
+            case .delayed: return "Issue a \"delayed \(delay) seconds\" alert"
+            case .repeating: return "Issue a \"repeating every \(delay) seconds\" alert"
+            case .issueLater: return "Issue an immediate alert \(delay) seconds from now"
+            case .buzz: return "Issue an immediate vibrate alert"
             }
         }
         
         var trigger: DeviceAlert.Trigger {
             switch self {
             case .immediate: return .immediate
-            case .delayed: return .delayed(interval: 5)
-            case .repeating: return .repeating(repeatInterval: 8)
+            case .delayed: return .delayed(interval: delay)
+            case .repeating: return .repeating(repeatInterval: delay)
             case .issueLater: return .immediate
             case .buzz: return .immediate
             }
@@ -44,7 +46,7 @@ final class IssueAlertTableViewController: UITableViewController {
         
         var delayBeforeIssue: TimeInterval? {
             switch self {
-            case .issueLater: return 10
+            case .issueLater: return delay
             default: return nil
             }
         }


### PR DESCRIPTION
Here's the use case:  
- User gets an alert while the app is in the background.
- Alert shows in NotificationCenter, but the user does nothing about it (doesn't clear it, doesn't tap it... pretty normal for a busy person to do)
- At some point, the app is quit (i.e. ejected from memory) on iOS.  So any alerts "showing" in the UI are no longer in memory.
- The user re-launches the app (either by tapping the UserNotification or launching the app normally).  The alert modal should still be shown.

The idea here is: Let NotificationCenter keep track of those alerts.  So all I do is, upon launch, "re-play" those alerts that are in the "delivered" or "pending" lists in NotificationCenter.

However, there was a catch: the alerts delivered to NotificationCenter are not necessarily the same copy (body text) as the ones delivered in the modal.  Thus, I went ahead and implemented serializability to the DeviceAlert, which I then used to stuff into the `userInfo` on the `UNNotificationRequest` itself.  When the app launches, I deserialize it and play back. 
