### PR TITLE
LOOP-1144 Refactor dosing decision errors to allow serialization

### DIFF
--- a/LoopKit/CarbKit/CarbValue.swift
+++ b/LoopKit/CarbKit/CarbValue.swift
@@ -14,7 +14,7 @@ public struct CarbValue: SampleValue {
     public let endDate: Date
     public var quantity: HKQuantity
 
-    init(startDate: Date, endDate: Date? = nil, quantity: HKQuantity) {
+    public init(startDate: Date, endDate: Date? = nil, quantity: HKQuantity) {
         self.startDate = startDate
         self.endDate = endDate ?? startDate
         self.quantity = quantity

--- a/LoopKit/DeviceManager/PumpManagerStatus.swift
+++ b/LoopKit/DeviceManager/PumpManagerStatus.swift
@@ -133,11 +133,11 @@ extension PumpManagerStatus.BasalDeliveryState: Codable {
             }
         } else {
             let container = try decoder.container(keyedBy: CodableKeys.self)
-            if let active = try? container.decode(Active.self, forKey: .active) {
+            if let active = try container.decodeIfPresent(Active.self, forKey: .active) {
                 self = .active(active.at)
-            } else if let tempBasal = try? container.decode(TempBasal.self, forKey: .tempBasal) {
+            } else if let tempBasal = try container.decodeIfPresent(TempBasal.self, forKey: .tempBasal) {
                 self = .tempBasal(tempBasal.dose)
-            } else if let suspended = try? container.decode(Suspended.self, forKey: .suspended) {
+            } else if let suspended = try container.decodeIfPresent(Suspended.self, forKey: .suspended) {
                 self = .suspended(suspended.at)
             } else {
                 throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "invalid enumeration"))
@@ -209,7 +209,7 @@ extension PumpManagerStatus.BolusState: Codable {
             }
         } else {
             let container = try decoder.container(keyedBy: CodableKeys.self)
-            if let inProgress = try? container.decode(InProgress.self, forKey: .inProgress) {
+            if let inProgress = try container.decodeIfPresent(InProgress.self, forKey: .inProgress) {
                 self = .inProgress(inProgress.dose)
             } else {
                 throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "invalid enumeration"))

--- a/LoopKit/DosingDecisionStore.swift
+++ b/LoopKit/DosingDecisionStore.swift
@@ -26,22 +26,20 @@ public class DosingDecisionStore {
     private let store: PersistenceController
     private let expireAfter: TimeInterval
     private let dataAccessQueue = DispatchQueue(label: "com.loopkit.DosingDecisionStore.dataAccessQueue", qos: .utility)
-    private let log = OSLog(category: "DosingDecisionStore")
+    public let log = OSLog(category: "DosingDecisionStore")
 
     public init(store: PersistenceController, expireAfter: TimeInterval) {
         self.store = store
         self.expireAfter = expireAfter
     }
 
-    public func storeDosingDecision(_ dosingDecision: StoredDosingDecision, completion: @escaping () -> Void) {
+    public func storeDosingDecisionData(_ dosingDecisionData: StoredDosingDecisionData, completion: @escaping () -> Void) {
         dataAccessQueue.async {
-            if let data = self.encodeDosingDecision(dosingDecision) {
-                self.store.managedObjectContext.performAndWait {
-                    let object = DosingDecisionObject(context: self.store.managedObjectContext)
-                    object.data = data
-                    object.date = dosingDecision.date
-                    self.store.save()
-                }
+            self.store.managedObjectContext.performAndWait {
+                let object = DosingDecisionObject(context: self.store.managedObjectContext)
+                object.date = dosingDecisionData.date
+                object.data = dosingDecisionData.data
+                self.store.save()
             }
 
             self.purgeExpiredDosingDecisionObjects()
@@ -67,27 +65,6 @@ public class DosingDecisionStore {
             } catch let error {
                 self.log.error("Unable to purge DosingDecisionObjects: %@", String(describing: error))
             }
-        }
-    }
-
-    private func encodeDosingDecision(_ dosingDecision: StoredDosingDecision) -> Data? {
-        do {
-            let encoder = PropertyListEncoder()
-            encoder.outputFormat = .binary
-            return try encoder.encode(dosingDecision)
-        } catch let error {
-            self.log.error("Error encoding StoredDosingDecision: %@", String(describing: error))
-            return nil
-        }
-    }
-
-    private func decodeDosingDecision(fromData data: Data) -> StoredDosingDecision? {
-        do {
-            let decoder = PropertyListDecoder()
-            return try decoder.decode(StoredDosingDecision.self, from: data)
-        } catch let error {
-            self.log.error("Error decoding StoredDosingDecision: %@", String(describing: error))
-            return nil
         }
     }
 }
@@ -116,15 +93,15 @@ extension DosingDecisionStore {
         }
     }
     
-    public enum DosingDecisionQueryResult {
-        case success(QueryAnchor, [StoredDosingDecision])
+    public enum DosingDecisionDataQueryResult {
+        case success(QueryAnchor, [StoredDosingDecisionData])
         case failure(Error)
     }
     
-    public func executeDosingDecisionQuery(fromQueryAnchor queryAnchor: QueryAnchor?, limit: Int, completion: @escaping (DosingDecisionQueryResult) -> Void) {
+    public func executeDosingDecisionDataQuery(fromQueryAnchor queryAnchor: QueryAnchor?, limit: Int, completion: @escaping (DosingDecisionDataQueryResult) -> Void) {
         dataAccessQueue.async {
             var queryAnchor = queryAnchor ?? QueryAnchor()
-            var queryResult = [StoredDosingDecision]()
+            var queryResult = [StoredDosingDecisionData]()
             var queryError: Error?
 
             guard limit > 0 else {
@@ -144,7 +121,7 @@ extension DosingDecisionStore {
                     if let modificationCounter = stored.max(by: { $0.modificationCounter < $1.modificationCounter })?.modificationCounter {
                         queryAnchor.modificationCounter = modificationCounter
                     }
-                    queryResult.append(contentsOf: stored.compactMap { self.decodeDosingDecision(fromData: $0.data) })
+                    queryResult.append(contentsOf: stored.compactMap { StoredDosingDecisionData(date: $0.date, data: $0.data) })
                 } catch let error {
                     queryError = error
                     return
@@ -161,20 +138,30 @@ extension DosingDecisionStore {
     }
 }
 
-public struct StoredDosingDecision: Codable {
+public struct StoredDosingDecisionData {
     public let date: Date
-    public var insulinOnBoard: InsulinValue?
-    public var carbsOnBoard: CarbValue?
-    public var scheduleOverride: TemporaryScheduleOverride?
-    public var glucoseTargetRangeSchedule: GlucoseRangeSchedule?
-    public var glucoseTargetRangeScheduleApplyingOverrideIfActive: GlucoseRangeSchedule?
-    public var predictedGlucose: [PredictedGlucoseValue]?
-    public var predictedGlucoseIncludingPendingInsulin: [PredictedGlucoseValue]?
-    public var lastReservoirValue: LastReservoirValue?
-    public var recommendedTempBasal: TempBasalRecommendationWithDate?
-    public var recommendedBolus: BolusRecommendationWithDate?
-    public var pumpManagerStatus: PumpManagerStatus?
-    public var errors: [CodableError]?
+    public let data: Data
+
+    public init(date: Date, data: Data) {
+        self.date = date
+        self.data = data
+    }
+}
+
+public struct StoredDosingDecision {
+    public let date: Date
+    public let insulinOnBoard: InsulinValue?
+    public let carbsOnBoard: CarbValue?
+    public let scheduleOverride: TemporaryScheduleOverride?
+    public let glucoseTargetRangeSchedule: GlucoseRangeSchedule?
+    public let glucoseTargetRangeScheduleApplyingOverrideIfActive: GlucoseRangeSchedule?
+    public let predictedGlucose: [PredictedGlucoseValue]?
+    public let predictedGlucoseIncludingPendingInsulin: [PredictedGlucoseValue]?
+    public let lastReservoirValue: LastReservoirValue?
+    public let recommendedTempBasal: TempBasalRecommendationWithDate?
+    public let recommendedBolus: BolusRecommendationWithDate?
+    public let pumpManagerStatus: PumpManagerStatus?
+    public let errors: [Error]?
     public let syncIdentifier: String
 
     public init(date: Date = Date(),
@@ -203,7 +190,7 @@ public struct StoredDosingDecision: Codable {
         self.recommendedTempBasal = recommendedTempBasal
         self.recommendedBolus = recommendedBolus
         self.pumpManagerStatus = pumpManagerStatus
-        self.errors = errors?.map { CodableError($0) }
+        self.errors = errors
         self.syncIdentifier = syncIdentifier
     }
 
@@ -235,17 +222,6 @@ public struct StoredDosingDecision: Codable {
             self.recommendation = recommendation
             self.date = date
         }
-    }
-
-    // TODO: Temporary placeholder for error serialization. Will be fixed with https://tidepool.atlassian.net/browse/LOOP-1144
-    public struct CodableError: Error, CustomStringConvertible, Codable {
-        private let errorString: String
-
-        init(_ error: Error) {
-            self.errorString = String(describing: error)
-        }
-
-        public var description: String { return errorString }
     }
 }
 

--- a/LoopKit/InsulinKit/BolusRecommendation.swift
+++ b/LoopKit/InsulinKit/BolusRecommendation.swift
@@ -18,11 +18,11 @@ public enum BolusRecommendationNotice {
 extension BolusRecommendationNotice: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodableKeys.self)
-        if let glucoseBelowSuspendThreshold = try? container.decode(GlucoseBelowSuspendThreshold.self, forKey: .glucoseBelowSuspendThreshold) {
+        if let glucoseBelowSuspendThreshold = try container.decodeIfPresent(GlucoseBelowSuspendThreshold.self, forKey: .glucoseBelowSuspendThreshold) {
             self = .glucoseBelowSuspendThreshold(minGlucose: glucoseBelowSuspendThreshold.minGlucose)
-        } else if let currentGlucoseBelowTarget = try? container.decode(CurrentGlucoseBelowTarget.self, forKey: .currentGlucoseBelowTarget) {
+        } else if let currentGlucoseBelowTarget = try container.decodeIfPresent(CurrentGlucoseBelowTarget.self, forKey: .currentGlucoseBelowTarget) {
             self = .currentGlucoseBelowTarget(glucose: currentGlucoseBelowTarget.glucose)
-        } else if let predictedGlucoseBelowTarget = try? container.decode(PredictedGlucoseBelowTarget.self, forKey: .predictedGlucoseBelowTarget) {
+        } else if let predictedGlucoseBelowTarget = try container.decodeIfPresent(PredictedGlucoseBelowTarget.self, forKey: .predictedGlucoseBelowTarget) {
             self = .predictedGlucoseBelowTarget(minGlucose: predictedGlucoseBelowTarget.minGlucose)
         } else {
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "invalid enumeration"))

--- a/LoopKit/SettingsStore.swift
+++ b/LoopKit/SettingsStore.swift
@@ -71,21 +71,26 @@ public class SettingsStore {
         }
     }
 
+    private static var encoder: PropertyListEncoder = {
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .binary
+        return encoder
+    }()
+
     private func encodeSettings(_ settings: StoredSettings) -> Data? {
         do {
-            let encoder = PropertyListEncoder()
-            encoder.outputFormat = .binary
-            return try encoder.encode(settings)
+            return try SettingsStore.encoder.encode(settings)
         } catch let error {
             self.log.error("Error encoding StoredSettings: %@", String(describing: error))
             return nil
         }
     }
 
+    private static var decoder: PropertyListDecoder = PropertyListDecoder()
+
     private func decodeSettings(fromData data: Data) -> StoredSettings? {
         do {
-            let decoder = PropertyListDecoder()
-            return try decoder.decode(StoredSettings.self, from: data)
+            return try SettingsStore.decoder.decode(StoredSettings.self, from: data)
         } catch let error {
             self.log.error("Error decoding StoredSettings: %@", String(describing: error))
             return nil

--- a/LoopKit/SettingsStore.swift
+++ b/LoopKit/SettingsStore.swift
@@ -86,7 +86,7 @@ public class SettingsStore {
         }
     }
 
-    private static var decoder: PropertyListDecoder = PropertyListDecoder()
+    private static var decoder = PropertyListDecoder()
 
     private func decodeSettings(fromData data: Data) -> StoredSettings? {
         do {

--- a/LoopKit/TemporaryScheduleOverride.swift
+++ b/LoopKit/TemporaryScheduleOverride.swift
@@ -212,7 +212,7 @@ extension TemporaryScheduleOverride.Context: Codable {
             }
         } else {
             let container = try decoder.container(keyedBy: CodableKeys.self)
-            if let preset = try? container.decode(Preset.self, forKey: .preset) {
+            if let preset = try container.decodeIfPresent(Preset.self, forKey: .preset) {
                 self = .preset(preset.preset)
             } else {
                 throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "invalid enumeration"))
@@ -294,7 +294,7 @@ extension TemporaryScheduleOverride.Duration: Codable {
             }
         } else {
             let container = try decoder.container(keyedBy: CodableKeys.self)
-            if let finite = try? container.decode(Finite.self, forKey: .finite) {
+            if let finite = try container.decodeIfPresent(Finite.self, forKey: .finite) {
                 self = .finite(finite.duration)
             } else {
                 throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "invalid enumeration"))
@@ -368,7 +368,7 @@ extension TemporaryScheduleOverride.EnactTrigger: Codable {
             }
         } else {
             let container = try decoder.container(keyedBy: CodableKeys.self)
-            if let remote = try? container.decode(Remote.self, forKey: .remote) {
+            if let remote = try container.decodeIfPresent(Remote.self, forKey: .remote) {
                 self = .remote(remote.address)
             } else {
                 throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "invalid enumeration"))

--- a/LoopKitTests/BolusRecommendationTests.swift
+++ b/LoopKitTests/BolusRecommendationTests.swift
@@ -13,25 +13,86 @@ import HealthKit
 
 class BolusRecommendationNoticeCodableTests: XCTestCase {
     func testCodableGlucoseBelowSuspendThreshold() throws {
-        let glucoseValue = SimpleGlucoseValue(startDate: Date(), quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 65.0))
-        try assertBolusRecommendationNoticeCodable(.glucoseBelowSuspendThreshold(minGlucose: glucoseValue))
+        let glucoseValue = SimpleGlucoseValue(startDate: dateFormatter.date(from: "2020-05-14T22:14:16Z")!,
+                                              quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 65.0))
+        try assertBolusRecommendationNoticeCodable(.glucoseBelowSuspendThreshold(minGlucose: glucoseValue), encodesJSON: """
+{
+  "bolusRecommendationNotice" : {
+    "glucoseBelowSuspendThreshold" : {
+      "minGlucose" : {
+        "endDate" : "2020-05-14T22:14:16Z",
+        "quantity" : 65,
+        "quantityUnit" : "mg/dL",
+        "startDate" : "2020-05-14T22:14:16Z"
+      }
+    }
+  }
+}
+"""
+        )
     }
 
     func testCodableCurrentGlucoseBelowTarget() throws {
-        let glucoseValue = SimpleGlucoseValue(startDate: Date(), quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 85.0))
-        try assertBolusRecommendationNoticeCodable(.currentGlucoseBelowTarget(glucose: glucoseValue))
+        let glucoseValue = SimpleGlucoseValue(startDate: dateFormatter.date(from: "2020-05-14T22:20:16Z")!,
+                                              quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 85.0))
+        try assertBolusRecommendationNoticeCodable(.currentGlucoseBelowTarget(glucose: glucoseValue), encodesJSON: """
+{
+  "bolusRecommendationNotice" : {
+    "currentGlucoseBelowTarget" : {
+      "glucose" : {
+        "endDate" : "2020-05-14T22:20:16Z",
+        "quantity" : 85,
+        "quantityUnit" : "mg/dL",
+        "startDate" : "2020-05-14T22:20:16Z"
+      }
+    }
+  }
+}
+"""
+        )
     }
 
     func testCodablePredictedGlucoseBelowTarget() throws {
-        let glucoseValue = SimpleGlucoseValue(startDate: Date(), quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 80.0))
-        try assertBolusRecommendationNoticeCodable(.predictedGlucoseBelowTarget(minGlucose: glucoseValue))
+        let glucoseValue = SimpleGlucoseValue(startDate: dateFormatter.date(from: "2020-05-14T22:38:16Z")!,
+                                              quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 80.0))
+        try assertBolusRecommendationNoticeCodable(.predictedGlucoseBelowTarget(minGlucose: glucoseValue), encodesJSON: """
+{
+  "bolusRecommendationNotice" : {
+    "predictedGlucoseBelowTarget" : {
+      "minGlucose" : {
+        "endDate" : "2020-05-14T22:38:16Z",
+        "quantity" : 80,
+        "quantityUnit" : "mg/dL",
+        "startDate" : "2020-05-14T22:38:16Z"
+      }
+    }
+  }
+}
+"""
+        )
     }
 
-    func assertBolusRecommendationNoticeCodable(_ original: BolusRecommendationNotice) throws {
-        let data = try PropertyListEncoder().encode(TestContainer(bolusRecommendationNotice: original))
-        let decoded = try PropertyListDecoder().decode(TestContainer.self, from: data)
+    private func assertBolusRecommendationNoticeCodable(_ original: BolusRecommendationNotice, encodesJSON string: String) throws {
+        let data = try encoder.encode(TestContainer(bolusRecommendationNotice: original))
+        XCTAssertEqual(String(data: data, encoding: .utf8), string)
+        let decoded = try decoder.decode(TestContainer.self, from: data)
         XCTAssertEqual(decoded.bolusRecommendationNotice, original)
     }
+
+    private let dateFormatter = ISO8601DateFormatter()
+
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
 
     private struct TestContainer: Codable, Equatable {
         let bolusRecommendationNotice: BolusRecommendationNotice

--- a/LoopKitTests/CarbValueTests.swift
+++ b/LoopKitTests/CarbValueTests.swift
@@ -13,14 +13,39 @@ import HealthKit
 
 class CarbValueCodableTests: XCTestCase {
     func testCodable() throws {
-        try assertCarbValueCodable(CarbValue(startDate: Date(),
-                                             endDate: Date().addingTimeInterval(.hours(1)),
-                                             quantity: HKQuantity(unit: .gram(), doubleValue: 34.5)))
+        try assertCarbValueCodable(CarbValue(startDate: dateFormatter.date(from: "2020-05-14T12:18:14Z")!,
+                                             endDate: dateFormatter.date(from: "2020-05-14T13:18:14Z")!,
+                                             quantity: HKQuantity(unit: .gram(), doubleValue: 34.5)),
+                                   encodesJSON: """
+{
+  "endDate" : "2020-05-14T13:18:14Z",
+  "quantity" : 34.5,
+  "quantityUnit" : "g",
+  "startDate" : "2020-05-14T12:18:14Z"
+}
+"""
+        )
     }
 
-    func assertCarbValueCodable(_ original: CarbValue) throws {
-        let data = try PropertyListEncoder().encode(original)
-        let decoded = try PropertyListDecoder().decode(CarbValue.self, from: data)
+    private func assertCarbValueCodable(_ original: CarbValue, encodesJSON string: String) throws {
+        let data = try encoder.encode(original)
+        XCTAssertEqual(String(data: data, encoding: .utf8), string)
+        let decoded = try decoder.decode(CarbValue.self, from: data)
         XCTAssertEqual(decoded, original)
     }
+
+    private let dateFormatter = ISO8601DateFormatter()
+
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
 }

--- a/LoopKitTests/DailyQuantityScheduleTests.swift
+++ b/LoopKitTests/DailyQuantityScheduleTests.swift
@@ -11,27 +11,133 @@ import LoopKit
 
 class DailyQuantityScheduleCodableTests: XCTestCase {
     func testCodableDouble() throws {
-        try assertDailyQuantityScheduleCodable { Double.random(in: Double(Int.min)...Double(Int.max)) }
+        try assertCodable(DailyQuantitySchedule(unit: .milligramsPerDeciliter,
+                                                dailyItems: [RepeatingScheduleValue(startTime: .hours(0), value: 110.3),
+                                                             RepeatingScheduleValue(startTime: .hours(5), value: 100.5),
+                                                             RepeatingScheduleValue(startTime: .hours(18), value: 120.5)],
+                                                timeZone: TimeZone(identifier: "America/New_York")!)!,
+                          encodesJSON: """
+{
+  "unit" : "mg/dL",
+  "valueSchedule" : {
+    "items" : [
+      {
+        "startTime" : 0,
+        "value" : 110.3
+      },
+      {
+        "startTime" : 18000,
+        "value" : 100.5
+      },
+      {
+        "startTime" : 64800,
+        "value" : 120.5
+      }
+    ],
+    "referenceTimeInterval" : 0,
+    "repeatInterval" : 86400,
+    "timeZone" : {
+      "identifier" : "America/New_York"
+    }
+  }
+}
+"""
+        )
+    }
+
+    func testCodableDoubleRange() throws {
+        try assertCodable(DailyQuantitySchedule(unit: .milligramsPerDeciliter,
+                                                dailyItems: [RepeatingScheduleValue(startTime: .hours(0), value: DoubleRange(minValue: 100.2, maxValue: 111.2)),
+                                                             RepeatingScheduleValue(startTime: .hours(6), value: DoubleRange(minValue: 90.5, maxValue: 101.2)),
+                                                             RepeatingScheduleValue(startTime: .hours(19), value: DoubleRange(minValue: 110.2, maxValue: 121.2))],
+                                                timeZone: TimeZone(identifier: "America/Chicago")!)!,
+                          encodesJSON: """
+{
+  "unit" : "mg/dL",
+  "valueSchedule" : {
+    "items" : [
+      {
+        "startTime" : 0,
+        "value" : {
+          "maxValue" : 111.2,
+          "minValue" : 100.2
+        }
+      },
+      {
+        "startTime" : 21600,
+        "value" : {
+          "maxValue" : 101.2,
+          "minValue" : 90.5
+        }
+      },
+      {
+        "startTime" : 68400,
+        "value" : {
+          "maxValue" : 121.2,
+          "minValue" : 110.2
+        }
+      }
+    ],
+    "referenceTimeInterval" : 0,
+    "repeatInterval" : 86400,
+    "timeZone" : {
+      "identifier" : "America/Chicago"
+    }
+  }
+}
+"""
+        )
     }
 
     func testCodableInt() throws {
-        try assertDailyQuantityScheduleCodable { Int.random(in: Int.min...Int.max) }
+        try assertCodable(DailyQuantitySchedule(unit: .milligramsPerDeciliter,
+                                                dailyItems: [RepeatingScheduleValue(startTime: .hours(0), value: 112),
+                                                             RepeatingScheduleValue(startTime: .hours(7), value: 102),
+                                                             RepeatingScheduleValue(startTime: .hours(20), value: 122)],
+                                                timeZone: TimeZone(identifier: "America/Los_Angeles")!)!,
+                          encodesJSON: """
+{
+  "unit" : "mg/dL",
+  "valueSchedule" : {
+    "items" : [
+      {
+        "startTime" : 0,
+        "value" : 112
+      },
+      {
+        "startTime" : 25200,
+        "value" : 102
+      },
+      {
+        "startTime" : 72000,
+        "value" : 122
+      }
+    ],
+    "referenceTimeInterval" : 0,
+    "repeatInterval" : 86400,
+    "timeZone" : {
+      "identifier" : "America/Los_Angeles"
+    }
+  }
+}
+"""
+        )
     }
 
-    private func assertDailyQuantityScheduleCodable<T>(factory: () -> T) throws where T: RawRepresentable & Codable & Equatable {
-        let original = dailyQuantitySchedule(factory: factory)
-        let data = try PropertyListEncoder().encode(original)
-        let decoded = try PropertyListDecoder().decode(DailyQuantitySchedule<T>.self, from: data)
+    func assertCodable<T>(_ original: DailyQuantitySchedule<T>, encodesJSON string: String) throws where T: RawRepresentable & Codable & Equatable {
+        let data = try encoder.encode(original)
+        XCTAssertEqual(String(data: data, encoding: .utf8), string)
+        let decoded = try decoder.decode(DailyQuantitySchedule<T>.self, from: data)
         XCTAssertEqual(decoded, original)
     }
 
-    private func dailyQuantitySchedule<T>(factory: () -> T) -> DailyQuantitySchedule<T> {
-        return DailyQuantitySchedule<T>(unit: .internationalUnitsPerHour, dailyItems: dailyItems(factory), timeZone: TimeZone.current)!
-    }
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        return encoder
+    }()
 
-    private func dailyItems<T>(_ factory: () -> T) -> [RepeatingScheduleValue<T>] {
-        return Array(0..<24).map { RepeatingScheduleValue<T>(startTime: .hours(Double($0)), value: factory()) }
-    }
+    private let decoder = JSONDecoder()
 }
 
 extension Int: RawRepresentable {

--- a/LoopKitTests/DoseEntryTests.swift
+++ b/LoopKitTests/DoseEntryTests.swift
@@ -14,19 +14,50 @@ import HealthKit
 class DoseEntryCodableTests: XCTestCase {
     func testCodable() throws {
         try assertDoseEntryCodable(DoseEntry(type: .tempBasal,
-                                             startDate: Date(),
-                                             endDate: Date().addingTimeInterval(.minutes(30)),
+                                             startDate: dateFormatter.date(from: "2020-05-14T22:07:19Z")!,
+                                             endDate: dateFormatter.date(from: "2020-05-14T22:37:19Z")!,
                                              value: 1.25,
                                              unit: .unitsPerHour,
                                              deliveredUnits: 0.5,
                                              description: "Temporary Basal",
-                                             syncIdentifier: UUID().uuidString,
-                                             scheduledBasalRate: HKQuantity(unit: DoseEntry.unitsPerHour, doubleValue: 1.0)))
+                                             syncIdentifier: "238E41EA-9576-4981-A1A4-51E10228584F",
+                                             scheduledBasalRate: HKQuantity(unit: DoseEntry.unitsPerHour, doubleValue: 1.5)),
+        encodesJSON: """
+{
+  "deliveredUnits" : 0.5,
+  "description" : "Temporary Basal",
+  "endDate" : "2020-05-14T22:37:19Z",
+  "scheduledBasalRate" : 1.5,
+  "scheduledBasalRateUnit" : "IU/hr",
+  "startDate" : "2020-05-14T22:07:19Z",
+  "syncIdentifier" : "238E41EA-9576-4981-A1A4-51E10228584F",
+  "type" : "tempBasal",
+  "unit" : "U/hour",
+  "value" : 1.25
+}
+"""
+        )
     }
     
-    func assertDoseEntryCodable(_ original: DoseEntry) throws {
-        let data = try PropertyListEncoder().encode(original)
-        let decoded = try PropertyListDecoder().decode(DoseEntry.self, from: data)
+    private func assertDoseEntryCodable(_ original: DoseEntry, encodesJSON string: String) throws {
+        let data = try encoder.encode(original)
+        XCTAssertEqual(String(data: data, encoding: .utf8), string)
+        let decoded = try decoder.decode(DoseEntry.self, from: data)
         XCTAssertEqual(decoded, original)
     }
+
+    private let dateFormatter = ISO8601DateFormatter()
+
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
 }

--- a/LoopKitTests/DosingDecisionStoreTests.swift
+++ b/LoopKitTests/DosingDecisionStoreTests.swift
@@ -39,9 +39,9 @@ class DosingDecisionStorePersistenceTests: PersistenceControllerTestCase, Dosing
 
     // MARK: -
 
-    func testStoreDosingDecision() {
-        let storeDosingDecisionHandler = expectation(description: "Store dosing decision handler")
-        let storeDosingDecisionCompletion = expectation(description: "Store dosing decision completion")
+    func testStoreDosingDecisionData() {
+        let storeDosingDecisionDataHandler = expectation(description: "Store dosing decision data handler")
+        let storeDosingDecisionDataCompletion = expectation(description: "Store dosing decision data completion")
 
         var handlerInvocation = 0
 
@@ -50,24 +50,24 @@ class DosingDecisionStorePersistenceTests: PersistenceControllerTestCase, Dosing
 
             switch handlerInvocation {
             case 1:
-                storeDosingDecisionHandler.fulfill()
+                storeDosingDecisionDataHandler.fulfill()
             default:
                 XCTFail("Unexpected handler invocation")
             }
         }
 
-        dosingDecisionStore.storeDosingDecision(StoredDosingDecision()) {
-            storeDosingDecisionCompletion.fulfill()
+        dosingDecisionStore.storeDosingDecisionData(StoredDosingDecisionData()) {
+            storeDosingDecisionDataCompletion.fulfill()
         }
 
-        wait(for: [storeDosingDecisionHandler, storeDosingDecisionCompletion], timeout: 2, enforceOrder: true)
+        wait(for: [storeDosingDecisionDataHandler, storeDosingDecisionDataCompletion], timeout: 2, enforceOrder: true)
     }
 
-    func testStoreDosingDecisionMultiple() {
-        let storeDosingDecisionHandler1 = expectation(description: "Store dosing decision handler 1")
-        let storeDosingDecisionHandler2 = expectation(description: "Store dosing decision handler 2")
-        let storeDosingDecisionCompletion1 = expectation(description: "Store dosing decision completion 1")
-        let storeDosingDecisionCompletion2 = expectation(description: "Store dosing decision completion 2")
+    func testStoreDosingDecisionDataMultiple() {
+        let storeDosingDecisionDataHandler1 = expectation(description: "Store dosing decision data handler 1")
+        let storeDosingDecisionDataHandler2 = expectation(description: "Store dosing decision data handler 2")
+        let storeDosingDecisionDataCompletion1 = expectation(description: "Store dosing decision data completion 1")
+        let storeDosingDecisionDataCompletion2 = expectation(description: "Store dosing decision data completion 2")
 
         var handlerInvocation = 0
 
@@ -76,23 +76,23 @@ class DosingDecisionStorePersistenceTests: PersistenceControllerTestCase, Dosing
 
             switch handlerInvocation {
             case 1:
-                storeDosingDecisionHandler1.fulfill()
+                storeDosingDecisionDataHandler1.fulfill()
             case 2:
-                storeDosingDecisionHandler2.fulfill()
+                storeDosingDecisionDataHandler2.fulfill()
             default:
                 XCTFail("Unexpected handler invocation")
             }
         }
 
-        dosingDecisionStore.storeDosingDecision(StoredDosingDecision()) {
-            storeDosingDecisionCompletion1.fulfill()
+        dosingDecisionStore.storeDosingDecisionData(StoredDosingDecisionData()) {
+            storeDosingDecisionDataCompletion1.fulfill()
         }
 
-        dosingDecisionStore.storeDosingDecision(StoredDosingDecision()) {
-            storeDosingDecisionCompletion2.fulfill()
+        dosingDecisionStore.storeDosingDecisionData(StoredDosingDecisionData()) {
+            storeDosingDecisionDataCompletion2.fulfill()
         }
 
-        wait(for: [storeDosingDecisionHandler1, storeDosingDecisionCompletion1, storeDosingDecisionHandler2, storeDosingDecisionCompletion2], timeout: 2, enforceOrder: true)
+        wait(for: [storeDosingDecisionDataHandler1, storeDosingDecisionDataCompletion1, storeDosingDecisionDataHandler2, storeDosingDecisionDataCompletion2], timeout: 2, enforceOrder: true)
     }
 
 }
@@ -168,7 +168,7 @@ class DosingDecisionStoreQueryTests: PersistenceControllerTestCase {
     // MARK: -
 
     func testEmptyWithDefaultQueryAnchor() {
-        dosingDecisionStore.executeDosingDecisionQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
+        dosingDecisionStore.executeDosingDecisionDataQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
             switch result {
             case .failure(let error):
                 XCTFail("Unexpected failure: \(error)")
@@ -185,7 +185,7 @@ class DosingDecisionStoreQueryTests: PersistenceControllerTestCase {
     func testEmptyWithMissingQueryAnchor() {
         queryAnchor = nil
 
-        dosingDecisionStore.executeDosingDecisionQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
+        dosingDecisionStore.executeDosingDecisionDataQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
             switch result {
             case .failure(let error):
                 XCTFail("Unexpected failure: \(error)")
@@ -202,7 +202,7 @@ class DosingDecisionStoreQueryTests: PersistenceControllerTestCase {
     func testEmptyWithNonDefaultQueryAnchor() {
         queryAnchor.modificationCounter = 1
 
-        dosingDecisionStore.executeDosingDecisionQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
+        dosingDecisionStore.executeDosingDecisionDataQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
             switch result {
             case .failure(let error):
                 XCTFail("Unexpected failure: \(error)")
@@ -217,19 +217,19 @@ class DosingDecisionStoreQueryTests: PersistenceControllerTestCase {
     }
 
     func testDataWithUnusedQueryAnchor() {
-        let syncIdentifiers = [generateSyncIdentifier(), generateSyncIdentifier(), generateSyncIdentifier()]
+        let dataStrings = [generateDataString(), generateDataString(), generateDataString()]
 
-        addData(withSyncIdentifiers: syncIdentifiers)
+        addData(withDataStrings: dataStrings)
 
-        dosingDecisionStore.executeDosingDecisionQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
+        dosingDecisionStore.executeDosingDecisionDataQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
             switch result {
             case .failure(let error):
                 XCTFail("Unexpected failure: \(error)")
             case .success(let anchor, let data):
                 XCTAssertEqual(anchor.modificationCounter, 3)
                 XCTAssertEqual(data.count, 3)
-                for (index, syncIdentifier) in syncIdentifiers.enumerated() {
-                    XCTAssertEqual(data[index].syncIdentifier, syncIdentifier)
+                for (index, dataString) in dataStrings.enumerated() {
+                    XCTAssertEqual(data[index].dataString, dataString)
                 }
             }
             self.completion.fulfill()
@@ -239,20 +239,20 @@ class DosingDecisionStoreQueryTests: PersistenceControllerTestCase {
     }
 
     func testDataWithStaleQueryAnchor() {
-        let syncIdentifiers = [generateSyncIdentifier(), generateSyncIdentifier(), generateSyncIdentifier()]
+        let dataStrings = [generateDataString(), generateDataString(), generateDataString()]
 
-        addData(withSyncIdentifiers: syncIdentifiers)
+        addData(withDataStrings: dataStrings)
 
         queryAnchor.modificationCounter = 2
 
-        dosingDecisionStore.executeDosingDecisionQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
+        dosingDecisionStore.executeDosingDecisionDataQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
             switch result {
             case .failure(let error):
                 XCTFail("Unexpected failure: \(error)")
             case .success(let anchor, let data):
                 XCTAssertEqual(anchor.modificationCounter, 3)
                 XCTAssertEqual(data.count, 1)
-                XCTAssertEqual(data[0].syncIdentifier, syncIdentifiers[2])
+                XCTAssertEqual(data[0].dataString, dataStrings[2])
             }
             self.completion.fulfill()
         }
@@ -261,13 +261,13 @@ class DosingDecisionStoreQueryTests: PersistenceControllerTestCase {
     }
 
     func testDataWithCurrentQueryAnchor() {
-        let syncIdentifiers = [generateSyncIdentifier(), generateSyncIdentifier(), generateSyncIdentifier()]
+        let dataStrings = [generateDataString(), generateDataString(), generateDataString()]
 
-        addData(withSyncIdentifiers: syncIdentifiers)
+        addData(withDataStrings: dataStrings)
 
         queryAnchor.modificationCounter = 3
 
-        dosingDecisionStore.executeDosingDecisionQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
+        dosingDecisionStore.executeDosingDecisionDataQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
             switch result {
             case .failure(let error):
                 XCTFail("Unexpected failure: \(error)")
@@ -282,13 +282,13 @@ class DosingDecisionStoreQueryTests: PersistenceControllerTestCase {
     }
 
     func testDataWithLimitZero() {
-        let syncIdentifiers = [generateSyncIdentifier(), generateSyncIdentifier(), generateSyncIdentifier()]
+        let dataStrings = [generateDataString(), generateDataString(), generateDataString()]
 
-        addData(withSyncIdentifiers: syncIdentifiers)
+        addData(withDataStrings: dataStrings)
 
         limit = 0
 
-        dosingDecisionStore.executeDosingDecisionQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
+        dosingDecisionStore.executeDosingDecisionDataQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
             switch result {
             case .failure(let error):
                 XCTFail("Unexpected failure: \(error)")
@@ -303,21 +303,21 @@ class DosingDecisionStoreQueryTests: PersistenceControllerTestCase {
     }
 
     func testDataWithLimitCoveredByData() {
-        let syncIdentifiers = [generateSyncIdentifier(), generateSyncIdentifier(), generateSyncIdentifier()]
+        let dataStrings = [generateDataString(), generateDataString(), generateDataString()]
 
-        addData(withSyncIdentifiers: syncIdentifiers)
+        addData(withDataStrings: dataStrings)
 
         limit = 2
 
-        dosingDecisionStore.executeDosingDecisionQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
+        dosingDecisionStore.executeDosingDecisionDataQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
             switch result {
             case .failure(let error):
                 XCTFail("Unexpected failure: \(error)")
             case .success(let anchor, let data):
                 XCTAssertEqual(anchor.modificationCounter, 2)
                 XCTAssertEqual(data.count, 2)
-                XCTAssertEqual(data[0].syncIdentifier, syncIdentifiers[0])
-                XCTAssertEqual(data[1].syncIdentifier, syncIdentifiers[1])
+                XCTAssertEqual(data[0].dataString, dataStrings[0])
+                XCTAssertEqual(data[1].dataString, dataStrings[1])
             }
             self.completion.fulfill()
         }
@@ -325,16 +325,26 @@ class DosingDecisionStoreQueryTests: PersistenceControllerTestCase {
         wait(for: [completion], timeout: 2, enforceOrder: true)
     }
 
-    private func addData(withSyncIdentifiers syncIdentifiers: [String]) {
+    private func addData(withDataStrings dataStrings: [String]) {
         let semaphore = DispatchSemaphore(value: 0)
-        for (_, syncIdentifier) in syncIdentifiers.enumerated() {
-            self.dosingDecisionStore.storeDosingDecision(StoredDosingDecision(syncIdentifier: syncIdentifier)) { semaphore.signal() }
+        for dataString in dataStrings {
+            self.dosingDecisionStore.storeDosingDecisionData(StoredDosingDecisionData(dataString: dataString)) { semaphore.signal() }
         }
-        for _ in syncIdentifiers { semaphore.wait() }
+        for _ in dataStrings { semaphore.wait() }
     }
 
-    private func generateSyncIdentifier() -> String {
+    private func generateDataString() -> String {
         return UUID().uuidString
     }
 
+}
+
+extension StoredDosingDecisionData {
+    init(date: Date = Date(), dataString: String = UUID().uuidString) {
+        self.init(date: date, data: dataString.data(using: .utf8)!)
+    }
+
+    var dataString: String {
+        return String(data: data, encoding: .utf8)!
+    }
 }

--- a/LoopKitTests/GlucoseThresholdTests.swift
+++ b/LoopKitTests/GlucoseThresholdTests.swift
@@ -76,16 +76,39 @@ class GlucoseThresholdTests: XCTestCase {
 
 class GlucoseThresholdCodableTests: XCTestCase {
     func testCodableMilligramsPerDeciliter() throws {
-        try assertGlucoseThresholdCodable(GlucoseThreshold(unit: .milligramsPerDeciliter, value: 123))
+        try assertGlucoseThresholdCodable(GlucoseThreshold(unit: .milligramsPerDeciliter, value: 123),
+                                          encodesJSON: """
+{
+  "unit" : "mg/dL",
+  "value" : 123
+}
+"""
+        )
     }
 
     func testCodableMillimolesPerLiter() throws {
-        try assertGlucoseThresholdCodable(GlucoseThreshold(unit: .millimolesPerLiter, value: 6.83))
+        try assertGlucoseThresholdCodable(GlucoseThreshold(unit: .millimolesPerLiter, value: 6.5),
+                                          encodesJSON: """
+{
+  "unit" : "mmol<180.1558800000541>/L",
+  "value" : 6.5
+}
+"""
+        )
     }
 
-    func assertGlucoseThresholdCodable(_ original: GlucoseThreshold) throws {
-        let data = try PropertyListEncoder().encode(original)
-        let decoded = try PropertyListDecoder().decode(GlucoseThreshold.self, from: data)
+    private func assertGlucoseThresholdCodable(_ original: GlucoseThreshold, encodesJSON string: String) throws {
+        let data = try encoder.encode(original)
+        XCTAssertEqual(String(data: data, encoding: .utf8), string)
+        let decoded = try decoder.decode(GlucoseThreshold.self, from: data)
         XCTAssertEqual(decoded, original)
     }
+
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        return encoder
+    }()
+
+    private let decoder = JSONDecoder()
 }

--- a/LoopKitTests/GlucoseValueTests.swift
+++ b/LoopKitTests/GlucoseValueTests.swift
@@ -21,7 +21,7 @@ class SimpleGlucoseValueTests: XCTestCase {
         XCTAssertEqual(simpleGlucoseValue.endDate, endDate)
         XCTAssertEqual(simpleGlucoseValue.quantity, quantity)
     }
-
+    
     func testInitializerMillimolesPerLiter() {
         let startDate = Date()
         let endDate = Date().addingTimeInterval(.hours(1))
@@ -31,7 +31,7 @@ class SimpleGlucoseValueTests: XCTestCase {
         XCTAssertEqual(simpleGlucoseValue.endDate, endDate)
         XCTAssertEqual(simpleGlucoseValue.quantity, quantity)
     }
-
+    
     func testInitializerMissingEndDate() {
         let startDate = Date()
         let quantity = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 234.5)
@@ -40,7 +40,7 @@ class SimpleGlucoseValueTests: XCTestCase {
         XCTAssertEqual(simpleGlucoseValue.endDate, startDate)
         XCTAssertEqual(simpleGlucoseValue.quantity, quantity)
     }
-
+    
     func testInitializerGlucoseValue() {
         let startDate = Date()
         let endDate = Date().addingTimeInterval(.hours(1))
@@ -54,38 +54,104 @@ class SimpleGlucoseValueTests: XCTestCase {
 
 class SimpleGlucoseValueCodableTests: XCTestCase {
     func testCodableMilligramsPerDeciliter() throws {
-        try assertSimpleGlucoseValueCodable(SimpleGlucoseValue(startDate: Date(),
-                                                               endDate: Date().addingTimeInterval(.hours(1)),
-                                                               quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 234.5)))
+        try assertSimpleGlucoseValueCodable(SimpleGlucoseValue(startDate: dateFormatter.date(from: "2020-05-14T22:00:03Z")!,
+                                                               endDate: dateFormatter.date(from: "2020-05-14T23:00:03Z")!,
+                                                               quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 234.5)),
+                                            encodesJSON: """
+{
+  "endDate" : "2020-05-14T23:00:03Z",
+  "quantity" : 234.5,
+  "quantityUnit" : "mg/dL",
+  "startDate" : "2020-05-14T22:00:03Z"
+}
+"""
+        )
     }
-
+    
     func testCodableMillimolesPerLiter() throws {
-        try assertSimpleGlucoseValueCodable(SimpleGlucoseValue(startDate: Date(),
-                                                               endDate: Date().addingTimeInterval(.hours(1)),
-                                                               quantity: HKQuantity(unit: .millimolesPerLiter, doubleValue: 12.3)))
+        try assertSimpleGlucoseValueCodable(SimpleGlucoseValue(startDate: dateFormatter.date(from: "2020-05-14T14:05:03Z")!,
+                                                               endDate: dateFormatter.date(from: "2020-05-14T15:05:03Z")!,
+                                                               quantity: HKQuantity(unit: .millimolesPerLiter, doubleValue: 13.2)),
+                                            encodesJSON: """
+{
+  "endDate" : "2020-05-14T15:05:03Z",
+  "quantity" : 237.80576160007135,
+  "quantityUnit" : "mg/dL",
+  "startDate" : "2020-05-14T14:05:03Z"
+}
+"""
+        )
     }
-
-    func assertSimpleGlucoseValueCodable(_ original: SimpleGlucoseValue) throws {
-        let data = try PropertyListEncoder().encode(original)
-        let decoded = try PropertyListDecoder().decode(SimpleGlucoseValue.self, from: data)
+    
+    private func assertSimpleGlucoseValueCodable(_ original: SimpleGlucoseValue, encodesJSON string: String) throws {
+        let data = try encoder.encode(original)
+        XCTAssertEqual(String(data: data, encoding: .utf8), string)
+        let decoded = try decoder.decode(SimpleGlucoseValue.self, from: data)
         XCTAssertEqual(decoded, original)
     }
+    
+    private let dateFormatter = ISO8601DateFormatter()
+    
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+    
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
 }
 
 class PredictedGlucoseValueCodableTests: XCTestCase {
     func testCodableMilligramsPerDeciliter() throws {
-        try assertPredictedGlucoseValueCodable(PredictedGlucoseValue(startDate: Date(),
-                                                                     quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 234.5)))
+        try assertPredictedGlucoseValueCodable(PredictedGlucoseValue(startDate: dateFormatter.date(from: "2020-05-14T22:38:26Z")!,
+                                                                     quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 234.5)),
+                                               encodesJSON: """
+{
+  "quantity" : 234.5,
+  "quantityUnit" : "mg/dL",
+  "startDate" : "2020-05-14T22:38:26Z"
+}
+"""
+        )
     }
-
+    
     func testCodableMillimolesPerLiter() throws {
-        try assertPredictedGlucoseValueCodable(PredictedGlucoseValue(startDate: Date(),
-                                                                     quantity: HKQuantity(unit: .millimolesPerLiter, doubleValue: 12.3)))
+        try assertPredictedGlucoseValueCodable(PredictedGlucoseValue(startDate: dateFormatter.date(from: "2020-05-14T21:23:33Z")!,
+                                                                     quantity: HKQuantity(unit: .millimolesPerLiter, doubleValue: 12.3)),
+                                               encodesJSON: """
+{
+  "quantity" : 221.59173240006652,
+  "quantityUnit" : "mg/dL",
+  "startDate" : "2020-05-14T21:23:33Z"
+}
+"""
+        )
     }
-
-    func assertPredictedGlucoseValueCodable(_ original: PredictedGlucoseValue) throws {
-        let data = try PropertyListEncoder().encode(original)
-        let decoded = try PropertyListDecoder().decode(PredictedGlucoseValue.self, from: data)
+    
+    private func assertPredictedGlucoseValueCodable(_ original: PredictedGlucoseValue, encodesJSON string: String) throws {
+        let data = try encoder.encode(original)
+        XCTAssertEqual(String(data: data, encoding: .utf8), string)
+        let decoded = try decoder.decode(PredictedGlucoseValue.self, from: data)
         XCTAssertEqual(decoded, original)
     }
+    
+    private let dateFormatter = ISO8601DateFormatter()
+    
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+    
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
 }

--- a/LoopKitTests/SettingsStoreTests.swift
+++ b/LoopKitTests/SettingsStoreTests.swift
@@ -327,7 +327,7 @@ class SettingsStoreQueryTests: PersistenceControllerTestCase {
 
     private func addData(withSyncIdentifiers syncIdentifiers: [String]) {
         let semaphore = DispatchSemaphore(value: 0)
-        for (_, syncIdentifier) in syncIdentifiers.enumerated() {
+        for syncIdentifier in syncIdentifiers {
             self.settingsStore.storeSettings(StoredSettings(syncIdentifier: syncIdentifier)) { semaphore.signal() }
         }
         for _ in syncIdentifiers { semaphore.wait() }

--- a/LoopKitTests/SettingsStoreTests.swift
+++ b/LoopKitTests/SettingsStoreTests.swift
@@ -10,44 +10,44 @@ import XCTest
 @testable import LoopKit
 
 class SettingsStorePersistenceTests: PersistenceControllerTestCase, SettingsStoreDelegate {
-
+    
     var settingsStore: SettingsStore!
-
+    
     override func setUp() {
         super.setUp()
-
+        
         settingsStoreHasUpdatedSettingsDataHandler = nil
         settingsStore = SettingsStore(store: cacheStore, expireAfter: .hours(24))
         settingsStore.delegate = self
     }
-
+    
     override func tearDown() {
         settingsStore.delegate = nil
         settingsStore = nil
         settingsStoreHasUpdatedSettingsDataHandler = nil
-
+        
         super.tearDown()
     }
-
+    
     // MARK: - SettingsStoreDelegate
-
+    
     var settingsStoreHasUpdatedSettingsDataHandler: ((_ : SettingsStore) -> Void)?
-
+    
     func settingsStoreHasUpdatedSettingsData(_ settingsStore: SettingsStore) {
         settingsStoreHasUpdatedSettingsDataHandler?(settingsStore)
     }
-
+    
     // MARK: -
-
+    
     func testStoreSettings() {
         let storeSettingsHandler = expectation(description: "Store settings handler")
         let storeSettingsCompletion = expectation(description: "Store settings completion")
-
+        
         var handlerInvocation = 0
-
+        
         settingsStoreHasUpdatedSettingsDataHandler = { settingsStore in
             handlerInvocation += 1
-
+            
             switch handlerInvocation {
             case 1:
                 storeSettingsHandler.fulfill()
@@ -55,25 +55,25 @@ class SettingsStorePersistenceTests: PersistenceControllerTestCase, SettingsStor
                 XCTFail("Unexpected handler invocation")
             }
         }
-
+        
         settingsStore.storeSettings(StoredSettings()) {
             storeSettingsCompletion.fulfill()
         }
-
+        
         wait(for: [storeSettingsHandler, storeSettingsCompletion], timeout: 2, enforceOrder: true)
     }
-
+    
     func testStoreSettingsMultiple() {
         let storeSettingsHandler1 = expectation(description: "Store settings handler 1")
         let storeSettingsHandler2 = expectation(description: "Store settings handler 2")
         let storeSettingsCompletion1 = expectation(description: "Store settings completion 1")
         let storeSettingsCompletion2 = expectation(description: "Store settings completion 2")
-
+        
         var handlerInvocation = 0
-
+        
         settingsStoreHasUpdatedSettingsDataHandler = { settingsStore in
             handlerInvocation += 1
-
+            
             switch handlerInvocation {
             case 1:
                 storeSettingsHandler1.fulfill()
@@ -83,53 +83,53 @@ class SettingsStorePersistenceTests: PersistenceControllerTestCase, SettingsStor
                 XCTFail("Unexpected handler invocation")
             }
         }
-
+        
         settingsStore.storeSettings(StoredSettings()) {
             storeSettingsCompletion1.fulfill()
         }
-
+        
         settingsStore.storeSettings(StoredSettings()) {
             storeSettingsCompletion2.fulfill()
         }
-
+        
         wait(for: [storeSettingsHandler1, storeSettingsCompletion1, storeSettingsHandler2, storeSettingsCompletion2], timeout: 2, enforceOrder: true)
     }
-
+    
 }
 
 class SettingsStoreQueryAnchorTests: XCTestCase {
-
+    
     var rawValue: SettingsStore.QueryAnchor.RawValue = [
         "modificationCounter": Int64(123)
     ]
-
+    
     func testInitializerDefault() {
         let queryAnchor = SettingsStore.QueryAnchor()
         XCTAssertEqual(queryAnchor.modificationCounter, 0)
     }
-
+    
     func testInitializerRawValue() {
         let queryAnchor = SettingsStore.QueryAnchor(rawValue: rawValue)
         XCTAssertNotNil(queryAnchor)
         XCTAssertEqual(queryAnchor?.modificationCounter, 123)
     }
-
+    
     func testInitializerRawValueMissingModificationCounter() {
         rawValue["modificationCounter"] = nil
         XCTAssertNil(SettingsStore.QueryAnchor(rawValue: rawValue))
     }
-
+    
     func testInitializerRawValueInvalidModificationCounter() {
         rawValue["modificationCounter"] = "123"
         XCTAssertNil(SettingsStore.QueryAnchor(rawValue: rawValue))
     }
-
+    
     func testRawValueWithDefault() {
         let rawValue = SettingsStore.QueryAnchor().rawValue
         XCTAssertEqual(rawValue.count, 1)
         XCTAssertEqual(rawValue["modificationCounter"] as? Int64, Int64(0))
     }
-
+    
     func testRawValueWithNonDefault() {
         var queryAnchor = SettingsStore.QueryAnchor()
         queryAnchor.modificationCounter = 123
@@ -137,36 +137,36 @@ class SettingsStoreQueryAnchorTests: XCTestCase {
         XCTAssertEqual(rawValue.count, 1)
         XCTAssertEqual(rawValue["modificationCounter"] as? Int64, Int64(123))
     }
-
+    
 }
 
 class SettingsStoreQueryTests: PersistenceControllerTestCase {
-
+    
     var settingsStore: SettingsStore!
     var completion: XCTestExpectation!
     var queryAnchor: SettingsStore.QueryAnchor!
     var limit: Int!
-
+    
     override func setUp() {
         super.setUp()
-
+        
         settingsStore = SettingsStore(store: cacheStore, expireAfter: .hours(24))
         completion = expectation(description: "Completion")
         queryAnchor = SettingsStore.QueryAnchor()
         limit = Int.max
     }
-
+    
     override func tearDown() {
         limit = nil
         queryAnchor = nil
         completion = nil
         settingsStore = nil
-
+        
         super.tearDown()
     }
-
+    
     // MARK: -
-
+    
     func testEmptyWithDefaultQueryAnchor() {
         settingsStore.executeSettingsQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
             switch result {
@@ -178,13 +178,13 @@ class SettingsStoreQueryTests: PersistenceControllerTestCase {
             }
             self.completion.fulfill()
         }
-
+        
         wait(for: [completion], timeout: 2, enforceOrder: true)
     }
-
+    
     func testEmptyWithMissingQueryAnchor() {
         queryAnchor = nil
-
+        
         settingsStore.executeSettingsQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
             switch result {
             case .failure(let error):
@@ -195,13 +195,13 @@ class SettingsStoreQueryTests: PersistenceControllerTestCase {
             }
             self.completion.fulfill()
         }
-
+        
         wait(for: [completion], timeout: 2, enforceOrder: true)
     }
-
+    
     func testEmptyWithNonDefaultQueryAnchor() {
         queryAnchor.modificationCounter = 1
-
+        
         settingsStore.executeSettingsQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
             switch result {
             case .failure(let error):
@@ -212,15 +212,15 @@ class SettingsStoreQueryTests: PersistenceControllerTestCase {
             }
             self.completion.fulfill()
         }
-
+        
         wait(for: [completion], timeout: 2, enforceOrder: true)
     }
-
+    
     func testDataWithUnusedQueryAnchor() {
         let syncIdentifiers = [generateSyncIdentifier(), generateSyncIdentifier(), generateSyncIdentifier()]
-
+        
         addData(withSyncIdentifiers: syncIdentifiers)
-
+        
         settingsStore.executeSettingsQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
             switch result {
             case .failure(let error):
@@ -234,17 +234,17 @@ class SettingsStoreQueryTests: PersistenceControllerTestCase {
             }
             self.completion.fulfill()
         }
-
+        
         wait(for: [completion], timeout: 2, enforceOrder: true)
     }
-
+    
     func testDataWithStaleQueryAnchor() {
         let syncIdentifiers = [generateSyncIdentifier(), generateSyncIdentifier(), generateSyncIdentifier()]
-
+        
         addData(withSyncIdentifiers: syncIdentifiers)
-
+        
         queryAnchor.modificationCounter = 2
-
+        
         settingsStore.executeSettingsQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
             switch result {
             case .failure(let error):
@@ -256,17 +256,17 @@ class SettingsStoreQueryTests: PersistenceControllerTestCase {
             }
             self.completion.fulfill()
         }
-
+        
         wait(for: [completion], timeout: 2, enforceOrder: true)
     }
-
+    
     func testDataWithCurrentQueryAnchor() {
         let syncIdentifiers = [generateSyncIdentifier(), generateSyncIdentifier(), generateSyncIdentifier()]
-
+        
         addData(withSyncIdentifiers: syncIdentifiers)
-
+        
         queryAnchor.modificationCounter = 3
-
+        
         settingsStore.executeSettingsQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
             switch result {
             case .failure(let error):
@@ -277,17 +277,17 @@ class SettingsStoreQueryTests: PersistenceControllerTestCase {
             }
             self.completion.fulfill()
         }
-
+        
         wait(for: [completion], timeout: 2, enforceOrder: true)
     }
-
+    
     func testDataWithLimitZero() {
         let syncIdentifiers = [generateSyncIdentifier(), generateSyncIdentifier(), generateSyncIdentifier()]
-
+        
         addData(withSyncIdentifiers: syncIdentifiers)
-
+        
         limit = 0
-
+        
         settingsStore.executeSettingsQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
             switch result {
             case .failure(let error):
@@ -298,17 +298,17 @@ class SettingsStoreQueryTests: PersistenceControllerTestCase {
             }
             self.completion.fulfill()
         }
-
+        
         wait(for: [completion], timeout: 2, enforceOrder: true)
     }
-
+    
     func testDataWithLimitCoveredByData() {
         let syncIdentifiers = [generateSyncIdentifier(), generateSyncIdentifier(), generateSyncIdentifier()]
-
+        
         addData(withSyncIdentifiers: syncIdentifiers)
-
+        
         limit = 2
-
+        
         settingsStore.executeSettingsQuery(fromQueryAnchor: queryAnchor, limit: limit) { result in
             switch result {
             case .failure(let error):
@@ -321,10 +321,10 @@ class SettingsStoreQueryTests: PersistenceControllerTestCase {
             }
             self.completion.fulfill()
         }
-
+        
         wait(for: [completion], timeout: 2, enforceOrder: true)
     }
-
+    
     private func addData(withSyncIdentifiers syncIdentifiers: [String]) {
         let semaphore = DispatchSemaphore(value: 0)
         for syncIdentifier in syncIdentifiers {
@@ -332,28 +332,28 @@ class SettingsStoreQueryTests: PersistenceControllerTestCase {
         }
         for _ in syncIdentifiers { semaphore.wait() }
     }
-
+    
     private func generateSyncIdentifier() -> String {
         return UUID().uuidString
     }
-
+    
 }
 
 class StoredSettingsCodableTests: XCTestCase {
     func testCodable() throws {
-        let settings = StoredSettings(date: Date(),
+        let settings = StoredSettings(date: dateFormatter.date(from: "2020-05-14T22:48:15Z")!,
                                       dosingEnabled: true,
                                       glucoseTargetRangeSchedule: GlucoseRangeSchedule(rangeSchedule: DailyQuantitySchedule(unit: .milligramsPerDeciliter,
                                                                                                                             dailyItems: [RepeatingScheduleValue(startTime: .hours(0), value: DoubleRange(minValue: 100.0, maxValue: 110.0)),
                                                                                                                                          RepeatingScheduleValue(startTime: .hours(7), value: DoubleRange(minValue: 90.0, maxValue: 100.0)),
                                                                                                                                          RepeatingScheduleValue(startTime: .hours(21), value: DoubleRange(minValue: 110.0, maxValue: 120.0))],
-                                                                                                                            timeZone: TimeZone.currentFixed)!,
+                                                                                                                            timeZone: TimeZone(identifier: "America/Los_Angeles")!)!,
                                                                                        override: GlucoseRangeSchedule.Override(value: DoubleRange(minValue: 105.0, maxValue: 115.0),
-                                                                                                                               start: Date(),
-                                                                                                                               end: Date().addingTimeInterval(.minutes(30)))),
+                                                                                                                               start: dateFormatter.date(from: "2020-05-14T12:48:15Z")!,
+                                                                                                                               end: dateFormatter.date(from: "2020-05-14T14:48:15Z")!)),
                                       preMealTargetRange: DoubleRange(minValue: 80.0, maxValue: 90.0),
                                       workoutTargetRange: DoubleRange(minValue: 150.0, maxValue: 160.0),
-                                      overridePresets: [TemporaryScheduleOverridePreset(id: UUID(),
+                                      overridePresets: [TemporaryScheduleOverridePreset(id: UUID(uuidString: "2A67A303-5203-4CB8-8263-79498265368E")!,
                                                                                         symbol: "🍎",
                                                                                         name: "Apple",
                                                                                         settings: TemporaryScheduleOverrideSettings(unit: .milligramsPerDeciliter,
@@ -364,18 +364,18 @@ class StoredSettingsCodableTests: XCTestCase {
                                                                                   settings: TemporaryScheduleOverrideSettings(unit: .milligramsPerDeciliter,
                                                                                                                               targetRange: DoubleRange(minValue: 110.0, maxValue: 120.0),
                                                                                                                               insulinNeedsScaleFactor: 1.5),
-                                                                                  startDate: Date(),
+                                                                                  startDate: dateFormatter.date(from: "2020-05-14T14:48:19Z")!,
                                                                                   duration: .finite(.minutes(60)),
                                                                                   enactTrigger: .remote("127.0.0.1"),
-                                                                                  syncIdentifier: UUID()),
+                                                                                  syncIdentifier: UUID(uuidString: "2A67A303-1234-4CB8-8263-79498265368E")!),
                                       preMealOverride: TemporaryScheduleOverride(context: .preMeal,
                                                                                  settings: TemporaryScheduleOverrideSettings(unit: .milligramsPerDeciliter,
                                                                                                                              targetRange: DoubleRange(minValue: 80.0, maxValue: 90.0),
                                                                                                                              insulinNeedsScaleFactor: 0.5),
-                                                                                 startDate: Date(),
+                                                                                 startDate: dateFormatter.date(from: "2020-05-14T14:38:39Z")!,
                                                                                  duration: .indefinite,
                                                                                  enactTrigger: .local,
-                                                                                 syncIdentifier: UUID()),
+                                                                                 syncIdentifier: UUID(uuidString: "2A67A303-5203-1234-8263-79498265368E")!),
                                       maximumBasalRatePerHour: 3.5,
                                       maximumBolus: 10.0,
                                       suspendThreshold: GlucoseThreshold(unit: .milligramsPerDeciliter, value: 75.0),
@@ -384,27 +384,238 @@ class StoredSettingsCodableTests: XCTestCase {
                                       basalRateSchedule: BasalRateSchedule(dailyItems: [RepeatingScheduleValue(startTime: .hours(0), value: 1.0),
                                                                                         RepeatingScheduleValue(startTime: .hours(6), value: 1.5),
                                                                                         RepeatingScheduleValue(startTime: .hours(18), value: 1.25)],
-                                                                           timeZone: TimeZone.currentFixed),
+                                                                           timeZone: TimeZone(identifier: "America/Los_Angeles")!),
                                       insulinSensitivitySchedule: InsulinSensitivitySchedule(unit: .milligramsPerDeciliter,
                                                                                              dailyItems: [RepeatingScheduleValue(startTime: .hours(0), value: 45.0),
                                                                                                           RepeatingScheduleValue(startTime: .hours(3), value: 40.0),
                                                                                                           RepeatingScheduleValue(startTime: .hours(15), value: 50.0)],
-                                                                                             timeZone: TimeZone.currentFixed),
+                                                                                             timeZone: TimeZone(identifier: "America/Los_Angeles")!),
                                       carbRatioSchedule: CarbRatioSchedule(unit: .gram(),
                                                                            dailyItems: [RepeatingScheduleValue(startTime: .hours(0), value: 15.0),
                                                                                         RepeatingScheduleValue(startTime: .hours(9), value: 14.0),
                                                                                         RepeatingScheduleValue(startTime: .hours(20), value: 18.0)],
-                                                                           timeZone: TimeZone.currentFixed),
+                                                                           timeZone: TimeZone(identifier: "America/Los_Angeles")!),
                                       bloodGlucoseUnit: .milligramsPerDeciliter,
-                                      syncIdentifier: UUID().uuidString)
-        try assertStoredSettingsCodable(settings)
+                                      syncIdentifier: "2A67A303-1234-4CB8-1234-79498265368E")
+        try assertStoredSettingsCodable(settings, encodesJSON: """
+{
+  "basalRateSchedule" : {
+    "items" : [
+      {
+        "startTime" : 0,
+        "value" : 1
+      },
+      {
+        "startTime" : 21600,
+        "value" : 1.5
+      },
+      {
+        "startTime" : 64800,
+        "value" : 1.25
+      }
+    ],
+    "referenceTimeInterval" : 0,
+    "repeatInterval" : 86400,
+    "timeZone" : {
+      "identifier" : "America/Los_Angeles"
     }
-
-    func assertStoredSettingsCodable(_ original: StoredSettings) throws {
-        let data = try PropertyListEncoder().encode(original)
-        let decoded = try PropertyListDecoder().decode(StoredSettings.self, from: data)
+  },
+  "bloodGlucoseUnit" : "mg/dL",
+  "carbRatioSchedule" : {
+    "unit" : "g",
+    "valueSchedule" : {
+      "items" : [
+        {
+          "startTime" : 0,
+          "value" : 15
+        },
+        {
+          "startTime" : 32400,
+          "value" : 14
+        },
+        {
+          "startTime" : 72000,
+          "value" : 18
+        }
+      ],
+      "referenceTimeInterval" : 0,
+      "repeatInterval" : 86400,
+      "timeZone" : {
+        "identifier" : "America/Los_Angeles"
+      }
+    }
+  },
+  "date" : "2020-05-14T22:48:15Z",
+  "deviceToken" : "DeviceTokenString",
+  "dosingEnabled" : true,
+  "glucoseTargetRangeSchedule" : {
+    "override" : {
+      "end" : "2020-05-14T14:48:15Z",
+      "start" : "2020-05-14T12:48:15Z",
+      "value" : {
+        "maxValue" : 115,
+        "minValue" : 105
+      }
+    },
+    "rangeSchedule" : {
+      "unit" : "mg/dL",
+      "valueSchedule" : {
+        "items" : [
+          {
+            "startTime" : 0,
+            "value" : {
+              "maxValue" : 110,
+              "minValue" : 100
+            }
+          },
+          {
+            "startTime" : 25200,
+            "value" : {
+              "maxValue" : 100,
+              "minValue" : 90
+            }
+          },
+          {
+            "startTime" : 75600,
+            "value" : {
+              "maxValue" : 120,
+              "minValue" : 110
+            }
+          }
+        ],
+        "referenceTimeInterval" : 0,
+        "repeatInterval" : 86400,
+        "timeZone" : {
+          "identifier" : "America/Los_Angeles"
+        }
+      }
+    }
+  },
+  "insulinModel" : {
+    "actionDuration" : 21600,
+    "modelType" : "rapidAdult",
+    "peakActivity" : 10800
+  },
+  "insulinSensitivitySchedule" : {
+    "unit" : "mg/dL",
+    "valueSchedule" : {
+      "items" : [
+        {
+          "startTime" : 0,
+          "value" : 45
+        },
+        {
+          "startTime" : 10800,
+          "value" : 40
+        },
+        {
+          "startTime" : 54000,
+          "value" : 50
+        }
+      ],
+      "referenceTimeInterval" : 0,
+      "repeatInterval" : 86400,
+      "timeZone" : {
+        "identifier" : "America/Los_Angeles"
+      }
+    }
+  },
+  "maximumBasalRatePerHour" : 3.5,
+  "maximumBolus" : 10,
+  "overridePresets" : [
+    {
+      "duration" : {
+        "finite" : {
+          "duration" : 3600
+        }
+      },
+      "id" : "2A67A303-5203-4CB8-8263-79498265368E",
+      "name" : "Apple",
+      "settings" : {
+        "insulinNeedsScaleFactor" : 2,
+        "targetRangeInMgdl" : {
+          "maxValue" : 140,
+          "minValue" : 130
+        }
+      },
+      "symbol" : "🍎"
+    }
+  ],
+  "preMealOverride" : {
+    "context" : "preMeal",
+    "duration" : "indefinite",
+    "enactTrigger" : "local",
+    "settings" : {
+      "insulinNeedsScaleFactor" : 0.5,
+      "targetRangeInMgdl" : {
+        "maxValue" : 90,
+        "minValue" : 80
+      }
+    },
+    "startDate" : "2020-05-14T14:38:39Z",
+    "syncIdentifier" : "2A67A303-5203-1234-8263-79498265368E"
+  },
+  "preMealTargetRange" : {
+    "maxValue" : 90,
+    "minValue" : 80
+  },
+  "scheduleOverride" : {
+    "context" : "preMeal",
+    "duration" : {
+      "finite" : {
+        "duration" : 3600
+      }
+    },
+    "enactTrigger" : {
+      "remote" : {
+        "address" : "127.0.0.1"
+      }
+    },
+    "settings" : {
+      "insulinNeedsScaleFactor" : 1.5,
+      "targetRangeInMgdl" : {
+        "maxValue" : 120,
+        "minValue" : 110
+      }
+    },
+    "startDate" : "2020-05-14T14:48:19Z",
+    "syncIdentifier" : "2A67A303-1234-4CB8-8263-79498265368E"
+  },
+  "suspendThreshold" : {
+    "unit" : "mg/dL",
+    "value" : 75
+  },
+  "syncIdentifier" : "2A67A303-1234-4CB8-1234-79498265368E",
+  "workoutTargetRange" : {
+    "maxValue" : 160,
+    "minValue" : 150
+  }
+}
+"""
+        )
+    }
+    
+    private func assertStoredSettingsCodable(_ original: StoredSettings, encodesJSON string: String) throws {
+        let data = try encoder.encode(original)
+        XCTAssertEqual(String(data: data, encoding: .utf8), string)
+        let decoded = try decoder.decode(StoredSettings.self, from: data)
         XCTAssertEqual(decoded, original)
     }
+    
+    private let dateFormatter = ISO8601DateFormatter()
+    
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+    
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
 }
 
 extension StoredSettings: Equatable {

--- a/MockKit/MockService.swift
+++ b/MockKit/MockService.swift
@@ -94,42 +94,43 @@ extension MockService: RemoteDataService {
     
     public func uploadCarbData(deleted: [DeletedCarbEntry], stored: [StoredCarbEntry], completion: @escaping (Result<Bool, Error>) -> Void) {
         if remoteData {
-            record("[RemoteDataService] Upload carb data")
+            record("[RemoteDataService] Upload carb data (deleted: \(deleted.count), stored: \(stored.count))")
         }
         completion(.success(false))
     }
     
     public func uploadDoseData(_ stored: [DoseEntry], completion: @escaping (Result<Bool, Error>) -> Void) {
         if remoteData {
-            record("[RemoteDataService] Upload dose data")
+            record("[RemoteDataService] Upload dose data (stored: \(stored.count))")
         }
         completion(.success(false))
     }
 
     public func uploadDosingDecisionData(_ stored: [StoredDosingDecision], completion: @escaping (Result<Bool, Error>) -> Void) {
         if remoteData {
-            record("[RemoteDataService] Upload dosing decision data")
+            let errored = stored.filter { $0.errors?.isEmpty == false }
+            record("[RemoteDataService] Upload dosing decision data (stored: \(stored.count), errored: \(errored.count))")
         }
         completion(.success(false))
     }
 
     public func uploadGlucoseData(_ stored: [StoredGlucoseSample], completion: @escaping (Result<Bool, Error>) -> Void) {
         if remoteData {
-            record("[RemoteDataService] Upload glucose data")
+            record("[RemoteDataService] Upload glucose data (stored: \(stored.count))")
         }
         completion(.success(false))
     }
     
     public func uploadPumpEventData(_ stored: [PersistedPumpEvent], completion: @escaping (Result<Bool, Error>) -> Void) {
         if remoteData {
-            record("[RemoteDataService] Upload pump event data")
+            record("[RemoteDataService] Upload pump event data (stored: \(stored.count))")
         }
         completion(.success(false))
     }
     
     public func uploadSettingsData(_ stored: [StoredSettings], completion: @escaping (Result<Bool, Error>) -> Void) {
         if remoteData {
-            record("[RemoteDataService] Upload settings data")
+            record("[RemoteDataService] Upload settings data (stored: \(stored.count))")
         }
         completion(.success(false))
     }


### PR DESCRIPTION
- https://tidepool.atlassian.net/browse/LOOP-1144
- Move StoredDosingDecision Codable from LoopKit to Loop to support error serialization
- Update DosingDecisionStore to store and retrieve generalized data
- Update decoding of optional properties to use decodeIfPresent
- Use static encoder and decoder for StoredSettings
- Add additional remote data service logging in MockService

@ps2, @nhamming I would like two reviews on this PR.