### PR TITLE
[LOOP-452] Introduce FractionalQuantityPicker & CarbRatioScheduleEditor

### DIFF
--- a/Extensions/Collection.swift
+++ b/Extensions/Collection.swift
@@ -48,3 +48,39 @@ extension RangeReplaceableCollection where Index: Hashable {
         }
     }
 }
+
+// Source:  https://github.com/apple/swift/blob/master/stdlib/public/core/CollectionAlgorithms.swift#L476
+extension Collection {
+    /// Returns the index of the first element in the collection that matches
+    /// the predicate.
+    ///
+    /// The collection must already be partitioned according to the predicate.
+    /// That is, there should be an index `i` where for every element in
+    /// `collection[..<i]` the predicate is `false`, and for every element
+    /// in `collection[i...]` the predicate is `true`.
+    ///
+    /// - Parameter predicate: A predicate that partitions the collection.
+    /// - Returns: The index of the first element in the collection for which
+    ///   `predicate` returns `true`.
+    ///
+    /// - Complexity: O(log *n*), where *n* is the length of this collection if
+    ///   the collection conforms to `RandomAccessCollection`, otherwise O(*n*).
+    func partitioningIndex(
+        where predicate: (Element) throws -> Bool
+    ) rethrows -> Index {
+        var n = count
+        var l = startIndex
+
+        while n > 0 {
+            let half = n / 2
+            let mid = index(l, offsetBy: half)
+            if try predicate(self[mid]) {
+                n = half
+            } else {
+                l = index(after: mid)
+                n -= half + 1
+            }
+        }
+        return l
+    }
+}

--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -365,6 +365,8 @@
 		895FE09322011F4800FCF18A /* EmojiInputController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895FE08F22011F4800FCF18A /* EmojiInputController.swift */; };
 		89627B16244115A400BEB424 /* CardList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89627B15244115A400BEB424 /* CardList.swift */; };
 		89627B182441168900BEB424 /* ConfigurationPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89627B172441168900BEB424 /* ConfigurationPage.swift */; };
+		89653C802473527100E1BAA5 /* FractionalQuantityPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89653C7F2473527100E1BAA5 /* FractionalQuantityPicker.swift */; };
+		89653C822473592600E1BAA5 /* CarbRatioScheduleEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89653C812473592600E1BAA5 /* CarbRatioScheduleEditor.swift */; };
 		8974AFC022120D7A0043F01B /* TemporaryScheduleOverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8974AFBF22120D7A0043F01B /* TemporaryScheduleOverrideTests.swift */; };
 		8974B0682215FE460043F01B /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8974B0672215FE460043F01B /* Collection.swift */; };
 		8974B0692215FE460043F01B /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8974B0672215FE460043F01B /* Collection.swift */; };
@@ -1208,6 +1210,8 @@
 		895FE08F22011F4800FCF18A /* EmojiInputController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmojiInputController.swift; sourceTree = "<group>"; };
 		89627B15244115A400BEB424 /* CardList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardList.swift; sourceTree = "<group>"; };
 		89627B172441168900BEB424 /* ConfigurationPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationPage.swift; sourceTree = "<group>"; };
+		89653C7F2473527100E1BAA5 /* FractionalQuantityPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FractionalQuantityPicker.swift; sourceTree = "<group>"; };
+		89653C812473592600E1BAA5 /* CarbRatioScheduleEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarbRatioScheduleEditor.swift; sourceTree = "<group>"; };
 		8974AFBF22120D7A0043F01B /* TemporaryScheduleOverrideTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TemporaryScheduleOverrideTests.swift; sourceTree = "<group>"; };
 		8974B0672215FE460043F01B /* Collection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Collection.swift; sourceTree = "<group>"; };
 		898B4E74246CCAB50053C484 /* Binding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };
@@ -1662,6 +1666,8 @@
 				89BE75CA2464BC2000B145D9 /* AlertContent.swift */,
 				89904031245B5CA500F1C0A2 /* Deletable.swift */,
 				899012C0246F1D8F007B88BA /* ExpandableSetting.swift */,
