### PR TITLE
Various guardrails fixes

### DIFF
--- a/LoopKitUI/Views/CorrectionRangeScheduleEditor.swift
+++ b/LoopKitUI/Views/CorrectionRangeScheduleEditor.swift
@@ -12,7 +12,7 @@ import LoopKit
 
 
 extension Guardrail where Value == HKQuantity {
-    public static let correctionRange = Guardrail(absoluteBounds: 60...180, recommendedBounds: 100...120, unit: .milligramsPerDeciliter)
+    public static let correctionRange = Guardrail(absoluteBounds: 60...180, recommendedBounds: 70...120, unit: .milligramsPerDeciliter)
 }
 
 

--- a/LoopKitUI/Views/ExpandableSetting.swift
+++ b/LoopKitUI/Views/ExpandableSetting.swift
@@ -17,26 +17,29 @@ public struct ExpandableSetting<
     @Binding var isEditing: Bool
     var leadingValueContent: LeadingValueContent
     var trailingValueContent: TrailingValueContent
-    var expandedContent: ExpandedContent
+    var expandedContent: () -> ExpandedContent
 
     public init(
         isEditing: Binding<Bool>,
         @ViewBuilder leadingValueContent: () -> LeadingValueContent,
         @ViewBuilder trailingValueContent: () -> TrailingValueContent,
-        @ViewBuilder expandedContent: () -> ExpandedContent
+        @ViewBuilder expandedContent: @escaping () -> ExpandedContent
     ) {
         self._isEditing = isEditing
         self.leadingValueContent = leadingValueContent()
         self.trailingValueContent = trailingValueContent()
-        self.expandedContent = expandedContent()
+        self.expandedContent = expandedContent
     }
 
     public var body: some View {
         VStack(spacing: 0) {
             HStack {
                 leadingValueContent
+
                 Spacer()
+
                 trailingValueContent
+                    .fixedSize(horizontal: true, vertical: false)
             }
             .contentShape(Rectangle())
             .onTapGesture {
@@ -46,7 +49,7 @@ public struct ExpandableSetting<
             }
 
             if isEditing {
-                expandedContent
+                expandedContent()
                     .padding(.horizontal, -8)
                     .transition(.fadeInFromTop)
             }
@@ -59,7 +62,7 @@ extension ExpandableSetting where LeadingValueContent == EmptyView {
     public init(
         isEditing: Binding<Bool>,
         @ViewBuilder valueContent: () -> TrailingValueContent,
-        @ViewBuilder expandedContent: () -> ExpandedContent
+        @ViewBuilder expandedContent: @escaping () -> ExpandedContent
     ) {
         self.init(isEditing: isEditing, leadingValueContent: EmptyView.init, trailingValueContent: valueContent, expandedContent: expandedContent)
     }

--- a/LoopKitUI/Views/GlucoseRangePicker.swift
+++ b/LoopKitUI/Views/GlucoseRangePicker.swift
@@ -61,7 +61,7 @@ public struct GlucoseRangePicker: View {
         case .independent:
             return AnyView(
                 GeometryReader { geometry in
-                    HStack {
+                    HStack(spacing: 0) {
                         Spacer()
                         self.body(availableWidth: geometry.size.width)
                         Spacer()
@@ -90,7 +90,7 @@ public struct GlucoseRangePicker: View {
                     .offset(x: spacing + separatorWidth),
                 alignment: .trailing
             )
-            .padding(.leading, usageContext == .independent ? unitLabelWidth + spacing : 0)
+            .padding(.leading, usageContext == .independent ? unitLabelWidth : 0)
             .padding(.trailing, spacing + separatorWidth + spacing)
             .clipped()
             .accessibility(identifier: "min_glucose_picker")
@@ -104,7 +104,7 @@ public struct GlucoseRangePicker: View {
             // Ensure the selectable picker values update when either bound changes
             .id(lowerBound...upperBound)
             .frame(width: availableWidth / 3.5)
-            .padding(.trailing, spacing + unitLabelWidth)
+            .padding(.trailing, unitLabelWidth)
             .clipped()
             .accessibility(identifier: "max_glucose_picker")
         }

--- a/LoopKitUI/Views/GuardrailConstraintedQuantityView.swift
+++ b/LoopKitUI/Views/GuardrailConstraintedQuantityView.swift
@@ -57,6 +57,7 @@ public struct GuardrailConstrainedQuantityView: View {
 
                 Text(formatter.string(from: value.doubleValue(for: unit)) ?? "\(value.doubleValue(for: unit))")
                     .foregroundColor(warningColor)
+                    .fixedSize(horizontal: true, vertical: false)
             }
 
             if isUnitLabelVisible {

--- a/LoopKitUI/Views/QuantityPicker.swift
+++ b/LoopKitUI/Views/QuantityPicker.swift
@@ -66,6 +66,7 @@ public struct QuantityPicker: View {
                 Text(self.formatter.string(from: value) ?? "\(value)")
                     .foregroundColor(self.pickerTextColor(for: value))
                     .anchorPreference(key: PickerValueBoundsKey.self, value: .bounds, transform: { [$0] })
+                    .accessibility(identifier: self.formatter.string(from: value) ?? "\(value)")
             }
         }
         .labelsHidden()

--- a/LoopKitUI/Views/ScheduleEditor.swift
+++ b/LoopKitUI/Views/ScheduleEditor.swift
@@ -276,7 +276,7 @@ struct ScheduleEditor<Value: Equatable, ValueContent: View, ValuePicker: View, A
                     .contentShape(Rectangle())
             }
         )
-        .disabled(tableDeletionState != .disabled || scheduleItems.count > scheduleItemLimit)
+        .disabled(tableDeletionState != .disabled || scheduleItems.count >= scheduleItemLimit)
     }
 }
 

--- a/LoopKitUI/Views/ScheduleItemView.swift
+++ b/LoopKitUI/Views/ScheduleItemView.swift
@@ -34,7 +34,7 @@ struct ScheduleItemView<ValueContent: View, ExpandedContent: View>: View {
             isEditing: $isEditing,
             leadingValueContent: { timeText },
             trailingValueContent: { valueContent },
-            expandedContent: { expandedContent }
+            expandedContent: { self.expandedContent }
         )
     }
 


### PR DESCRIPTION
- Improve SwiftUI layout performance when many schedule items are present
- Fix correction range guardrail recommended lower bound to match spec
- Add accessibility identifier for each selectable `QuantityPicker` value per conversation with @jh-bate 
- Fix off-by-one error with schedule item limit (`>` instead of `>=`)