### PR TITLE
LOOP-1282: add `arrows` accessor more readable than `symbol`

### DIFF
--- a/LoopKit/GlucoseKit/GlucoseTrend.swift
+++ b/LoopKit/GlucoseKit/GlucoseTrend.swift
@@ -36,6 +36,25 @@ public enum GlucoseTrend: Int, CaseIterable {
             return "⇊"
         }
     }
+    
+    public var arrows: String {
+        switch self {
+        case .upUpUp:
+            return "↑↑"
+        case .upUp:
+            return "↑"
+        case .up:
+            return "↗︎"
+        case .flat:
+            return "→"
+        case .down:
+            return "↘︎"
+        case .downDown:
+            return "↓"
+        case .downDownDown:
+            return "↓↓"
+        }
+    }
 
     public var localizedDescription: String {
         switch self {


### PR DESCRIPTION
I agree with Becky, the arrows in the User Notification as they already existed in LoopKit are hard to read.  Added a separate accessor for that.  

https://tidepool.atlassian.net/browse/LOOP-1282

See also https://github.com/tidepool-org/dexcom-icgm-loop-plugin/pull/79

LW PR: https://github.com/tidepool-org/LoopWorkspace/pull/86