+				89653C7F2473527100E1BAA5 /* FractionalQuantityPicker.swift */,
+				89653C812473592600E1BAA5 /* CarbRatioScheduleEditor.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -2791,6 +2797,7 @@
 				43F5034D210599CC009FA89A /* AuthenticationViewController.swift in Sources */,
 				B4C004D32416961300B40429 /* ActionButton.swift in Sources */,
 				895FE08922011F0C00FCF18A /* OverrideSelectionHeaderView.swift in Sources */,
+				89653C802473527100E1BAA5 /* FractionalQuantityPicker.swift in Sources */,
 				898E6E67224179310019E459 /* BaseHUDView.swift in Sources */,
 				43F5034F210599DF009FA89A /* ValidatingIndicatorView.swift in Sources */,
 				C1E4B308242E995200E70CCB /* ActivityIndicator.swift in Sources */,
@@ -2816,6 +2823,7 @@
 				89AF78C22447E353002B4FCC /* Splat.swift in Sources */,
 				893C9F8C2447DBD900CD4185 /* CardBuilder.swift in Sources */,
 				89BE75C524649C8100B145D9 /* NewScheduleItemEditor.swift in Sources */,
+				89653C822473592600E1BAA5 /* CarbRatioScheduleEditor.swift in Sources */,
 				4369F08F208859E6000E3E45 /* PaddedTextField.swift in Sources */,
 				A9498D8823386CAF00DAA9B9 /* ServiceViewController.swift in Sources */,
 				892A5D9E2231E122008961AB /* StateColorPalette.swift in Sources */,

--- a/LoopKit/QuantityFormatter.swift
+++ b/LoopKit/QuantityFormatter.swift
@@ -46,7 +46,7 @@ open class QuantityFormatter {
     open func setPreferredNumberFormatter(for unit: HKUnit) {
         numberFormatter.numberStyle = .decimal
         numberFormatter.minimumFractionDigits = unit.preferredFractionDigits
-        numberFormatter.maximumFractionDigits = unit.preferredFractionDigits
+        numberFormatter.maximumFractionDigits = unit.maxFractionDigits
     }
 
     private var hasNumberFormatter = false
@@ -143,6 +143,14 @@ public extension HKUnit {
             return 1
         } else {
             return 0
+        }
+    }
+
+    var maxFractionDigits: Int {
+        if self == HKUnit.gram().unitDivided(by: .internationalUnit()) {
+            return 2
+        } else {
+            return preferredFractionDigits
         }
     }
 

--- a/LoopKitUI/Extensions/Binding.swift
+++ b/LoopKitUI/Extensions/Binding.swift
@@ -18,3 +18,12 @@ extension Binding where Value == Double {
         )
     }
 }
+
+extension Binding where Value == HKQuantity {
+    func doubleValue(for unit: HKUnit) -> Binding<Double> {
+        Binding<Double>(
+            get: { self.wrappedValue.doubleValue(for: unit) },
+            set: { self.wrappedValue = HKQuantity(unit: unit, doubleValue: $0) }
+        )
+    }
+}

