### PR TITLE
Add method to notify pump manager of max temp basal changes

### DIFF
--- a/LoopKit/DeviceManager/PumpManager.swift
+++ b/LoopKit/DeviceManager/PumpManager.swift
@@ -95,7 +95,7 @@ public protocol PumpManager: DeviceManager {
     
     /// The most-recent status
     var status: PumpManagerStatus { get }
-
+    
     /// Adds an observer of changes in PumpManagerStatus
     ///
     /// Observers are held by weak reference.
@@ -163,6 +163,12 @@ public protocol PumpManager: DeviceManager {
     ///   - completion: A closure called after the command is complete
     ///   - error: An error describing why the command failed
     func resumeDelivery(completion: @escaping (_ error: Error?) -> Void)
+    
+    /// Notifies the PumpManager of a change in the user's preference for maximum basal rate.
+    ///
+    /// - Parameters:
+    ///   - rate: The maximum rate the pumpmanager should expect to receive in an enactTempBasal command.
+    func setMaximumTempBasalRate(_ rate: Double)
 }
 
 

--- a/MockKit/MockPumpManager.swift
+++ b/MockKit/MockPumpManager.swift
@@ -412,6 +412,8 @@ public final class MockPumpManager: TestingPumpManager {
     }
 
     public func acknowledgeAlert(alertIdentifier: DeviceAlert.AlertIdentifier) { }
+    
+    public func setMaximumTempBasalRate(_ rate: Double) { }
 }
 
 extension MockPumpManager {


### PR DESCRIPTION
Pod pump manager needs maximumTempBasal to be able to display relative basal rate visually.
https://tidepool.atlassian.net/browse/LOOP-1154

https://github.com/tidepool-org/Loop/pull/80
https://github.com/tidepool-org/DashKit/pull/26