### PR TITLE
[LOOP-451] Introduce CorrectionRangeScheduleEditor

### DIFF
--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -369,6 +369,9 @@
 		8974B0682215FE460043F01B /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8974B0672215FE460043F01B /* Collection.swift */; };
 		8974B0692215FE460043F01B /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8974B0672215FE460043F01B /* Collection.swift */; };
 		898B4E75246CCAB50053C484 /* Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 898B4E74246CCAB50053C484 /* Binding.swift */; };
+		898B4E77246DAE280053C484 /* GlucoseRangePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 898B4E76246DAE280053C484 /* GlucoseRangePicker.swift */; };
+		898B4E7B246DC6A70053C484 /* CorrectionRangeScheduleEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 898B4E7A246DC6A70053C484 /* CorrectionRangeScheduleEditor.swift */; };
+		898B4E7E246DEB920053C484 /* GuardrailConstrainedQuantityRangeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 898B4E7D246DEB920053C484 /* GuardrailConstrainedQuantityRangeView.swift */; };
 		898E6E5D2241783C0019E459 /* SetConstrainedScheduleEntryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892A5D63222F6B13008961AB /* SetConstrainedScheduleEntryTableViewCell.swift */; };
 		898E6E67224179310019E459 /* BaseHUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 898E6E64224179300019E459 /* BaseHUDView.swift */; };
 		898E6E68224179310019E459 /* BatteryLevelHUDView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 898E6E65224179300019E459 /* BatteryLevelHUDView.xib */; };
@@ -1207,6 +1210,9 @@
 		8974AFBF22120D7A0043F01B /* TemporaryScheduleOverrideTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TemporaryScheduleOverrideTests.swift; sourceTree = "<group>"; };
 		8974B0672215FE460043F01B /* Collection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Collection.swift; sourceTree = "<group>"; };
 		898B4E74246CCAB50053C484 /* Binding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };
+		898B4E76246DAE280053C484 /* GlucoseRangePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseRangePicker.swift; sourceTree = "<group>"; };
+		898B4E7A246DC6A70053C484 /* CorrectionRangeScheduleEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectionRangeScheduleEditor.swift; sourceTree = "<group>"; };
+		898B4E7D246DEB920053C484 /* GuardrailConstrainedQuantityRangeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuardrailConstrainedQuantityRangeView.swift; sourceTree = "<group>"; };
 		898E6E64224179300019E459 /* BaseHUDView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseHUDView.swift; sourceTree = "<group>"; };
 		898E6E65224179300019E459 /* BatteryLevelHUDView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BatteryLevelHUDView.xib; sourceTree = "<group>"; };
 		898E6E66224179300019E459 /* BatteryLevelHUDView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BatteryLevelHUDView.swift; sourceTree = "<group>"; };
@@ -1640,11 +1646,14 @@
 				89F6E312244A1AB500CB9E15 /* GuardrailWarning.swift */,
 				89AC9DCC24529D9B004A6B8A /* TimePicker.swift */,
 				89B0B2A92453C0AB0063D4A7 /* GuardrailConstraintedQuantityView.swift */,
+				898B4E7D246DEB920053C484 /* GuardrailConstrainedQuantityRangeView.swift */,
 				89FC688A245A2D670075CF59 /* InsulinSensitivityScheduleEditor.swift */,
 				89FC688B245A2D670075CF59 /* QuantityScheduleEditor.swift */,
 				89FC688D245A2D680075CF59 /* ScheduleEditor.swift */,
 				89BE75C024649C2E00B145D9 /* ModalHeaderButtonBar.swift */,
 				89FC688C245A2D680075CF59 /* ScheduleItemPicker.swift */,
+				898B4E76246DAE280053C484 /* GlucoseRangePicker.swift */,
+				898B4E7A246DC6A70053C484 /* CorrectionRangeScheduleEditor.swift */,
 				89FC688E245A2D680075CF59 /* ScheduleItemView.swift */,
 				89BE75C224649C4C00B145D9 /* RoundedCorners.swift */,
 				89BE75C424649C8100B145D9 /* NewScheduleItemEditor.swift */,