--- a/LoopKitUI/Views/CarbRatioScheduleEditor.swift
+++ b/LoopKitUI/Views/CarbRatioScheduleEditor.swift
@@ -1,0 +1,100 @@
+//
+//  CarbRatioScheduleEditor.swift
+//  LoopKitUI
+//
+//  Created by Michael Pangburn on 4/20/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+import HealthKit
+import LoopKit
+
+
+fileprivate extension HKUnit {
+    static let storedCarbRatioScheduleUnit = HKUnit.gram()
+    static let realCarbRatioScheduleUnit = HKUnit.gram().unitDivided(by: .internationalUnit())
+}
+
+extension Guardrail where Value == HKQuantity {
+    static let carbRatio = Guardrail(
+        absoluteBounds: 1...150,
+        recommendedBounds: 4...27,
+        unit: .realCarbRatioScheduleUnit
+    )
+}
+
+public struct CarbRatioScheduleEditor: View {
+    private var schedule: DailyQuantitySchedule<Double>?
+    private var save: (CarbRatioSchedule) -> Void
+
+    public init(
+        schedule: CarbRatioSchedule?,
+        onSave save: @escaping (CarbRatioSchedule) -> Void
+    ) {
+        // CarbRatioSchedule stores only the gram unit.
+        // For consistency across display & computation, convert to "real" g/U units.
+        self.schedule = schedule.map { schedule in
+            DailyQuantitySchedule(
+                unit: .realCarbRatioScheduleUnit,
+                dailyItems: schedule.items
+            )!
+        }
+        self.save = save
+    }
+
+    public var body: some View {
+        QuantityScheduleEditor(
+            title: Text("Carb Ratios", comment: "Title of carb ratio settings page"),
+            description: description,
+            schedule: schedule,
+            unit: .realCarbRatioScheduleUnit,
+            guardrail: .carbRatio,
+            selectableValueStride: HKQuantity(unit: .realCarbRatioScheduleUnit, doubleValue: 1), // TODO
+            quantitySelectionMode: .fractional,
+            defaultFirstScheduleItemValue: Guardrail.carbRatio.absoluteBounds.upperBound,
+            confirmationAlertContent: confirmationAlertContent,
+            guardrailWarning: CarbRatioGuardrailWarning.init(crossedThresholds:),
+            onSave: {
+                // Convert back to the expected gram-unit-only schedule.
+                self.save(DailyQuantitySchedule(unit: .storedCarbRatioScheduleUnit, dailyItems: $0.items)!)
+            }
+        )
+    }
+
+    private var description: Text {
+        Text("Your carb ratio is the number of grams of carbohydrate covered by one unit of insulin.", comment: "Carb ratio setting description")
+    }
+
+    private var confirmationAlertContent: AlertContent {
+        AlertContent(
+            title: Text("Save Carb Ratios?", comment: "Alert title for confirming carb ratios outside the recommended range"),
+            message: Text("One or more of the values you have entered are outside of what Tidepool generally recommends.", comment: "Alert message for confirming carb ratios outside the recommended range")
+        )
+    }
+}
+
+private struct CarbRatioGuardrailWarning: View {
+    var crossedThresholds: [SafetyClassification.Threshold]
+
+    var body: some View {
+        assert(!crossedThresholds.isEmpty)
+        return GuardrailWarning(
+            title: crossedThresholds.count == 1 ? singularWarningTitle(for: crossedThresholds.first!) : multipleWarningTitle,
+            thresholds: crossedThresholds
+        )
+    }
+
+    private func singularWarningTitle(for threshold: SafetyClassification.Threshold) -> Text {
+        switch threshold {
+        case .minimum, .belowRecommended:
+            return Text("Low Carb Ratio", comment: "Title text for the low carb ratio warning")
+        case .aboveRecommended, .maximum:
+            return Text("High Carb Ratio", comment: "Title text for the high carb ratio warning")
+        }
+    }
+
+    private var multipleWarningTitle: Text {
+        Text("Carb Ratios", comment: "Title text for multi-value carb ratio warning")
+    }
+}

