### PR TITLE
Rename DeviceAlert -> Alert

### DIFF
--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -9,11 +9,11 @@
 /* Begin PBXBuildFile section */
 		1D25C22E246A2A1A00E87FA0 /* critical.caf in Resources */ = {isa = PBXBuildFile; fileRef = 1D25C22D246A2A1A00E87FA0 /* critical.caf */; };
 		1D640FF724525228008F9755 /* sub.caf in Resources */ = {isa = PBXBuildFile; fileRef = 1D640FF524524284008F9755 /* sub.caf */; };
-		1D841AAD24577EE10069DBFF /* DeviceAlertSoundPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D841AAC24577EE10069DBFF /* DeviceAlertSoundPlayer.swift */; };
-		1DA649AB2445174400F61E75 /* DeviceAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649AA2445174400F61E75 /* DeviceAlert.swift */; };
+		1D841AAD24577EE10069DBFF /* AlertSoundPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D841AAC24577EE10069DBFF /* AlertSoundPlayer.swift */; };
+		1DA649AB2445174400F61E75 /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649AA2445174400F61E75 /* Alert.swift */; };
 		1DABAD3A2453615200ACF708 /* IssueAlertTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DABAD392453615200ACF708 /* IssueAlertTableViewController.swift */; };
-		1DD3DEB624451C3300BD8E40 /* DeviceAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649AA2445174400F61E75 /* DeviceAlert.swift */; };
-		1DFB99D6245CB2E900DCC8C9 /* DeviceAlertTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFB99D5245CB2E900DCC8C9 /* DeviceAlertTests.swift */; };
+		1DD3DEB624451C3300BD8E40 /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649AA2445174400F61E75 /* Alert.swift */; };
+		1DFB99D6245CB2E900DCC8C9 /* AlertTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFB99D5245CB2E900DCC8C9 /* AlertTests.swift */; };
 		1F5DAB1D2118C95700048054 /* LocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5DAB1C2118C95700048054 /* LocalizedString.swift */; };
 		1F5DAB1F2118C95700048054 /* LocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5DAB1C2118C95700048054 /* LocalizedString.swift */; };
 		1F5DAB202118C95700048054 /* LocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5DAB1C2118C95700048054 /* LocalizedString.swift */; };
@@ -780,10 +780,10 @@
 /* Begin PBXFileReference section */
 		1D25C22D246A2A1A00E87FA0 /* critical.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = critical.caf; sourceTree = "<group>"; };
 		1D640FF524524284008F9755 /* sub.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = sub.caf; sourceTree = "<group>"; };
-		1D841AAC24577EE10069DBFF /* DeviceAlertSoundPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceAlertSoundPlayer.swift; sourceTree = "<group>"; };
-		1DA649AA2445174400F61E75 /* DeviceAlert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceAlert.swift; sourceTree = "<group>"; };
+		1D841AAC24577EE10069DBFF /* AlertSoundPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertSoundPlayer.swift; sourceTree = "<group>"; };
+		1DA649AA2445174400F61E75 /* Alert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Alert.swift; sourceTree = "<group>"; };
 		1DABAD392453615200ACF708 /* IssueAlertTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueAlertTableViewController.swift; sourceTree = "<group>"; };
-		1DFB99D5245CB2E900DCC8C9 /* DeviceAlertTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceAlertTests.swift; sourceTree = "<group>"; };
+		1DFB99D5245CB2E900DCC8C9 /* AlertTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertTests.swift; sourceTree = "<group>"; };
 		1F50C31F212B20D300C18FAB /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		1F50C320212B20D300C18FAB /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Main.strings; sourceTree = "<group>"; };
 		1F50C321212B20D300C18FAB /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/CarbKit.strings; sourceTree = "<group>"; };
@@ -1837,7 +1837,7 @@
 				43D8FDE71C7290350073BE78 /* DailyQuantitySchedule.swift */,
 				891A3FD4224B047200378B27 /* DailyQuantitySchedule+Override.swift */,
 				43D8FDE81C7290350073BE78 /* DailyValueSchedule.swift */,