@@ -2763,6 +2772,7 @@
 			files = (
 				898E6E6E2241ED9F0019E459 /* SuspendResumeTableViewCell.swift in Sources */,
 				B4C004D12416961300B40429 /* GuidePage.swift in Sources */,
+				898B4E7E246DEB920053C484 /* GuardrailConstrainedQuantityRangeView.swift in Sources */,
 				898E6E69224179310019E459 /* BatteryLevelHUDView.swift in Sources */,
 				89B0B2AA2453C0AB0063D4A7 /* GuardrailConstraintedQuantityView.swift in Sources */,
 				898B4E75246CCAB50053C484 /* Binding.swift in Sources */,
@@ -2792,6 +2802,7 @@
 				892155152245C57E009112BC /* SegmentedGaugeBarLayer.swift in Sources */,
 				B4C004D42416962600B40429 /* Color.swift in Sources */,
 				432CF86720D76AB90066B889 /* SettingsTableViewCell.swift in Sources */,
+				898B4E7B246DC6A70053C484 /* CorrectionRangeScheduleEditor.swift in Sources */,
 				898E6E6A224179530019E459 /* BasalScheduleTableViewController.swift in Sources */,
 				892A5DB42231E191008961AB /* LevelMaskView.swift in Sources */,
 				892A5DA02231E130008961AB /* CompletionNotifying.swift in Sources */,
@@ -2839,6 +2850,7 @@
 				43BA716F201E49220058961E /* FoodEmojiDataSource.swift in Sources */,
 				43F89C9F22BDFB10006BB54E /* UIActivityIndicatorView.swift in Sources */,
 				892ADE002446C858007CE08C /* Card.swift in Sources */,
+				898B4E77246DAE280053C484 /* GlucoseRangePicker.swift in Sources */,
 				432CF86D20D76C470066B889 /* SwitchTableViewCell.swift in Sources */,
 				43BA7188201EE85B0058961E /* HKUnit.swift in Sources */,
 				89F6E30D2449713600CB9E15 /* CardStack.swift in Sources */,

--- a/LoopKit/GlucoseRangeSchedule.swift
+++ b/LoopKit/GlucoseRangeSchedule.swift
@@ -165,6 +165,11 @@ public struct GlucoseRangeSchedule: DailySchedule, Equatable {
     public var rawValue: RawValue {
         return rangeSchedule.rawValue
     }
+
+    public func minLowerBound() -> HKQuantity {
+        let minDoubleValue = items.lazy.map { $0.value.minValue }.min()!
+        return HKQuantity(unit: unit, doubleValue: minDoubleValue)
+    }
 }
 
 extension GlucoseRangeSchedule: Codable {}

--- a/LoopKit/GlucoseRangeSchedule.swift
+++ b/LoopKit/GlucoseRangeSchedule.swift
@@ -180,7 +180,7 @@ extension DoubleRange {
 }
 
 extension ClosedRange where Bound == HKQuantity {
-    func doubleRange(for unit: HKUnit) -> DoubleRange {
+    public func doubleRange(for unit: HKUnit) -> DoubleRange {
         return DoubleRange(minValue: lowerBound.doubleValue(for: unit), maxValue: upperBound.doubleValue(for: unit))
     }
 }

--- a/LoopKitUI/Views/CorrectionRangeScheduleEditor.swift
+++ b/LoopKitUI/Views/CorrectionRangeScheduleEditor.swift
@@ -20,6 +20,7 @@ public struct CorrectionRangeScheduleEditor: View {
     var initialSchedule: GlucoseRangeSchedule?
     @State var scheduleItems: [RepeatingScheduleValue<DoubleRange>]
     var unit: HKUnit
+    var minValue: HKQuantity?
     var save: (GlucoseRangeSchedule) -> Void
     let guardrail = Guardrail.correctionRange
 
@@ -29,11 +30,13 @@ public struct CorrectionRangeScheduleEditor: View {
     public init(
         schedule: GlucoseRangeSchedule?,
         unit: HKUnit,
+        minValue: HKQuantity?,
         onSave save: @escaping (GlucoseRangeSchedule) -> Void
     ) {
         self.initialSchedule = schedule
         self._scheduleItems = State(initialValue: schedule?.items ?? [])
         self.unit = unit
+        self.minValue = minValue
         self.save = save
     }
 
@@ -58,6 +61,7 @@ public struct CorrectionRangeScheduleEditor: View {
                         }
                     ),
                     unit: self.unit,
+                    minValue: self.minValue,
                     guardrail: self.guardrail,
                     stride: self.stride,
                     availableWidth: availableWidth

--- a/LoopKitUI/Views/CorrectionRangeScheduleEditor.swift
+++ b/LoopKitUI/Views/CorrectionRangeScheduleEditor.swift
@@ -104,7 +104,7 @@ public struct CorrectionRangeScheduleEditor: View {
     }
 
     var description: Text {
-        Text("The correction range is the glucose range that you would like the App to correct your glucose to by adjusting insulin dosing.", comment: "Description of correction range setting")
+        Text("The app adjusts insulin delivery in an effort to bring your glucose into your correction range.", comment: "Description of correction range setting")
     }
 
     var guardrailWarningIfNecessary: some View {

--- a/LoopKitUI/Views/CorrectionRangeScheduleEditor.swift
+++ b/LoopKitUI/Views/CorrectionRangeScheduleEditor.swift
@@ -59,7 +59,8 @@ public struct CorrectionRangeScheduleEditor: View {
                     ),
                     unit: self.unit,
                     guardrail: self.guardrail,
-                    stride: self.stride
+                    stride: self.stride,
+                    availableWidth: availableWidth
                 )
             },
             actionAreaContent: {

--- a/LoopKitUI/Views/CorrectionRangeScheduleEditor.swift
+++ b/LoopKitUI/Views/CorrectionRangeScheduleEditor.swift
@@ -1,0 +1,172 @@
+//
+//  CorrectionRangeScheduleEditor.swift
+//  LoopKitUI
+//
+//  Created by Michael Pangburn on 5/14/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+import HealthKit
+import LoopKit
+
+
+extension Guardrail where Value == HKQuantity {
+    static let correctionRange = Guardrail(absoluteBounds: 60...180, recommendedBounds: 100...120, unit: .milligramsPerDeciliter)
+}
+
+
+public struct CorrectionRangeScheduleEditor: View {
+    var initialSchedule: GlucoseRangeSchedule?
+    @State var scheduleItems: [RepeatingScheduleValue<DoubleRange>]
+    var unit: HKUnit
+    var save: (GlucoseRangeSchedule) -> Void
+    let guardrail = Guardrail.correctionRange
+
+    @Environment(\.dismiss) var dismiss
+    @State var showingConfirmationAlert = false
+
+    public init(
+        schedule: GlucoseRangeSchedule?,
+        unit: HKUnit,
+        onSave save: @escaping (GlucoseRangeSchedule) -> Void
+    ) {
+        self.initialSchedule = schedule
+        self._scheduleItems = State(initialValue: schedule?.items ?? [])
+        self.unit = unit
+        self.save = save
+    }
+
+    public var body: some View {
+        ScheduleEditor(
+            title: Text("Correction Ranges", comment: "Title of correction range schedule editor"),
+            description: description,
+            scheduleItems: $scheduleItems,
+            initialScheduleItems: initialSchedule?.items ?? [],
+            defaultFirstScheduleItemValue: defaultFirstScheduleItemValue,
+            valueContent: { range, isEditing in
+                GuardrailConstrainedQuantityRangeView(range: range.quantityRange(for: self.unit), unit: self.unit, guardrail: self.guardrail, isEditing: isEditing)
+            },
+            valuePicker: { scheduleItem, availableWidth in
+                GlucoseRangePicker(
+                    range: Binding(
+                        get: { scheduleItem.wrappedValue.value.quantityRange(for: self.unit) },
+                        set: { quantityRange in
+                            withAnimation {
+                                scheduleItem.wrappedValue.value = quantityRange.doubleRange(for: self.unit)
+                            }
+                        }
+                    ),
+                    unit: self.unit,
+                    guardrail: self.guardrail,
+                    stride: self.stride
+                )
+            },
+            actionAreaContent: {
+                guardrailWarningIfNecessary
+            },
+            onSave: { scheduleItems in
+                if self.crossedThresholds.isEmpty {
+                    self.saveAndDismiss()
+                } else {
+                    self.showingConfirmationAlert = true
+                }
+            }
+        )
+        .alert(isPresented: $showingConfirmationAlert, content: confirmationAlert)
+    }
+
+    private var stride: HKQuantity {
+        switch unit {
+        case .milligramsPerDeciliter:
+            return HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 1)
+        case .millimolesPerLiter:
+            return HKQuantity(unit: .millimolesPerLiter, doubleValue: 0.1)
+        default:
+            fatalError("Unsupported glucose unit \(unit)")
+        }
+    }
+
+    var defaultFirstScheduleItemValue: DoubleRange {
+        switch unit {
+        case .milligramsPerDeciliter:
+            return DoubleRange(minValue: 100, maxValue: 120)
+        case .millimolesPerLiter:
+            return DoubleRange(minValue: 5.6, maxValue: 6.7)
+        default:
+            fatalError("Unsupposed glucose unit \(unit)")
+        }
+    }
+
+    var description: Text {
+        Text("The correction range is the glucose range that you would like the App to correct your glucose to by adjusting insulin dosing.", comment: "Description of correction range setting")
+    }
+
+    var guardrailWarningIfNecessary: some View {
+        let crossedThresholds = self.crossedThresholds
+        return Group {
+            if !crossedThresholds.isEmpty {
+                CorrectionRangeGuardrailWarning(crossedThresholds: crossedThresholds)
+            }
+        }
+    }
+
+    var crossedThresholds: [SafetyClassification.Threshold] {
+        scheduleItems.flatMap { (item) -> [SafetyClassification.Threshold] in
+            let lowerBound = HKQuantity(unit: unit, doubleValue: item.value.minValue)
+            let upperBound = HKQuantity(unit: unit, doubleValue: item.value.maxValue)
+            return [lowerBound, upperBound].compactMap { (bound) -> SafetyClassification.Threshold? in
+                switch guardrail.classification(for: bound) {
+                case .withinRecommendedRange:
+                    return nil
+                case .outsideRecommendedRange(let threshold):
+                    return threshold
+                }
+            }
+        }
+    }
+
+    func saveAndDismiss() {
+        let quantitySchedule = DailyQuantitySchedule(unit: unit, dailyItems: scheduleItems)!
+        let rangeSchedule = GlucoseRangeSchedule(rangeSchedule: quantitySchedule, override: initialSchedule?.override)
+        save(rangeSchedule)
+        dismiss()
+    }
+
+    private func confirmationAlert() -> Alert {
+        Alert(
+            title: Text("Save Correction Range(s)?", comment: "Alert title for confirming correction ranges outside the recommended range"),
+            message: Text("One or more of the values you have entered are outside of what Tidepool generally recommends.", comment: "Alert message for confirming correction ranges outside the recommended range"),
+            primaryButton: .cancel(Text("Go Back")),
+            secondaryButton: .default(
+                Text("Continue"),
+                action: saveAndDismiss
+            )
+        )
+    }
+}
+
+private struct CorrectionRangeGuardrailWarning: View {
+    var crossedThresholds: [SafetyClassification.Threshold]
+
+    var body: some View {
+        assert(!crossedThresholds.isEmpty)
+        return GuardrailWarning(
+            title: crossedThresholds.count == 1 ? singularWarningTitle(for: crossedThresholds.first!) : multipleWarningTitle,
+            thresholds: crossedThresholds
+        )
+    }
+
+    private func singularWarningTitle(for threshold: SafetyClassification.Threshold) -> Text {
+        switch threshold {
+        case .minimum, .belowRecommended:
+            return Text("Low Correction Value", comment: "Title text for the low correction value warning")
+        case .aboveRecommended, .maximum:
+            return Text("High Correction Value", comment: "Title text for the high correction value warning")
+        }
+    }
+
+    private var multipleWarningTitle: Text {
+        Text("Correction Values", comment: "Title text for multi-value correction value warning")
+    }
+}

--- a/LoopKitUI/Views/GlucoseRangePicker.swift
+++ b/LoopKitUI/Views/GlucoseRangePicker.swift
@@ -45,37 +45,41 @@ struct GlucoseRangePicker: View {
 
     var body: some View {
         GeometryReader { geometry in
-            HStack(spacing: 0) {
-                GlucoseValuePicker(
-                    value: self.$lowerBound,
-                    unit: self.unit,
-                    guardrail: self.guardrail,
-                    bounds: self.lowerBoundRange,
-                    isUnitLabelVisible: false
-                )
-                // Ensure the selectable picker values update when either bound changes
-                .id(self.lowerBound...self.upperBound)
-                .frame(width: geometry.size.width / 3.5)
-                .overlay(
-                    Text(self.separator)
-                        .foregroundColor(Color(.secondaryLabel))
-                        .offset(x: self.spacing + self.separatorWidth),
-                    alignment: .trailing
-                )
-                .padding(.trailing, self.spacing + self.separatorWidth + self.spacing)
-                .clipped()
+            HStack {
+                Spacer()
+                HStack(spacing: 0) {
+                    GlucoseValuePicker(
+                        value: self.$lowerBound,
+                        unit: self.unit,
+                        guardrail: self.guardrail,
+                        bounds: self.lowerBoundRange,
+                        isUnitLabelVisible: false
+                    )
+                    // Ensure the selectable picker values update when either bound changes
+                    .id(self.lowerBound...self.upperBound)
+                    .frame(width: geometry.size.width / 3.5)
+                    .overlay(
+                        Text(self.separator)
+                            .foregroundColor(Color(.secondaryLabel))
+                            .offset(x: self.spacing + self.separatorWidth),
+                        alignment: .trailing
+                    )
+                    .padding(.trailing, self.spacing + self.separatorWidth + self.spacing)
+                    .clipped()
 
-                GlucoseValuePicker(
-                    value: self.$upperBound,
-                    unit: self.unit,
-                    guardrail: self.guardrail,
-                    bounds: self.upperBoundRange
-                )
-                // Ensure the selectable picker values update when either bound changes
-                .id(self.lowerBound...self.upperBound)
-                .frame(width: geometry.size.width / 3.5)
-                .padding(.trailing, self.spacing + self.unitLabelWidth)
-                .clipped()
+                    GlucoseValuePicker(
+                        value: self.$upperBound,
+                        unit: self.unit,
+                        guardrail: self.guardrail,
+                        bounds: self.upperBoundRange
+                    )
+                    // Ensure the selectable picker values update when either bound changes
+                    .id(self.lowerBound...self.upperBound)
+                    .frame(width: geometry.size.width / 3.5)
+                    .padding(.trailing, self.spacing + self.unitLabelWidth)
+                    .clipped()
+                }
+                Spacer()
             }
         }
     }

--- a/LoopKitUI/Views/GlucoseRangePicker.swift
+++ b/LoopKitUI/Views/GlucoseRangePicker.swift
@@ -1,0 +1,116 @@
+//
+//  GlucoseRangePicker.swift
+//  LoopKitUI
+//
+//  Created by Michael Pangburn on 5/14/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+import HealthKit
+import LoopKit
+
+
+struct GlucoseRangePicker: View {
+    @Binding var lowerBound: HKQuantity
+    @Binding var upperBound: HKQuantity
+    var unit: HKUnit
+    var guardrail: Guardrail<HKQuantity>
+    var stride: HKQuantity
+    var formatter: NumberFormatter
+
+    init(
+        range: Binding<ClosedRange<HKQuantity>>,
+        unit: HKUnit,
+        guardrail: Guardrail<HKQuantity>,
+        stride: HKQuantity
+    ) {
+        self._lowerBound = Binding(
+            get: { range.wrappedValue.lowerBound},
+            set: { range.wrappedValue = $0...range.wrappedValue.upperBound }
+        )
+        self._upperBound = Binding(
+            get: { range.wrappedValue.upperBound },
+            set: { range.wrappedValue = range.wrappedValue.lowerBound...$0 }
+        )
+        self.unit = unit
+        self.guardrail = guardrail
+        self.stride = stride
+        self.formatter = {
+            let quantityFormatter = QuantityFormatter()
+            quantityFormatter.setPreferredNumberFormatter(for: unit)
+            return quantityFormatter.numberFormatter
+        }()
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            HStack(spacing: 0) {
+                GlucoseValuePicker(
+                    value: self.$lowerBound,
+                    unit: self.unit,
+                    guardrail: self.guardrail,
+                    bounds: self.lowerBoundRange,
+                    isUnitLabelVisible: false
+                )
+                // Ensure the selectable picker values update when either bound changes
+                .id(self.lowerBound...self.upperBound)
+                .frame(width: geometry.size.width / 3.5)
+                .overlay(
+                    Text(self.separator)
+                        .foregroundColor(Color(.secondaryLabel))
+                        .offset(x: self.spacing + self.separatorWidth),
+                    alignment: .trailing
+                )
+                .padding(.trailing, self.spacing + self.separatorWidth + self.spacing)
+                .clipped()
+
+                GlucoseValuePicker(
+                    value: self.$upperBound,
+                    unit: self.unit,
+                    guardrail: self.guardrail,
+                    bounds: self.upperBoundRange
+                )
+                // Ensure the selectable picker values update when either bound changes
+                .id(self.lowerBound...self.upperBound)
+                .frame(width: geometry.size.width / 3.5)
+                .padding(.trailing, self.spacing + self.unitLabelWidth)
+                .clipped()
+            }
+        }
+    }
+
+    var separator: String { "–" }
+
+    var separatorWidth: CGFloat {
+        let attributedSeparator = NSAttributedString(
+            string: separator,
+            attributes: [.font: UIFont.preferredFont(forTextStyle: .body)]
+        )
+
+        return attributedSeparator.size().width
+    }
+
+    var spacing: CGFloat { 8 }
+
+    var unitLabelWidth: CGFloat {
+        let attributedUnitString = NSAttributedString(
+            string: unit.shortLocalizedUnitString(),
+            attributes: [.font: UIFont.preferredFont(forTextStyle: .body)]
+        )
+
+        return attributedUnitString.size().width
+    }
+
+    var lowerBoundRange: ClosedRange<HKQuantity> {
+        let min = guardrail.absoluteBounds.lowerBound
+        let max = Swift.min(guardrail.absoluteBounds.upperBound, upperBound)
+        return min...max
+    }
+
+    var upperBoundRange: ClosedRange<HKQuantity> {
+        let min = max(guardrail.absoluteBounds.lowerBound, lowerBound)
+        let max = guardrail.absoluteBounds.upperBound
+        return min...max
+    }
+}

--- a/LoopKitUI/Views/GlucoseRangePicker.swift
+++ b/LoopKitUI/Views/GlucoseRangePicker.swift
@@ -18,12 +18,14 @@ struct GlucoseRangePicker: View {
     var guardrail: Guardrail<HKQuantity>
     var stride: HKQuantity
     var formatter: NumberFormatter
+    var availableWidth: CGFloat
 
     init(
         range: Binding<ClosedRange<HKQuantity>>,
         unit: HKUnit,
         guardrail: Guardrail<HKQuantity>,
-        stride: HKQuantity
+        stride: HKQuantity,
+        availableWidth: CGFloat
     ) {
         self._lowerBound = Binding(
             get: { range.wrappedValue.lowerBound},
@@ -41,46 +43,41 @@ struct GlucoseRangePicker: View {
             quantityFormatter.setPreferredNumberFormatter(for: unit)
             return quantityFormatter.numberFormatter
         }()
+        self.availableWidth = availableWidth
     }
 
     var body: some View {
-        GeometryReader { geometry in
-            HStack {
-                Spacer()
-                HStack(spacing: 0) {
-                    GlucoseValuePicker(
-                        value: self.$lowerBound,
-                        unit: self.unit,
-                        guardrail: self.guardrail,
-                        bounds: self.lowerBoundRange,
-                        isUnitLabelVisible: false
-                    )
-                    // Ensure the selectable picker values update when either bound changes
-                    .id(self.lowerBound...self.upperBound)
-                    .frame(width: geometry.size.width / 3.5)
-                    .overlay(
-                        Text(self.separator)
-                            .foregroundColor(Color(.secondaryLabel))
-                            .offset(x: self.spacing + self.separatorWidth),
-                        alignment: .trailing
-                    )
-                    .padding(.trailing, self.spacing + self.separatorWidth + self.spacing)
-                    .clipped()
+        HStack(spacing: 0) {
+            GlucoseValuePicker(
+                value: $lowerBound,
+                unit: unit,
+                guardrail: guardrail,
+                bounds: lowerBoundRange,
+                isUnitLabelVisible: false
+            )
+            // Ensure the selectable picker values update when either bound changes
+            .id(lowerBound...upperBound)
+            .frame(width: availableWidth / 3.5)
+            .overlay(
+                Text(separator)
+                    .foregroundColor(Color(.secondaryLabel))
+                    .offset(x: spacing + separatorWidth),
+                alignment: .trailing
+            )
+            .padding(.trailing, spacing + separatorWidth + spacing)
+            .clipped()
 
-                    GlucoseValuePicker(
-                        value: self.$upperBound,
-                        unit: self.unit,
-                        guardrail: self.guardrail,
-                        bounds: self.upperBoundRange
-                    )
-                    // Ensure the selectable picker values update when either bound changes
-                    .id(self.lowerBound...self.upperBound)
-                    .frame(width: geometry.size.width / 3.5)
-                    .padding(.trailing, self.spacing + self.unitLabelWidth)
-                    .clipped()
-                }
-                Spacer()
-            }
+            GlucoseValuePicker(
+                value: $upperBound,
+                unit: unit,
+                guardrail: guardrail,
+                bounds: upperBoundRange
+            )
+            // Ensure the selectable picker values update when either bound changes
+            .id(lowerBound...upperBound)
+            .frame(width: availableWidth / 3.5)
+            .padding(.trailing, spacing + unitLabelWidth)
+            .clipped()
         }
     }
 

--- a/LoopKitUI/Views/GlucoseRangePicker.swift
+++ b/LoopKitUI/Views/GlucoseRangePicker.swift
@@ -15,6 +15,7 @@ struct GlucoseRangePicker: View {
     @Binding var lowerBound: HKQuantity
     @Binding var upperBound: HKQuantity
     var unit: HKUnit
+    var minValue: HKQuantity?
     var guardrail: Guardrail<HKQuantity>
     var stride: HKQuantity
     var formatter: NumberFormatter
@@ -23,6 +24,7 @@ struct GlucoseRangePicker: View {
     init(
         range: Binding<ClosedRange<HKQuantity>>,
         unit: HKUnit,
+        minValue: HKQuantity?,
         guardrail: Guardrail<HKQuantity>,
         stride: HKQuantity,
         availableWidth: CGFloat
@@ -36,6 +38,7 @@ struct GlucoseRangePicker: View {
             set: { range.wrappedValue = range.wrappedValue.lowerBound...$0 }
         )
         self.unit = unit
+        self.minValue = minValue
         self.guardrail = guardrail
         self.stride = stride
         self.formatter = {
@@ -104,7 +107,8 @@ struct GlucoseRangePicker: View {
     }
 
     var lowerBoundRange: ClosedRange<HKQuantity> {
-        let min = guardrail.absoluteBounds.lowerBound
+        let min = minValue.map { Swift.max(guardrail.absoluteBounds.lowerBound, $0) }
+            ?? guardrail.absoluteBounds.lowerBound
         let max = Swift.min(guardrail.absoluteBounds.upperBound, upperBound)
         return min...max
     }

--- a/LoopKitUI/Views/GlucoseValuePicker.swift
+++ b/LoopKitUI/Views/GlucoseValuePicker.swift
@@ -15,15 +15,42 @@ public struct GlucoseValuePicker: View {
     @Binding var value: HKQuantity
     var unit: HKUnit
     var guardrail: Guardrail<HKQuantity>
+    var bounds: ClosedRange<HKQuantity>
+    var isUnitLabelVisible: Bool
 
-    public init(value: Binding<HKQuantity>, unit: HKUnit, guardrail: Guardrail<HKQuantity>) {
+    public init(
+        value: Binding<HKQuantity>,
+        unit: HKUnit,
+        guardrail: Guardrail<HKQuantity>,
+        bounds: ClosedRange<HKQuantity>,
+        isUnitLabelVisible: Bool = true
+    ) {
         self._value = value
         self.unit = unit
         self.guardrail = guardrail
+        self.bounds = bounds
+        self.isUnitLabelVisible = isUnitLabelVisible
+    }
+
+    public init(
+        value: Binding<HKQuantity>,
+        unit: HKUnit,
+        guardrail: Guardrail<HKQuantity>,
+        isUnitLabelVisible: Bool = true
+    ) {
+        self.init(value: value, unit: unit, guardrail: guardrail, bounds: guardrail.absoluteBounds, isUnitLabelVisible: isUnitLabelVisible)
     }
 
     public var body: some View {
-        QuantityPicker(value: $value, unit: unit, stride: stride, guardrail: guardrail)
+        QuantityPicker(value: $value, unit: unit, guardrail: guardrail, selectableValues: selectableValues, isUnitLabelVisible: isUnitLabelVisible)
+    }
+
+    private var selectableValues: [Double] {
+        Array(Swift.stride(
+            from: bounds.lowerBound.doubleValue(for: unit),
+            through: bounds.upperBound.doubleValue(for: unit),
+            by: stride.doubleValue(for: unit)
+        ))
     }
 
     private var stride: HKQuantity {

--- a/LoopKitUI/Views/GuardrailConstrainedQuantityRangeView.swift
+++ b/LoopKitUI/Views/GuardrailConstrainedQuantityRangeView.swift
@@ -39,13 +39,27 @@ struct GuardrailConstrainedQuantityRangeView: View {
 
     var body: some View {
         HStack {
-            GuardrailConstrainedQuantityView(value: range.lowerBound, unit: unit, guardrail: guardrail, isEditing: isEditing, iconSpacing: 4, isUnitLabelVisible: false)
+            GuardrailConstrainedQuantityView(
+                value: range.lowerBound,
+                unit: unit,
+                guardrail: guardrail,
+                isEditing: isEditing,
+                iconSpacing: 4,
+                isUnitLabelVisible: false
+            )
 
             Text("–")
                 .foregroundColor(Color(.secondaryLabel))
                 .animation(isEditing || !hasAppeared ? nil : .default)
 
-            GuardrailConstrainedQuantityView(value: range.upperBound, unit: unit, guardrail: guardrail, isEditing: isEditing, iconSpacing: 4)
+            GuardrailConstrainedQuantityView(
+                value: range.upperBound,
+                unit: unit,
+                guardrail: guardrail,
+                isEditing: isEditing,
+                iconSpacing: 4,
+                iconAnimatesOut: false
+            )
         }
         .onAppear { self.hasAppeared = true }
     }

--- a/LoopKitUI/Views/GuardrailConstrainedQuantityRangeView.swift
+++ b/LoopKitUI/Views/GuardrailConstrainedQuantityRangeView.swift
@@ -1,0 +1,52 @@
+//
+//  GuardrailConstrainedQuantityRangeView.swift
+//  LoopKitUI
+//
+//  Created by Michael Pangburn on 5/14/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+import HealthKit
+import LoopKit
+
+
+struct GuardrailConstrainedQuantityRangeView: View {
+    var range: ClosedRange<HKQuantity>
+    var unit: HKUnit
+    var guardrail: Guardrail<HKQuantity>
+    var isEditing: Bool
+    var formatter: NumberFormatter
+
+    @State var hasAppeared = false
+
+    init(
+        range: ClosedRange<HKQuantity>,
+        unit: HKUnit,
+        guardrail: Guardrail<HKQuantity>,
+        isEditing: Bool
+    ) {
+        self.range = range
+        self.unit = unit
+        self.guardrail = guardrail
+        self.isEditing = isEditing
+        self.formatter = {
+            let quantityFormatter = QuantityFormatter()
+            quantityFormatter.setPreferredNumberFormatter(for: unit)
+            return quantityFormatter.numberFormatter
+        }()
+    }
+
+    var body: some View {
+        HStack {
+            GuardrailConstrainedQuantityView(value: range.lowerBound, unit: unit, guardrail: guardrail, isEditing: isEditing, iconSpacing: 4, isUnitLabelVisible: false)
+
+            Text("–")
+                .foregroundColor(Color(.secondaryLabel))
+                .animation(isEditing || !hasAppeared ? nil : .default)
+
+            GuardrailConstrainedQuantityView(value: range.upperBound, unit: unit, guardrail: guardrail, isEditing: isEditing, iconSpacing: 4)
+        }
+        .onAppear { self.hasAppeared = true }
+    }
+}

--- a/LoopKitUI/Views/GuardrailConstraintedQuantityView.swift
+++ b/LoopKitUI/Views/GuardrailConstraintedQuantityView.swift
@@ -19,11 +19,21 @@ public struct GuardrailConstrainedQuantityView: View {
     var formatter: NumberFormatter
     var iconSpacing: CGFloat
     var isUnitLabelVisible: Bool
+    var iconAnimatesOut: Bool
     var forceDisableAnimations: Bool
 
     @State private var hasAppeared = false
 
-    public init(value: HKQuantity, unit: HKUnit, guardrail: Guardrail<HKQuantity>, isEditing: Bool, iconSpacing: CGFloat = 8, isUnitLabelVisible: Bool = true, forceDisableAnimations: Bool = false) {
+    public init(
+        value: HKQuantity,
+        unit: HKUnit,
+        guardrail: Guardrail<HKQuantity>,
+        isEditing: Bool,
+        iconSpacing: CGFloat = 8,
+        isUnitLabelVisible: Bool = true,
+        iconAnimatesOut: Bool = true,
+        forceDisableAnimations: Bool = false
+    ) {
         self.value = value
         self.unit = unit
         self.guardrail = guardrail
@@ -35,6 +45,7 @@ public struct GuardrailConstrainedQuantityView: View {
             return quantityFormatter.numberFormatter
         }()
         self.isUnitLabelVisible = isUnitLabelVisible
+        self.iconAnimatesOut = iconAnimatesOut
         self.forceDisableAnimations = forceDisableAnimations
     }
 
@@ -44,7 +55,7 @@ public struct GuardrailConstrainedQuantityView: View {
                 if guardrail.classification(for: value) != .withinRecommendedRange {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .foregroundColor(warningColor)
-                        .transition(.springInScaleOut)
+                        .transition(iconAnimatesOut ? .springInScaleOut : .springInDisappear)
                 }
 
                 Text(formatter.string(from: value.doubleValue(for: unit)) ?? "\(value.doubleValue(for: unit))")
@@ -91,5 +102,10 @@ fileprivate extension AnyTransition {
     static let springInScaleOut = asymmetric(
         insertion: AnyTransition.scale.animation(.spring(dampingFraction: 0.5)),
         removal: AnyTransition.scale.combined(with: .opacity).animation(.default)
+    )
+
+    static let springInDisappear = asymmetric(
+        insertion: AnyTransition.scale.animation(.spring(dampingFraction: 0.5)),
+        removal: .identity
     )
 }

--- a/LoopKitUI/Views/GuardrailConstraintedQuantityView.swift
+++ b/LoopKitUI/Views/GuardrailConstraintedQuantityView.swift
@@ -17,36 +17,44 @@ public struct GuardrailConstrainedQuantityView: View {
     var guardrail: Guardrail<HKQuantity>
     var isEditing: Bool
     var formatter: NumberFormatter
+    var iconSpacing: CGFloat
+    var isUnitLabelVisible: Bool
     var forceDisableAnimations: Bool
 
     @State private var hasAppeared = false
 
-    public init(value: HKQuantity, unit: HKUnit, guardrail: Guardrail<HKQuantity>, isEditing: Bool, forceDisableAnimations: Bool = false) {
+    public init(value: HKQuantity, unit: HKUnit, guardrail: Guardrail<HKQuantity>, isEditing: Bool, iconSpacing: CGFloat = 8, isUnitLabelVisible: Bool = true, forceDisableAnimations: Bool = false) {
         self.value = value
         self.unit = unit
         self.guardrail = guardrail
         self.isEditing = isEditing
+        self.iconSpacing = iconSpacing
         self.formatter = {
             let quantityFormatter = QuantityFormatter()
             quantityFormatter.setPreferredNumberFormatter(for: unit)
             return quantityFormatter.numberFormatter
         }()
+        self.isUnitLabelVisible = isUnitLabelVisible
         self.forceDisableAnimations = forceDisableAnimations
     }
 
     public var body: some View {
         HStack {
-            if guardrail.classification(for: value) != .withinRecommendedRange {
-                Image(systemName: "exclamationmark.triangle.fill")
+            HStack(spacing: iconSpacing) {
+                if guardrail.classification(for: value) != .withinRecommendedRange {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(warningColor)
+                        .transition(.springInScaleOut)
+                }
+
+                Text(formatter.string(from: value.doubleValue(for: unit)) ?? "\(value.doubleValue(for: unit))")
                     .foregroundColor(warningColor)
-                    .transition(.springInScaleOut)
             }
 
-            Text(formatter.string(from: value.doubleValue(for: unit)) ?? "\(value.doubleValue(for: unit))")
-                .foregroundColor(warningColor)
-
-            Text(unit.shortLocalizedUnitString())
-                .foregroundColor(Color(.secondaryLabel))
+            if isUnitLabelVisible {
+                Text(unit.shortLocalizedUnitString())
+                    .foregroundColor(Color(.secondaryLabel))
+            }
         }
         .onAppear { self.hasAppeared = true }
         .animation(animation)

--- a/LoopKitUI/Views/QuantityPicker.swift
+++ b/LoopKitUI/Views/QuantityPicker.swift
@@ -23,16 +23,29 @@ public struct QuantityPicker: View {
     @Binding var value: HKQuantity
     var unit: HKUnit
     var guardrail: Guardrail<HKQuantity>
+    var isUnitLabelVisible: Bool
 
     private let selectableValues: [Double]
     private let formatter: NumberFormatter
 
-    public init(value: Binding<HKQuantity>, unit: HKUnit, stride: HKQuantity, guardrail: Guardrail<HKQuantity>) {
+    public init(
+        value: Binding<HKQuantity>,
+        unit: HKUnit,
+        stride: HKQuantity,
+        guardrail: Guardrail<HKQuantity>,
+        isUnitLabelVisible: Bool = true
+    ) {
         let selectableValues = guardrail.allValues(stridingBy: stride, unit: unit)
-        self.init(value: value, unit: unit, guardrail: guardrail, selectableValues: selectableValues)
+        self.init(value: value, unit: unit, guardrail: guardrail, selectableValues: selectableValues, isUnitLabelVisible: isUnitLabelVisible)
     }
 
-    public init(value: Binding<HKQuantity>, unit: HKUnit, guardrail: Guardrail<HKQuantity>, selectableValues: [Double]) {
+    public init(
+        value: Binding<HKQuantity>,
+        unit: HKUnit,
+        guardrail: Guardrail<HKQuantity>,
+        selectableValues: [Double],
+        isUnitLabelVisible: Bool = true
+    ) {
         self._value = value
         self.unit = unit
         self.guardrail = guardrail
@@ -42,6 +55,7 @@ public struct QuantityPicker: View {
             quantityFormatter.setPreferredNumberFormatter(for: unit)
             return quantityFormatter.numberFormatter
         }()
+        self.isUnitLabelVisible = isUnitLabelVisible
     }
 
     private var selection: Binding<Double> {
@@ -81,7 +95,7 @@ public struct QuantityPicker: View {
 
     private func unitLabel(positionedFrom pickerValueBounds: [Anchor<CGRect>]) -> some View {
         GeometryReader { geometry in
-            if !pickerValueBounds.isEmpty {
+            if self.isUnitLabelVisible && !pickerValueBounds.isEmpty {
                 Text(self.unit.shortLocalizedUnitString())
                     .foregroundColor(.gray)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)

--- a/LoopKitUI/Views/QuantityScheduleEditor.swift
+++ b/LoopKitUI/Views/QuantityScheduleEditor.swift
@@ -100,7 +100,7 @@ struct QuantityScheduleEditor<ActionAreaContent: View>: View {
                     guardrail: self.guardrail,
                     selectableValues: self.selectableValues
                 )
-                .frame(width: availableWidth / 3)
+                .frame(width: availableWidth / 2)
                 // Ensure overlaid unit label is not clipped
                 .padding(.trailing, self.unitLabelWidth + self.unitLabelSpacing)
                 .clipped()

--- a/LoopKitUI/Views/ScheduleItemPicker.swift
+++ b/LoopKitUI/Views/ScheduleItemPicker.swift
@@ -39,7 +39,7 @@ struct ScheduleItemPicker<Value, ValuePicker: View>: View {
                         .frame(width: geometry.size.width / 3)
                         .clipped()
 
-                    self.valuePicker(geometry.size.width)
+                    self.valuePicker(/* availableWidth: */ 2/3 * geometry.size.width)
                 }
                 Spacer()
             }

--- a/LoopKitUI/Views/SettingDescription.swift
+++ b/LoopKitUI/Views/SettingDescription.swift
@@ -17,11 +17,13 @@ public struct SettingDescription: View {
     }
 
     public var body: some View {
-        HStack(spacing: 16) {
+        HStack(spacing: 8) {
             text
                 .font(.callout)
                 .foregroundColor(Color(.secondaryLabel))
                 .fixedSize(horizontal: false, vertical: true)
+
+            Spacer()
 
             Button(
                 action: {
@@ -33,6 +35,7 @@ public struct SettingDescription: View {
                         .foregroundColor(.accentColor)
                 }
             )
+            .padding(.trailing, 4)
         }
     }
 }


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-451
(Not technically a part of this sprint, but I'm getting a jump on it.)

Pre-Meal and Workout targets will appear on a separate page (or pages), per the design spec

See https://github.com/tidepool-org/Loop/pull/90 for how this looks when integrated