--- a/LoopKitUI/Views/CarbRatioScheduleEditor.swift
+++ b/LoopKitUI/Views/CarbRatioScheduleEditor.swift
@@ -50,7 +50,7 @@ public struct CarbRatioScheduleEditor: View {
             schedule: schedule,
             unit: .realCarbRatioScheduleUnit,
             guardrail: .carbRatio,
-            selectableValueStride: HKQuantity(unit: .realCarbRatioScheduleUnit, doubleValue: 1), // TODO
+            selectableValueStride: HKQuantity(unit: .realCarbRatioScheduleUnit, doubleValue: 0.01),
             quantitySelectionMode: .fractional,
             defaultFirstScheduleItemValue: Guardrail.carbRatio.absoluteBounds.upperBound,
             confirmationAlertContent: confirmationAlertContent,

--- a/LoopKitUI/Views/CarbRatioScheduleEditor.swift
+++ b/LoopKitUI/Views/CarbRatioScheduleEditor.swift
@@ -19,7 +19,7 @@ fileprivate extension HKUnit {
 extension Guardrail where Value == HKQuantity {
     static let carbRatio = Guardrail(
         absoluteBounds: 1...150,
-        recommendedBounds: 4...27,
+        recommendedBounds: 3.0.nextUp...28.0.nextDown,
         unit: .realCarbRatioScheduleUnit
     )
 }

--- a/LoopKitUI/Views/ExpandableSetting.swift
+++ b/LoopKitUI/Views/ExpandableSetting.swift
@@ -12,23 +12,23 @@ import SwiftUI
 public struct ExpandableSetting<
     LeadingValueContent: View,
     TrailingValueContent: View,
-    ValuePicker: View
+    ExpandedContent: View
 >: View {
     @Binding var isEditing: Bool
     var leadingValueContent: LeadingValueContent
     var trailingValueContent: TrailingValueContent
-    var valuePicker: ValuePicker
+    var expandedContent: ExpandedContent
 
     public init(
         isEditing: Binding<Bool>,
         @ViewBuilder leadingValueContent: () -> LeadingValueContent,
         @ViewBuilder trailingValueContent: () -> TrailingValueContent,
-        @ViewBuilder valuePicker: () -> ValuePicker
+        @ViewBuilder expandedContent: () -> ExpandedContent
     ) {
         self._isEditing = isEditing
         self.leadingValueContent = leadingValueContent()
         self.trailingValueContent = trailingValueContent()
-        self.valuePicker = valuePicker()
+        self.expandedContent = expandedContent()
     }
 
     public var body: some View {
@@ -46,7 +46,7 @@ public struct ExpandableSetting<
             }
 
             if isEditing {
-                valuePicker
+                expandedContent
                     .padding(.horizontal, -8)
                     .transition(.fadeInFromTop)
             }
@@ -59,8 +59,8 @@ extension ExpandableSetting where LeadingValueContent == EmptyView {
     public init(
         isEditing: Binding<Bool>,
         @ViewBuilder valueContent: () -> TrailingValueContent,
-        @ViewBuilder valuePicker: () -> ValuePicker
+        @ViewBuilder expandedContent: () -> ExpandedContent
     ) {
-        self.init(isEditing: isEditing, leadingValueContent: EmptyView.init, trailingValueContent: valueContent, valuePicker: valuePicker)
+        self.init(isEditing: isEditing, leadingValueContent: EmptyView.init, trailingValueContent: valueContent, expandedContent: expandedContent)
     }
 }

--- a/LoopKitUI/Views/FractionalQuantityPicker.swift
+++ b/LoopKitUI/Views/FractionalQuantityPicker.swift
@@ -1,0 +1,160 @@
+//
+//  FractionalQuantityPicker.swift
+//  LoopKitUI
+//
+//  Created by Michael Pangburn on 5/18/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+import HealthKit
+import LoopKit
+
+
+fileprivate extension FloatingPoint {
+    var whole: Self { modf(self).0 }
+    var fraction: Self { modf(self).1 }
+
+    func roundedToHundredths() -> Self {
+        (self * 100).rounded() / 100
+    }
+}
+
+/// Enables selecting the whole and fractional (to hundredths precision) parts of an HKQuantity value in independent pickers.
+struct FractionalQuantityPicker: View {
+    enum UsageContext: Equatable {
+        /// This picker is one component of a larger multi-component picker (e.g. a schedule item picker).
+        case component(availableWidth: CGFloat)
+
+        /// This picker operates independently.
+        case independent
+    }
+
+    @Binding var whole: Double
+    @Binding var fraction: Double
+    var unit: HKUnit
+    var guardrail: Guardrail<HKQuantity>
+    var usageContext: UsageContext
+
+    private static let wholeFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.minimumIntegerDigits = 1
+        formatter.maximumFractionDigits = 0
+        return formatter
+    }()
+
+    private static let fractionalFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.decimalSeparator = ""
+        formatter.maximumIntegerDigits = 0
+        formatter.minimumFractionDigits = 2
+        return formatter
+    }()
+
+    init(value: Binding<HKQuantity>, unit: HKUnit, guardrail: Guardrail<HKQuantity>, usageContext: UsageContext = .independent) {
+        let doubleValue = value.doubleValue(for: unit)
+        self._whole = Binding(
+            get: { doubleValue.wrappedValue.whole },
+            set: { newValue in
+                if newValue == guardrail.absoluteBounds.upperBound.doubleValue(for: unit) {
+                    doubleValue.wrappedValue = newValue
+                } else {
+                    doubleValue.wrappedValue = newValue + doubleValue.wrappedValue.fraction
+                }
+            }
+        )
+        self._fraction = Binding<Double>(
+            get: { doubleValue.wrappedValue.fraction.roundedToHundredths() },
+            set: { doubleValue.wrappedValue = doubleValue.wrappedValue.whole + $0 }
+        )
+        self.unit = unit
+        self.guardrail = guardrail
+        self.usageContext = usageContext
+    }
+
+    var body: some View {
+        switch usageContext {
+        case .component(availableWidth: let availableWidth):
+            return AnyView(body(availableWidth: availableWidth))
+        case .independent:
+            return AnyView(
+                GeometryReader { geometry in
+                    HStack {
+                        Spacer()
+                        self.body(availableWidth: geometry.size.width)
+                        Spacer()
+                    }
+                }
+                .frame(height: 216)
+            )
+        }
+    }
+
+    func body(availableWidth: CGFloat) -> some View {
+        HStack(spacing: 0) {
+            QuantityPicker(
+                value: $whole.withUnit(unit),
+                unit: unit,
+                stride: HKQuantity(unit: unit, doubleValue: 1),
+                guardrail: guardrail,
+                formatter: Self.wholeFormatter,
+                isUnitLabelVisible: false
+            )
+            .frame(width: availableWidth / 3.5)
+            .overlay(
+                Text(separator)
+                    .foregroundColor(Color(.secondaryLabel))
+                    .offset(x: spacing + separatorWidth),
+                alignment: .trailing
+            )
+            .padding(.leading, usageContext == .independent ? unitLabelWidth + spacing : 0)
+            .padding(.trailing, spacing + separatorWidth + spacing)
+            .clipped()
+
+            QuantityPicker(
+                value: $fraction.withUnit(unit),
+                unit: unit,
+                guardrail: fractionalGuardrail,
+                selectableValues: selectableFractionValues,
+                formatter: Self.fractionalFormatter
+            )
+            // Ensure fractional picker values update when whole value updates
+            .id(whole + fraction)
+            .frame(width: availableWidth / 3.5)
+            .padding(.trailing, spacing + unitLabelWidth)
+            .clipped()
+        }
+    }
+
+    var fractionalGuardrail: Guardrail<HKQuantity> {
+        Guardrail(absoluteBounds: 0...0.99, recommendedBounds: 0...0.99, unit: unit)
+    }
+
+    var selectableFractionValues: [Double] {
+        whole == guardrail.absoluteBounds.upperBound.doubleValue(for: unit)
+            ? [0]
+            : fractionalGuardrail.allValues(stridingBy: HKQuantity(unit: unit, doubleValue: 0.01), unit: unit)
+    }
+
+    var separator: String { "." }
+
+    var separatorWidth: CGFloat {
+        let attributedSeparator = NSAttributedString(
+            string: separator,
+            attributes: [.font: UIFont.preferredFont(forTextStyle: .body)]
+        )
+
+        return attributedSeparator.size().width
+    }
+
+    var spacing: CGFloat { 8 }
+
+    var unitLabelWidth: CGFloat {
+        let attributedUnitString = NSAttributedString(
+            string: unit.shortLocalizedUnitString(),
+            attributes: [.font: UIFont.preferredFont(forTextStyle: .body)]
+        )
+
+        return attributedUnitString.size().width
+    }
+}

--- a/LoopKitUI/Views/QuantityPicker.swift
+++ b/LoopKitUI/Views/QuantityPicker.swift
@@ -33,10 +33,11 @@ public struct QuantityPicker: View {
         unit: HKUnit,
         stride: HKQuantity,
         guardrail: Guardrail<HKQuantity>,
+        formatter: NumberFormatter? = nil,
         isUnitLabelVisible: Bool = true
     ) {
         let selectableValues = guardrail.allValues(stridingBy: stride, unit: unit)
-        self.init(value: value, unit: unit, guardrail: guardrail, selectableValues: selectableValues, isUnitLabelVisible: isUnitLabelVisible)
+        self.init(value: value, unit: unit, guardrail: guardrail, selectableValues: selectableValues, formatter: formatter, isUnitLabelVisible: isUnitLabelVisible)
     }
 
     public init(
@@ -44,13 +45,14 @@ public struct QuantityPicker: View {
         unit: HKUnit,
         guardrail: Guardrail<HKQuantity>,
         selectableValues: [Double],
+        formatter: NumberFormatter? = nil,
         isUnitLabelVisible: Bool = true
     ) {
         self._value = value
         self.unit = unit
         self.guardrail = guardrail
         self.selectableValues = selectableValues
-        self.formatter = {
+        self.formatter = formatter ?? {
             let quantityFormatter = QuantityFormatter()
             quantityFormatter.setPreferredNumberFormatter(for: unit)
             return quantityFormatter.numberFormatter
@@ -58,15 +60,8 @@ public struct QuantityPicker: View {
         self.isUnitLabelVisible = isUnitLabelVisible
     }
 
-    private var selection: Binding<Double> {
-        Binding(
-            get: { self.value.doubleValue(for: self.unit) },
-            set: { self.value = HKQuantity(unit: self.unit, doubleValue: $0) }
-        )
-    }
-
     public var body: some View {
-        Picker("Quantity", selection: selection) {
+        Picker("Quantity", selection: $value.doubleValue(for: unit)) {
             ForEach(selectableValues, id: \.self) { value in
                 Text(self.formatter.string(from: value) ?? "\(value)")
                     .foregroundColor(self.pickerTextColor(for: value))

--- a/LoopKitUI/Views/QuantityPicker.swift
+++ b/LoopKitUI/Views/QuantityPicker.swift
@@ -22,7 +22,7 @@ private struct PickerValueBoundsKey: PreferenceKey {
 public struct QuantityPicker: View {
     @Binding var value: HKQuantity
     var unit: HKUnit
-    var guardrail: Guardrail<HKQuantity>
+    var guardrail: Guardrail<HKQuantity>?
     var isUnitLabelVisible: Bool
 
     private let selectableValues: [Double]
@@ -43,7 +43,7 @@ public struct QuantityPicker: View {
     public init(
         value: Binding<HKQuantity>,
         unit: HKUnit,
-        guardrail: Guardrail<HKQuantity>,
+        guardrail: Guardrail<HKQuantity>? = nil,
         selectableValues: [Double],
         formatter: NumberFormatter? = nil,
         isUnitLabelVisible: Bool = true
@@ -75,6 +75,10 @@ public struct QuantityPicker: View {
     }
 
     private func pickerTextColor(for value: Double) -> Color {
+        guard let guardrail = guardrail else {
+            return .primary
+        }
+
         let quantity = HKQuantity(unit: unit, doubleValue: value)
         switch guardrail.classification(for: quantity) {
         case .withinRecommendedRange:

--- a/LoopKitUI/Views/QuantityScheduleEditor.swift
+++ b/LoopKitUI/Views/QuantityScheduleEditor.swift
@@ -122,6 +122,7 @@ struct QuantityScheduleEditor<ActionAreaContent: View>: View {
                         value: item.value.animation().withUnit(self.unit),
                         unit: self.unit,
                         guardrail: self.guardrail,
+                        selectableValues: self.selectableValues,
                         usageContext: .component(availableWidth: availableWidth)
                     )
                 }

--- a/LoopKitUI/Views/QuantityScheduleEditor.swift
+++ b/LoopKitUI/Views/QuantityScheduleEditor.swift
@@ -11,12 +11,20 @@ import HealthKit
 import LoopKit
 
 struct QuantityScheduleEditor<ActionAreaContent: View>: View {
+    enum QuantitySelectionMode {
+        /// A single picker for selecting quantity values.
+        case whole
+        // A two-component picker for selecting the whole and fractional quantity values independently.
+        case fractional
+    }
+
     var title: Text
     var description: Text
     var initialScheduleItems: [RepeatingScheduleValue<Double>]
     @State var scheduleItems: [RepeatingScheduleValue<Double>]
     var unit: HKUnit
     var selectableValues: [Double]
+    var quantitySelectionMode: QuantitySelectionMode
     var guardrail: Guardrail<HKQuantity>
     var defaultFirstScheduleItemValue: HKQuantity
     var confirmationAlertContent: AlertContent
@@ -33,6 +41,7 @@ struct QuantityScheduleEditor<ActionAreaContent: View>: View {
         unit: HKUnit,
         selectableValues: [Double],
         guardrail: Guardrail<HKQuantity>,
+        quantitySelectionMode: QuantitySelectionMode = .whole,
         defaultFirstScheduleItemValue: HKQuantity,
         confirmationAlertContent: AlertContent,
         @ViewBuilder guardrailWarning: @escaping (_ thresholds: [SafetyClassification.Threshold]) -> ActionAreaContent,
@@ -43,6 +52,7 @@ struct QuantityScheduleEditor<ActionAreaContent: View>: View {
         self.initialScheduleItems = schedule?.items ?? []
         self._scheduleItems = State(initialValue: schedule?.items ?? [])
         self.unit = unit
+        self.quantitySelectionMode = quantitySelectionMode
         self.selectableValues = selectableValues
         self.guardrail = guardrail
         self.defaultFirstScheduleItemValue = defaultFirstScheduleItemValue
@@ -58,6 +68,7 @@ struct QuantityScheduleEditor<ActionAreaContent: View>: View {
         unit: HKUnit,
         guardrail: Guardrail<HKQuantity>,
         selectableValueStride: HKQuantity,
+        quantitySelectionMode: QuantitySelectionMode = .whole,
         defaultFirstScheduleItemValue: HKQuantity,
         confirmationAlertContent: AlertContent,
         @ViewBuilder guardrailWarning: @escaping (_ thresholds: [SafetyClassification.Threshold]) -> ActionAreaContent,
@@ -71,6 +82,7 @@ struct QuantityScheduleEditor<ActionAreaContent: View>: View {
             unit: unit,
             selectableValues: selectableValues,
             guardrail: guardrail,
+            quantitySelectionMode: quantitySelectionMode,
             defaultFirstScheduleItemValue: defaultFirstScheduleItemValue,
             confirmationAlertContent: confirmationAlertContent,
             guardrailWarning: guardrailWarning,
@@ -94,16 +106,25 @@ struct QuantityScheduleEditor<ActionAreaContent: View>: View {
                 )
             },
             valuePicker: { item, availableWidth in
-                QuantityPicker(
-                    value: item.value.animation().withUnit(self.unit),
-                    unit: self.unit,
-                    guardrail: self.guardrail,
-                    selectableValues: self.selectableValues
-                )
-                .frame(width: availableWidth / 2)
-                // Ensure overlaid unit label is not clipped
-                .padding(.trailing, self.unitLabelWidth + self.unitLabelSpacing)
-                .clipped()
+                if self.quantitySelectionMode == .whole {
+                    QuantityPicker(
+                        value: item.value.animation().withUnit(self.unit),
+                        unit: self.unit,
+                        guardrail: self.guardrail,
+                        selectableValues: self.selectableValues
+                    )
+                    .frame(width: availableWidth / 2)
+                    // Ensure overlaid unit label is not clipped
+                    .padding(.trailing, self.unitLabelWidth + self.unitLabelSpacing)
+                    .clipped()
+                } else {
+                    FractionalQuantityPicker(
+                        value: item.value.animation().withUnit(self.unit),
+                        unit: self.unit,
+                        guardrail: self.guardrail,
+                        usageContext: .component(availableWidth: availableWidth)
+                    )
+                }
             },
             actionAreaContent: {
                 guardrailWarningIfNecessary

--- a/LoopKitUI/Views/ScheduleItemView.swift
+++ b/LoopKitUI/Views/ScheduleItemView.swift
@@ -34,7 +34,7 @@ struct ScheduleItemView<ValueContent: View, ExpandedContent: View>: View {
             isEditing: $isEditing,
             leadingValueContent: { timeText },
             trailingValueContent: { valueContent },
-            valuePicker: { expandedContent }
+            expandedContent: { expandedContent }
         )
     }
 


### PR DESCRIPTION
`FractionalQuantityPicker` is a two-component picker that allows selecting the whole and fraction parts of a `HKQuantity`value independently. Its fractional picker formats in a way that supports variable precision across the span of selectable values.

In DIY Loop, for example, the supported precision of Minimed basal rates decreases as the rate increases.
- 0.025 increments from 0 to 1 U/h
- 0.05 increments from 1 to 10 U/h
- 0.1 increments >10 U/h

The values displayed by the fractional picker in each case are as follows:
- Whole value 0 or 1: 0.025, 0.050, 0.075, 0.100, 0.125, ... (all to 3 places)
- Whole value 1 to 10: 1.05, 1.10, 1.15, ... (all to 2 places)
- Whole value >10: 10.1, 10.2, 10.3, ... (all to 1 place)

`QuantityScheduleEditor` is updated to provide an option to allow the quantity to be selected fractionally. This option is used by `CardRatioScheduleEditor`—implemented here—and will be used by `BasalRateScheduleEditor` in the future.