### PR TITLE
Quash "'groupTableViewBackground' was deprecated in iOS 13.0" warning 

### DIFF
--- a/LoopKitUI/View Controllers/OverrideSelectionViewController.swift
+++ b/LoopKitUI/View Controllers/OverrideSelectionViewController.swift
@@ -40,7 +40,7 @@ public final class OverrideSelectionViewController: UICollectionViewController, 
         super.viewDidLoad()
 
         title = NSLocalizedString("Custom Preset", comment: "The title for the custom preset selection screen")
-        collectionView?.backgroundColor = .groupTableViewBackground
+        collectionView?.backgroundColor = .systemGroupedBackground
         navigationItem.rightBarButtonItems = [saveButton, editButton]
         navigationItem.leftBarButtonItem = cancelButton
     }


### PR DESCRIPTION
According to this (https://developer.apple.com/documentation/uikit/uicolor/1623404-grouptableviewbackground), `.groupTableViewBackground` is deprecated in iOS 13.
According to this: https://samwize.com/2019/11/26/supporting-dark-mode-in-ios-13/, we should use `.systemGroupedBackground` instead.