-				1DA649AA2445174400F61E75 /* DeviceAlert.swift */,
+				1DA649AA2445174400F61E75 /* Alert.swift */,
 				A9498D7723386C3300DAA9B9 /* DiagnosticLog.swift */,
 				A95A1D7E2460BBC70079378D /* DosingDecisionObject+CoreDataClass.swift */,
 				A95A1D812460BBDC0079378D /* DosingDecisionObject+CoreDataProperties.swift */,
@@ -1901,7 +1901,7 @@
 				A95A1D842460CAD50079378D /* CarbValueTests.swift */,
 				A9BFA03D245CCCB9001E4AE3 /* DailyQuantityScheduleTests.swift */,
 				891A3FD6224BE62100378B27 /* DailyValueScheduleTests.swift */,
-				1DFB99D5245CB2E900DCC8C9 /* DeviceAlertTests.swift */,
+				1DFB99D5245CB2E900DCC8C9 /* AlertTests.swift */,
 				A99C7374233993FE00C80963 /* DiagnosticLogTests.swift */,
 				A95A1D8C246101760079378D /* DoseEntryTests.swift */,
 				43A067121F245A2F00E9E90F /* DoseStoreTests.swift */,
@@ -2250,7 +2250,7 @@
 			children = (
 				C17F39BE23CD248000FA1113 /* DeviceLog */,
 				4352A73B20DECF0600CAC200 /* CGMManager.swift */,
-				1D841AAC24577EE10069DBFF /* DeviceAlertSoundPlayer.swift */,
+				1D841AAC24577EE10069DBFF /* AlertSoundPlayer.swift */,
 				4379CFE221102A4100AADC79 /* DeviceManager.swift */,
 				89AC792C224C781100B8E9BA /* DoseProgressReporter.swift */,
 				89AC792D224C781100B8E9BA /* DoseProgressTimerEstimator.swift */,
@@ -2992,7 +2992,7 @@
 				89AE222B228BC56A00BDFD85 /* WeakSet.swift in Sources */,
 				A9498D7C23386C3300DAA9B9 /* AnalyticsService.swift in Sources */,
 				4322B783202FA2AF0002837D /* Reservoir.swift in Sources */,
-				1DA649AB2445174400F61E75 /* DeviceAlert.swift in Sources */,
+				1DA649AB2445174400F61E75 /* Alert.swift in Sources */,
 				437AFEF02036A156008C4892 /* DeletedCarbObject+CoreDataProperties.swift in Sources */,
 				4322B777202FA2790002837D /* CarbValue.swift in Sources */,
 				4322B782202FA2AF0002837D /* PumpEventType.swift in Sources */,
@@ -3029,7 +3029,7 @@
 				C1F8403923DB84B700673141 /* DeviceLogEntry+CoreDataClass.swift in Sources */,
 				433BC7AD20538FCA000B1200 /* StoredGlucoseSample.swift in Sources */,
 				43D8FDF91C7290350073BE78 /* GlucoseEffect.swift in Sources */,
-				1D841AAD24577EE10069DBFF /* DeviceAlertSoundPlayer.swift in Sources */,
+				1D841AAD24577EE10069DBFF /* AlertSoundPlayer.swift in Sources */,
 				43CACE0E2247F89100F90AF5 /* WeakSynchronizedSet.swift in Sources */,
 				A912BE2B245B9E8600CBE199 /* SettingsObject+CoreDataProperties.swift in Sources */,
 				43D8FDFE1C7290350073BE78 /* LoopMath.swift in Sources */,
@@ -3102,7 +3102,7 @@
 				434113BE20F2C72000D05747 /* CachedCarbObjectTests.swift in Sources */,
 				43260F6E21C4BF7A00DD6837 /* UUID.swift in Sources */,
 				A971C8A223C6B17D0099BEFC /* SettingsStoreTests.swift in Sources */,
-				1DFB99D6245CB2E900DCC8C9 /* DeviceAlertTests.swift in Sources */,
+				1DFB99D6245CB2E900DCC8C9 /* AlertTests.swift in Sources */,
 				4303C4941E2D665F00ADEDC8 /* TimeZone.swift in Sources */,
 				4322B76D202F9EF20002837D /* GlucoseMathTests.swift in Sources */,
 				43025DAF1D5AB2E300106C28 /* NSTimeInterval.swift in Sources */,
@@ -3286,7 +3286,7 @@
 				A9E675C122713F4700E25293 /* NewGlucoseSample.swift in Sources */,
 				A9E675C222713F4700E25293 /* InsulinMath.swift in Sources */,
 				A9E675C322713F4700E25293 /* UnfairLock.swift in Sources */,
-				1DD3DEB624451C3300BD8E40 /* DeviceAlert.swift in Sources */,
+				1DD3DEB624451C3300BD8E40 /* Alert.swift in Sources */,
 				A9E675C422713F4700E25293 /* HealthStoreUnitCache.swift in Sources */,
 				A9D77A30242E8BDE0009F62C /* BolusRecommendation.swift in Sources */,
 				A9E675C622713F4700E25293 /* CarbStatus.swift in Sources */,

--- a/LoopKit/Alert.swift
+++ b/LoopKit/Alert.swift
@@ -1,5 +1,5 @@
 //
-//  DeviceAlert.swift
+//  Alert.swift
 //  LoopKit
 //
 //  Created by Rick Pasetto on 4/8/20.
@@ -9,21 +9,21 @@
 import Foundation
 
 /// Protocol that describes any class that presents Alerts.
-public protocol DeviceAlertPresenter: class {
+public protocol AlertPresenter: class {
     /// Issue (post) the given alert, according to its trigger schedule.
-    func issueAlert(_ alert: DeviceAlert)
+    func issueAlert(_ alert: Alert)
     /// Retract any alerts with the given identifier.  This includes both pending and delivered alerts.
-    func retractAlert(identifier: DeviceAlert.Identifier)
+    func retractAlert(identifier: Alert.Identifier)
 }
 
 /// Protocol that describes something that can deal with a user's response to an alert.
-public protocol DeviceAlertResponder: class {
+public protocol AlertResponder: class {
     /// Acknowledge alerts with a given type identifier
-    func acknowledgeAlert(alertIdentifier: DeviceAlert.AlertIdentifier) -> Void
+    func acknowledgeAlert(alertIdentifier: Alert.AlertIdentifier) -> Void
 }
 
 /// Structure that represents an Alert that is issued from a Device.
-public struct DeviceAlert: Equatable {
+public struct Alert: Equatable {
     /// Representation of an alert Trigger
     public enum Trigger: Equatable {
         /// Trigger the alert immediately
@@ -95,7 +95,7 @@ public struct DeviceAlert: Equatable {
     }
 }
 
-public extension DeviceAlert.Sound {
+public extension Alert.Sound {
     var filename: String? {
         switch self {
         case .sound(let name): return name
@@ -104,25 +104,25 @@ public extension DeviceAlert.Sound {
     }
 }
 
-public protocol DeviceAlertSoundVendor {
+public protocol AlertSoundVendor {
     // Get the base URL for where to find all the vendor's sounds.  It is under here that all of the sound files should be.
     // Returns nil if the vendor has no sounds.
     func getSoundBaseURL() -> URL?
     // Get all the sounds for this vendor.  Returns an empty array if the vendor has no sounds.
-    func getSounds() -> [DeviceAlert.Sound]
+    func getSounds() -> [Alert.Sound]
 }
 
 // MARK: Codable implementations
 
-extension DeviceAlert: Codable {
+extension Alert: Codable {
     enum CodableError: Swift.Error { case encodeFailed, decodeFailed }
     public func encode() throws -> Data {
         let encoder = JSONEncoder()
         return try encoder.encode(self)
     }
-    public static func decode(from data: Data) throws -> DeviceAlert {
+    public static func decode(from data: Data) throws -> Alert {
         let decoder = JSONDecoder()
-        return try decoder.decode(DeviceAlert.self, from: data)
+        return try decoder.decode(Alert.self, from: data)
     }
     public func encodeToString() throws -> String {
         let data = try encode()
@@ -131,7 +131,7 @@ extension DeviceAlert: Codable {
         }
         return result
     }
-    public static func decode(from string: String) throws -> DeviceAlert {
+    public static func decode(from string: String) throws -> Alert {
         guard let data = string.data(using: .utf8) else {
             throw CodableError.decodeFailed
         }
@@ -139,11 +139,11 @@ extension DeviceAlert: Codable {
     }
 }
 
-extension DeviceAlert.Content: Codable { }
-extension DeviceAlert.Identifier: Codable { }
+extension Alert.Content: Codable { }
+extension Alert.Identifier: Codable { }
 // These Codable implementations of enums with associated values cannot be synthesized (yet) in Swift.
 // The code below follows a pattern described by https://medium.com/@hllmandel/codable-enum-with-associated-values-swift-4-e7d75d6f4370
-extension DeviceAlert.Trigger: Codable {
+extension Alert.Trigger: Codable {
     private enum CodingKeys: String, CodingKey {
       case immediate, delayed, repeating
     }
@@ -188,7 +188,7 @@ extension DeviceAlert.Trigger: Codable {
     }
 }
 
-extension DeviceAlert.Sound: Codable {
+extension Alert.Sound: Codable {
     private enum CodingKeys: String, CodingKey {
       case silence, vibrate, sound
     }

--- a/LoopKit/DeviceManager/AlertSoundPlayer.swift
+++ b/LoopKit/DeviceManager/AlertSoundPlayer.swift
@@ -1,5 +1,5 @@
 //
-//  DeviceAlertSoundPlayer.swift
+//  AlertSoundPlayer.swift
 //  Loop
 //
 //  Created by Rick Pasetto on 4/27/20.
@@ -14,12 +14,12 @@ import AudioToolbox
 import AVFoundation
 import os.log
 
-public protocol DeviceAlertSoundPlayer {
+public protocol AlertSoundPlayer {
     func vibrate()
     func play(url: URL)
 }
 
-public class DeviceAVSoundPlayer: DeviceAlertSoundPlayer {
+public class DeviceAVSoundPlayer: AlertSoundPlayer {
     private let log = OSLog(category: "DeviceAVSoundPlayer")
     private let baseURL: URL?
     private var delegate: Delegate!
@@ -70,7 +70,7 @@ public class DeviceAVSoundPlayer: DeviceAlertSoundPlayer {
 
 public extension DeviceAVSoundPlayer {
 
-    func playAlert(sound: DeviceAlert.Sound) {
+    func playAlert(sound: Alert.Sound) {
         switch sound {
         case .silence:
             // noop

--- a/LoopKit/DeviceManager/DeviceManager.swift
+++ b/LoopKit/DeviceManager/DeviceManager.swift
@@ -8,7 +8,7 @@
 import Foundation
 import UserNotifications
 
-public protocol DeviceManagerDelegate: DeviceAlertPresenter {
+public protocol DeviceManagerDelegate: AlertPresenter {
     // Begin obsolescent code
     // Note: once all plugins are updated to use the new alert system instead of Notifications, this can be removed.
     func scheduleNotification(for manager: DeviceManager,
@@ -24,7 +24,7 @@ public protocol DeviceManagerDelegate: DeviceAlertPresenter {
     func deviceManager(_ manager: DeviceManager, logEventForDeviceIdentifier deviceIdentifier: String?, type: DeviceLogEntryType, message: String, completion: ((Error?) -> Void)?)
 }
 
-public protocol DeviceManager: CustomDebugStringConvertible, DeviceAlertResponder, DeviceAlertSoundVendor {
+public protocol DeviceManager: CustomDebugStringConvertible, AlertResponder, AlertSoundVendor {
     typealias RawStateValue = [String: Any]
 
     /// The identifier of the manager. This should be unique

--- a/LoopKitTests/AlertTests.swift
+++ b/LoopKitTests/AlertTests.swift
@@ -1,5 +1,5 @@
 //
-//  DeviceAlertTests.swift
+//  AlertTests.swift
 //  LoopKitTests
 //
 //  Created by Rick Pasetto on 5/1/20.
@@ -9,96 +9,96 @@
 import XCTest
 @testable import LoopKit
 
-class DeviceAlertTests: XCTestCase {
-    let identifier = DeviceAlert.Identifier(managerIdentifier: "managerIdentifier1", alertIdentifier: "alertIdentifier1")
-    let foregroundContent = DeviceAlert.Content(title: "title1", body: "body1", acknowledgeActionButtonLabel: "acknowledgeActionButtonLabel1", isCritical: false)
-    let backgroundContent = DeviceAlert.Content(title: "title2", body: "body2", acknowledgeActionButtonLabel: "acknowledgeActionButtonLabel2", isCritical: false)
+class AlertTests: XCTestCase {
+    let identifier = Alert.Identifier(managerIdentifier: "managerIdentifier1", alertIdentifier: "alertIdentifier1")
+    let foregroundContent = Alert.Content(title: "title1", body: "body1", acknowledgeActionButtonLabel: "acknowledgeActionButtonLabel1", isCritical: false)
+    let backgroundContent = Alert.Content(title: "title2", body: "body2", acknowledgeActionButtonLabel: "acknowledgeActionButtonLabel2", isCritical: false)
 
     func testIdentifierValue() {
         XCTAssertEqual("managerIdentifier1.alertIdentifier1", identifier.value)
     }
     
-    func testDeviceAlertImmediateEncodable() {
-        let alert = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
+    func testAlertImmediateEncodable() {
+        let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
         let str = try? alert.encodeToString()
     XCTAssertEqual("{\"trigger\":\"immediate\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}", str)
     }
     
-    func testDeviceAlertDelayedEncodable() {
-        let alert = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 1.0))
+    func testAlertDelayedEncodable() {
+        let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 1.0))
         let str = try? alert.encodeToString()
     XCTAssertEqual("{\"trigger\":{\"delayed\":{\"delayInterval\":1}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}", str)
     }
     
-    func testDeviceAlertRepeatingEncodable() {
-        let alert = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .repeating(repeatInterval: 2.0))
+    func testAlertRepeatingEncodable() {
+        let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .repeating(repeatInterval: 2.0))
         let str = try? alert.encodeToString()
     XCTAssertEqual("{\"trigger\":{\"repeating\":{\"repeatInterval\":2}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}", str)
     }
     
-    func testDeviceAlertSilentSoundEncodable() {
-        let alert = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .silence)
+    func testAlertSilentSoundEncodable() {
+        let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .silence)
         let str = try? alert.encodeToString()
         XCTAssertEqual("{\"trigger\":\"immediate\",\"sound\":\"silence\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}", str)
     }
 
-    func testDeviceAlertVibrateSoundEncodable() {
-        let alert = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .vibrate)
+    func testAlertVibrateSoundEncodable() {
+        let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .vibrate)
         let str = try? alert.encodeToString()
         XCTAssertEqual("{\"trigger\":\"immediate\",\"sound\":\"vibrate\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}", str)
     }
 
-    func testDeviceAlertSoundEncodable() {
-        let alert = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .sound(name: "soundName"))
+    func testAlertSoundEncodable() {
+        let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .sound(name: "soundName"))
         let str = try? alert.encodeToString()
         XCTAssertEqual("{\"trigger\":\"immediate\",\"sound\":{\"sound\":{\"name\":\"soundName\"}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}", str)
     }
 
-    func testDeviceAlertImmediateDecodable() {
+    func testAlertImmediateDecodable() {
         let str = "{\"trigger\":\"immediate\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
-        let expected = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
-        let alert = try? DeviceAlert.decode(from: str)
+        let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
+        let alert = try? Alert.decode(from: str)
         XCTAssertEqual(expected, alert)
     }
 
-    func testDeviceAlertDelayedDecodable() {
+    func testAlertDelayedDecodable() {
         let str = "{\"trigger\":{\"delayed\":{\"delayInterval\":1}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
-        let expected = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 1.0))
-        let alert = try? DeviceAlert.decode(from: str)
+        let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 1.0))
+        let alert = try? Alert.decode(from: str)
         XCTAssertEqual(expected, alert)
     }
 
-    func testDeviceAlertRepeatingDecodable() {
+    func testAlertRepeatingDecodable() {
         let str = "{\"trigger\":{\"repeating\":{\"repeatInterval\":2}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
-        let expected = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .repeating(repeatInterval: 2.0))
-        let alert = try? DeviceAlert.decode(from: str)
+        let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .repeating(repeatInterval: 2.0))
+        let alert = try? Alert.decode(from: str)
         XCTAssertEqual(expected, alert)
     }
 
-    func testDeviceAlertSilentSoundDecodable() {
+    func testAlertSilentSoundDecodable() {
         let str = "{\"trigger\":\"immediate\",\"sound\":\"silence\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
-        let expected = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .silence)
-        let alert = try? DeviceAlert.decode(from: str)
+        let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .silence)
+        let alert = try? Alert.decode(from: str)
         XCTAssertEqual(expected, alert)
     }
 
-    func testDeviceAlertVibrateSoundDecodable() {
+    func testAlertVibrateSoundDecodable() {
         let str = "{\"trigger\":\"immediate\",\"sound\":\"vibrate\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
-        let expected = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .vibrate)
-        let alert = try? DeviceAlert.decode(from: str)
+        let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .vibrate)
+        let alert = try? Alert.decode(from: str)
         XCTAssertEqual(expected, alert)
     }
 
-    func testDeviceAlertSoundDecodable() {
+    func testAlertSoundDecodable() {
         let str = "{\"trigger\":\"immediate\",\"sound\":{\"sound\":{\"name\":\"soundName\"}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
-        let expected = DeviceAlert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .sound(name: "soundName"))
-        let alert = try? DeviceAlert.decode(from: str)
+        let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .sound(name: "soundName"))
+        let alert = try? Alert.decode(from: str)
         XCTAssertEqual(expected, alert)
     }
     
-    func testDeviceAlertSoundFilename() {
-        XCTAssertNil(DeviceAlert.Sound.silence.filename)
-        XCTAssertNil(DeviceAlert.Sound.vibrate.filename)
-        XCTAssertEqual("foo", DeviceAlert.Sound.sound(name: "foo").filename)
+    func testAlertSoundFilename() {
+        XCTAssertNil(Alert.Sound.silence.filename)
+        XCTAssertNil(Alert.Sound.vibrate.filename)
+        XCTAssertEqual("foo", Alert.Sound.sound(name: "foo").filename)
     }
 }

--- a/LoopKitUI/Views/CorrectionRangeScheduleEditor.swift
+++ b/LoopKitUI/Views/CorrectionRangeScheduleEditor.swift
@@ -126,8 +126,8 @@ public struct CorrectionRangeScheduleEditor: View {
         dismiss()
     }
 
-    private func confirmationAlert() -> Alert {
-        Alert(
+    private func confirmationAlert() -> SwiftUI.Alert {
+        SwiftUI.Alert(
             title: Text("Save Correction Range(s)?", comment: "Alert title for confirming correction ranges outside the recommended range"),
             message: Text("One or more of the values you have entered are outside of what Tidepool generally recommends.", comment: "Alert message for confirming correction ranges outside the recommended range"),
             primaryButton: .cancel(Text("Go Back")),

--- a/LoopKitUI/Views/QuantityScheduleEditor.swift
+++ b/LoopKitUI/Views/QuantityScheduleEditor.swift
@@ -178,8 +178,8 @@ struct QuantityScheduleEditor<ActionAreaContent: View>: View {
         dismiss()
     }
 
-    private func confirmationAlert() -> Alert {
-        Alert(
+    private func confirmationAlert() -> SwiftUI.Alert {
+        SwiftUI.Alert(
             title: confirmationAlertContent.title,
             message: confirmationAlertContent.message,
             primaryButton: .cancel(Text("Go Back")),

--- a/MockKit/MockCGMManager.swift
+++ b/MockKit/MockCGMManager.swift
@@ -26,24 +26,24 @@ public final class MockCGMManager: TestingCGMManager {
     public static let localizedTitle = "Simulator"
 
     public struct MockAlert {
-        public let sound: DeviceAlert.Sound
-        public let identifier: DeviceAlert.AlertIdentifier
-        public let foregroundContent: DeviceAlert.Content
-        public let backgroundContent: DeviceAlert.Content
+        public let sound: Alert.Sound
+        public let identifier: Alert.AlertIdentifier
+        public let foregroundContent: Alert.Content
+        public let backgroundContent: Alert.Content
     }
-    let alerts: [DeviceAlert.AlertIdentifier: MockAlert] = [
+    let alerts: [Alert.AlertIdentifier: MockAlert] = [
         submarine.identifier: submarine, buzz.identifier: buzz, critical.identifier: critical
     ]
     
     public static let submarine = MockAlert(sound: .sound(name: "sub.caf"), identifier: "submarine",
-                                            foregroundContent: DeviceAlert.Content(title: "Alert: FG Title", body: "Alert: Foreground Body", acknowledgeActionButtonLabel: "FG OK"),
-                                            backgroundContent: DeviceAlert.Content(title: "Alert: BG Title", body: "Alert: Background Body", acknowledgeActionButtonLabel: "BG OK"))
+                                            foregroundContent: Alert.Content(title: "Alert: FG Title", body: "Alert: Foreground Body", acknowledgeActionButtonLabel: "FG OK"),
+                                            backgroundContent: Alert.Content(title: "Alert: BG Title", body: "Alert: Background Body", acknowledgeActionButtonLabel: "BG OK"))
     public static let critical = MockAlert(sound: .sound(name: "critical.caf"), identifier: "critical",
-                                            foregroundContent: DeviceAlert.Content(title: "Critical Alert: FG Title", body: "Critical Alert: Foreground Body", acknowledgeActionButtonLabel: "Critical FG OK", isCritical: true),
-                                            backgroundContent: DeviceAlert.Content(title: "Critical Alert: BG Title", body: "Critical Alert: Background Body", acknowledgeActionButtonLabel: "Critical BG OK", isCritical: true))
+                                            foregroundContent: Alert.Content(title: "Critical Alert: FG Title", body: "Critical Alert: Foreground Body", acknowledgeActionButtonLabel: "Critical FG OK", isCritical: true),
+                                            backgroundContent: Alert.Content(title: "Critical Alert: BG Title", body: "Critical Alert: Background Body", acknowledgeActionButtonLabel: "Critical BG OK", isCritical: true))
     public static let buzz = MockAlert(sound: .vibrate, identifier: "buzz",
-                                       foregroundContent: DeviceAlert.Content(title: "Alert: FG Title", body: "FG bzzzt", acknowledgeActionButtonLabel: "Buzz"),
-                                       backgroundContent: DeviceAlert.Content(title: "Alert: BG Title", body: "BG bzzzt", acknowledgeActionButtonLabel: "Buzz"))
+                                       foregroundContent: Alert.Content(title: "Alert: FG Title", body: "FG bzzzt", acknowledgeActionButtonLabel: "Buzz"),
+                                       backgroundContent: Alert.Content(title: "Alert: BG Title", body: "BG bzzzt", acknowledgeActionButtonLabel: "Buzz"))
 
     public var mockSensorState: MockCGMState {
         didSet {
@@ -201,18 +201,18 @@ extension MockCGMManager {
         return Bundle(for: type(of: self)).bundleURL
     }
     
-    public func getSounds() -> [DeviceAlert.Sound] {
+    public func getSounds() -> [Alert.Sound] {
         return alerts.map { $1.sound }
     }
     
-    public func issueAlert(identifier: DeviceAlert.AlertIdentifier, trigger: DeviceAlert.Trigger, delay: TimeInterval?) {
+    public func issueAlert(identifier: Alert.AlertIdentifier, trigger: Alert.Trigger, delay: TimeInterval?) {
         guard let alert = alerts[identifier] else {
             return
         }
         registerBackgroundTask()
         delegate.notifyDelayed(by: delay ?? 0) { delegate in
             self.logDeviceComms(.delegate, message: "\(#function): \(identifier) \(trigger)")
-            delegate?.issueAlert(DeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: self.managerIdentifier, alertIdentifier: identifier),
+            delegate?.issueAlert(Alert(identifier: Alert.Identifier(managerIdentifier: self.managerIdentifier, alertIdentifier: identifier),
                                              foregroundContent: alert.foregroundContent,
                                              backgroundContent: alert.backgroundContent,
                                              trigger: trigger,
@@ -220,13 +220,13 @@ extension MockCGMManager {
         }
     }
     
-    public func acknowledgeAlert(alertIdentifier: DeviceAlert.AlertIdentifier) {
+    public func acknowledgeAlert(alertIdentifier: Alert.AlertIdentifier) {
         endBackgroundTask()
         self.logDeviceComms(.delegateResponse, message: "\(#function): Alert \(alertIdentifier) acknowledged.")
     }
 
-    public func retractAlert(identifier: DeviceAlert.AlertIdentifier) {
-        delegate.notify { $0?.retractAlert(identifier: DeviceAlert.Identifier(managerIdentifier: self.managerIdentifier, alertIdentifier: identifier)) }
+    public func retractAlert(identifier: Alert.AlertIdentifier) {
+        delegate.notify { $0?.retractAlert(identifier: Alert.Identifier(managerIdentifier: self.managerIdentifier, alertIdentifier: identifier)) }
     }
     
     private func registerBackgroundTask() {

--- a/MockKit/MockCGMManager.swift
+++ b/MockKit/MockCGMManager.swift
@@ -213,10 +213,10 @@ extension MockCGMManager {
         delegate.notifyDelayed(by: delay ?? 0) { delegate in
             self.logDeviceComms(.delegate, message: "\(#function): \(identifier) \(trigger)")
             delegate?.issueAlert(Alert(identifier: Alert.Identifier(managerIdentifier: self.managerIdentifier, alertIdentifier: identifier),
-                                             foregroundContent: alert.foregroundContent,
-                                             backgroundContent: alert.backgroundContent,
-                                             trigger: trigger,
-                                             sound: alert.sound))
+                                       foregroundContent: alert.foregroundContent,
+                                       backgroundContent: alert.backgroundContent,
+                                       trigger: trigger,
+                                       sound: alert.sound))
         }
     }
     

--- a/MockKit/MockPumpManager.swift
+++ b/MockKit/MockPumpManager.swift
@@ -420,15 +420,15 @@ public final class MockPumpManager: TestingPumpManager {
     }
 }
 
-// MARK: - DeviceAlertResponder implementation
+// MARK: - AlertResponder implementation
 extension MockPumpManager {
-    public func acknowledgeAlert(alertIdentifier: DeviceAlert.AlertIdentifier) { }
+    public func acknowledgeAlert(alertIdentifier: Alert.AlertIdentifier) { }
 }
 
-// MARK: - DeviceAlertSoundVendor implementation
+// MARK: - AlertSoundVendor implementation
 extension MockPumpManager {
     public func getSoundBaseURL() -> URL? { return nil }
-    public func getSounds() -> [DeviceAlert.Sound] { return [] }
+    public func getSounds() -> [Alert.Sound] { return [] }
 }
 
 extension MockPumpManager {

--- a/MockKitUI/View Controllers/IssueAlertTableViewController.swift
+++ b/MockKitUI/View Controllers/IssueAlertTableViewController.swift
@@ -38,7 +38,7 @@ final class IssueAlertTableViewController: UITableViewController {
             }
         }
         
-        var trigger: DeviceAlert.Trigger {
+        var trigger: Alert.Trigger {
             switch self {
             case .immediate: return .immediate
             case .retract: return .immediate
@@ -57,7 +57,7 @@ final class IssueAlertTableViewController: UITableViewController {
             }
         }
         
-        var identifier: DeviceAlert.AlertIdentifier {
+        var identifier: Alert.AlertIdentifier {
             switch self {
             case .buzz: return MockCGMManager.buzz.identifier
             case .critical: return MockCGMManager.critical.identifier


### PR DESCRIPTION
Soon, we're going to have more "alerts" in the system than just "device alerts".  This renames it to just "Alert".  Note now disambiguation is going to be necessary for `SwiftUI.Alert`.