### PR TITLE
LOOP-1395, LOOP-490, LOOP-1214: For Tidepool Loop, exclude HealthKit data from other apps

### DIFF
--- a/LoopKit Example/Managers/DeviceDataManager.swift
+++ b/LoopKit Example/Managers/DeviceDataManager.swift
@@ -19,6 +19,7 @@ class DeviceDataManager : CarbStoreDelegate {
 
         carbStore = CarbStore(
             healthStore: healthStore,
+            observeHealthKitForCurrentAppOnly: false,
             cacheStore: cacheStore,
             carbRatioSchedule: carbRatioSchedule,
             insulinSensitivitySchedule: insulinSensitivitySchedule
@@ -31,12 +32,15 @@ class DeviceDataManager : CarbStoreDelegate {
         }
         doseStore = DoseStore(
             healthStore: healthStore,
+            observeHealthKitForCurrentAppOnly: false,
             cacheStore: cacheStore,
             insulinModel: insulinModel,
             basalProfile: basalRateSchedule,
             insulinSensitivitySchedule: insulinSensitivitySchedule
         )
-        glucoseStore = GlucoseStore(healthStore: healthStore, cacheStore: cacheStore)
+        glucoseStore = GlucoseStore(healthStore: healthStore,
+                                    observeHealthKitForCurrentAppOnly: false,
+                                    cacheStore: cacheStore)
         carbStore?.delegate = self
     }
 

--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		1D25C22E246A2A1A00E87FA0 /* critical.caf in Resources */ = {isa = PBXBuildFile; fileRef = 1D25C22D246A2A1A00E87FA0 /* critical.caf */; };
+		1D4990E624A17564005CC357 /* HKQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4990E524A17564005CC357 /* HKQuery.swift */; };
+		1D4990E724A17898005CC357 /* HKQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4990E524A17564005CC357 /* HKQuery.swift */; };
 		1D640FF724525228008F9755 /* sub.caf in Resources */ = {isa = PBXBuildFile; fileRef = 1D640FF524524284008F9755 /* sub.caf */; };
 		1D841AAD24577EE10069DBFF /* AlertSoundPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D841AAC24577EE10069DBFF /* AlertSoundPlayer.swift */; };
 		1DA649AB2445174400F61E75 /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649AA2445174400F61E75 /* Alert.swift */; };
@@ -777,6 +779,7 @@
 
 /* Begin PBXFileReference section */
 		1D25C22D246A2A1A00E87FA0 /* critical.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = critical.caf; sourceTree = "<group>"; };
+		1D4990E524A17564005CC357 /* HKQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HKQuery.swift; sourceTree = "<group>"; };
 		1D640FF524524284008F9755 /* sub.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = sub.caf; sourceTree = "<group>"; };
 		1D841AAC24577EE10069DBFF /* AlertSoundPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertSoundPlayer.swift; sourceTree = "<group>"; };
 		1DA649AA2445174400F61E75 /* Alert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Alert.swift; sourceTree = "<group>"; };
@@ -1706,6 +1709,7 @@
 				437AFF23203BE402008C4892 /* HKHealthStore.swift */,
 				43AF1FB11C926CDD00EA2F3D /* HKQuantity.swift */,
 				432762731D60505F0083215A /* HKQuantitySample.swift */,
+				1D4990E524A17564005CC357 /* HKQuery.swift */,
 				43CB51B0211EB16C00DB9B4A /* NSUserActivity+CarbKit.swift */,
 			);
 			path = Extensions;
@@ -3040,6 +3044,7 @@
 				4322B776202FA2790002837D /* CarbStore.swift in Sources */,
 				C1F8403A23DB84B700673141 /* DeviceLogEntry+CoreDataProperties.swift in Sources */,
 				A9498D7823386C3300DAA9B9 /* LoggingService.swift in Sources */,
+				1D4990E624A17564005CC357 /* HKQuery.swift in Sources */,
 				433BC7AA20538D4C000B1200 /* CachedGlucoseObject+CoreDataClass.swift in Sources */,
 				4322B786202FA2AF0002837D /* WalshInsulinModel.swift in Sources */,
 				4378B64B1ED61965000AE785 /* GlucoseEffectVelocity.swift in Sources */,
@@ -3209,6 +3214,7 @@
 				A9E6758822713F4700E25293 /* HealthKitSampleStore.swift in Sources */,
 				89AE223D228BCB0B00BDFD85 /* Collection.swift in Sources */,
 				A9E6758A22713F4700E25293 /* DeletedCarbEntry.swift in Sources */,
+				1D4990E724A17898005CC357 /* HKQuery.swift in Sources */,
 				A9E6758B22713F4700E25293 /* OSLog.swift in Sources */,
 				C17F39CC23CD2D3E00FA1113 /* DeviceLog.xcdatamodeld in Sources */,
 				A9E6758C22713F4700E25293 /* DoseType.swift in Sources */,

--- a/LoopKit/CarbKit/CarbStore.swift
+++ b/LoopKit/CarbKit/CarbStore.swift
@@ -300,7 +300,7 @@ extension CarbStore {
     ///   - completion: A closure called once the samples have been retrieved
     ///   - result: An array of samples, in chronological order by startDate
     private func getCarbSamples(start: Date, end: Date? = nil, completion: @escaping (_ result: CarbStoreResult<[StoredCarbEntry]>) -> Void) {
-        let predicate = HKQuery.predicateForSamples(withStart: start, end: end)
+        let predicate = HKQuery.predicateForSamplesForLoop(withStart: start, end: end)
         let sortDescriptors = [NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)]
 
         let query = HKSampleQuery(sampleType: carbType, predicate: predicate, limit: HKObjectQueryNoLimit, sortDescriptors: sortDescriptors) { (query, samples, error) in

--- a/LoopKit/CarbKit/CarbStore.swift
+++ b/LoopKit/CarbKit/CarbStore.swift
@@ -185,7 +185,7 @@ public final class CarbStore: HealthKitSampleStore {
      */
     public init(
         healthStore: HKHealthStore,
-        forCurrentAppOnly: Bool,
+        observeHealthKitForCurrentAppOnly: Bool,
         cacheStore: PersistenceController,
         observationEnabled: Bool = true,
         cacheLength: TimeInterval = defaultAbsorptionTimes.slow * 2,
@@ -213,7 +213,7 @@ public final class CarbStore: HealthKitSampleStore {
         self.observationInterval = max(observationInterval ?? 0, defaultAbsorptionTimes.slow * 2)
         self.carbAbsorptionModel = carbAbsorptionModel
 
-        super.init(healthStore: healthStore, forCurrentAppOnly: forCurrentAppOnly, type: carbType, observationStart: Date(timeIntervalSinceNow: -self.observationInterval), observationEnabled: observationEnabled)
+        super.init(healthStore: healthStore, observeHealthKitForCurrentAppOnly: observeHealthKitForCurrentAppOnly, type: carbType, observationStart: Date(timeIntervalSinceNow: -self.observationInterval), observationEnabled: observationEnabled)
 
         cacheStore.onReady { (error) in
             guard error == nil else { return }
@@ -301,7 +301,7 @@ extension CarbStore {
     ///   - completion: A closure called once the samples have been retrieved
     ///   - result: An array of samples, in chronological order by startDate
     private func getCarbSamples(start: Date, end: Date? = nil, completion: @escaping (_ result: CarbStoreResult<[StoredCarbEntry]>) -> Void) {
-        let predicate = HKQuery.predicateForSamples(forCurrentAppOnly: forCurrentAppOnly, withStart: start, end: end)
+        let predicate = HKQuery.predicateForSamples(observeHealthKitForCurrentAppOnly: observeHealthKitForCurrentAppOnly, withStart: start, end: end)
         let sortDescriptors = [NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)]
 
         let query = HKSampleQuery(sampleType: carbType, predicate: predicate, limit: HKObjectQueryNoLimit, sortDescriptors: sortDescriptors) { (query, samples, error) in

--- a/LoopKit/CarbKit/CarbStore.swift
+++ b/LoopKit/CarbKit/CarbStore.swift
@@ -185,6 +185,7 @@ public final class CarbStore: HealthKitSampleStore {
      */
     public init(
         healthStore: HKHealthStore,
+        forCurrentAppOnly: Bool,
         cacheStore: PersistenceController,
         observationEnabled: Bool = true,
         cacheLength: TimeInterval = defaultAbsorptionTimes.slow * 2,
@@ -212,7 +213,7 @@ public final class CarbStore: HealthKitSampleStore {
         self.observationInterval = max(observationInterval ?? 0, defaultAbsorptionTimes.slow * 2)
         self.carbAbsorptionModel = carbAbsorptionModel
 
-        super.init(healthStore: healthStore, type: carbType, observationStart: Date(timeIntervalSinceNow: -self.observationInterval), observationEnabled: observationEnabled)
+        super.init(healthStore: healthStore, forCurrentAppOnly: forCurrentAppOnly, type: carbType, observationStart: Date(timeIntervalSinceNow: -self.observationInterval), observationEnabled: observationEnabled)
 
         cacheStore.onReady { (error) in
             guard error == nil else { return }
@@ -300,7 +301,7 @@ extension CarbStore {
     ///   - completion: A closure called once the samples have been retrieved
     ///   - result: An array of samples, in chronological order by startDate
     private func getCarbSamples(start: Date, end: Date? = nil, completion: @escaping (_ result: CarbStoreResult<[StoredCarbEntry]>) -> Void) {
-        let predicate = HKQuery.predicateForSamplesForLoop(withStart: start, end: end)
+        let predicate = HKQuery.predicateForSamples(forCurrentAppOnly: forCurrentAppOnly, withStart: start, end: end)
         let sortDescriptors = [NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)]
 
         let query = HKSampleQuery(sampleType: carbType, predicate: predicate, limit: HKObjectQueryNoLimit, sortDescriptors: sortDescriptors) { (query, samples, error) in

--- a/LoopKit/Extensions/HKQuery.swift
+++ b/LoopKit/Extensions/HKQuery.swift
@@ -11,8 +11,8 @@ import HealthKit
 public var excludeHealthKitDataFromOtherApps = false
 
 extension HKQuery {
-    public class func predicateForSamplesForLoop(withStart startDate: Date?, end endDate: Date?, options: HKQueryOptions = []) -> NSPredicate {
-        if excludeHealthKitDataFromOtherApps {
+    public class func predicateForSamples(forCurrentAppOnly: Bool, withStart startDate: Date?, end endDate: Date?, options: HKQueryOptions = []) -> NSPredicate {
+        if forCurrentAppOnly {
             return NSCompoundPredicate(andPredicateWithSubpredicates: [
                 HKQuery.predicateForObjects(from: HKSource.default()),
                 HKQuery.predicateForSamples(withStart: startDate, end: endDate)

--- a/LoopKit/Extensions/HKQuery.swift
+++ b/LoopKit/Extensions/HKQuery.swift
@@ -1,0 +1,24 @@
+//
+//  HKQuery.swift
+//  LoopKit
+//
+//  Created by Rick Pasetto on 6/22/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import HealthKit
+
+public var excludeHealthKitDataFromOtherApps = false
+
+extension HKQuery {
+    public class func predicateForSamplesForLoop(withStart startDate: Date?, end endDate: Date?, options: HKQueryOptions = []) -> NSPredicate {
+        if excludeHealthKitDataFromOtherApps {
+            return NSCompoundPredicate(andPredicateWithSubpredicates: [
+                HKQuery.predicateForObjects(from: HKSource.default()),
+                HKQuery.predicateForSamples(withStart: startDate, end: endDate)
+            ])
+        } else {
+            return HKQuery.predicateForSamples(withStart: startDate, end: endDate)
+        }
+    }
+}

--- a/LoopKit/Extensions/HKQuery.swift
+++ b/LoopKit/Extensions/HKQuery.swift
@@ -9,8 +9,8 @@
 import HealthKit
 
 extension HKQuery {
-    public class func predicateForSamples(forCurrentAppOnly: Bool, withStart startDate: Date?, end endDate: Date?, options: HKQueryOptions = []) -> NSPredicate {
-        if forCurrentAppOnly {
+    public class func predicateForSamples(observeHealthKitForCurrentAppOnly: Bool, withStart startDate: Date?, end endDate: Date?, options: HKQueryOptions = []) -> NSPredicate {
+        if observeHealthKitForCurrentAppOnly {
             return NSCompoundPredicate(andPredicateWithSubpredicates: [
                 HKQuery.predicateForObjects(from: HKSource.default()),
                 HKQuery.predicateForSamples(withStart: startDate, end: endDate)

--- a/LoopKit/Extensions/HKQuery.swift
+++ b/LoopKit/Extensions/HKQuery.swift
@@ -8,8 +8,6 @@
 
 import HealthKit
 
-public var excludeHealthKitDataFromOtherApps = false
-
 extension HKQuery {
     public class func predicateForSamples(forCurrentAppOnly: Bool, withStart startDate: Date?, end endDate: Date?, options: HKQueryOptions = []) -> NSPredicate {
         if forCurrentAppOnly {

--- a/LoopKit/GlucoseKit/GlucoseStore.swift
+++ b/LoopKit/GlucoseKit/GlucoseStore.swift
@@ -100,6 +100,7 @@ public final class GlucoseStore: HealthKitSampleStore {
 
     public init(
         healthStore: HKHealthStore,
+        forCurrentAppOnly: Bool,
         cacheStore: PersistenceController,
         observationEnabled: Bool = true,
         cacheLength: TimeInterval = 60 /* minutes */ * 60 /* seconds */,
@@ -113,7 +114,7 @@ public final class GlucoseStore: HealthKitSampleStore {
         self.cacheLength = cacheLength
         self.observationInterval = observationInterval ?? cacheLength
 
-        super.init(healthStore: healthStore, type: glucoseType, observationStart: Date(timeIntervalSinceNow: -self.observationInterval), observationEnabled: observationEnabled)
+        super.init(healthStore: healthStore, forCurrentAppOnly: forCurrentAppOnly, type: glucoseType, observationStart: Date(timeIntervalSinceNow: -self.observationInterval), observationEnabled: observationEnabled)
 
         cacheStore.onReady { (error) in
             self.dataAccessQueue.async {
@@ -267,7 +268,7 @@ extension GlucoseStore {
         if let managedDataDate = managedDataDate, let managedDataInterval = managedDataInterval {
             let end = min(Date(timeIntervalSinceNow: -managedDataInterval), managedDataDate)
 
-            let predicate = HKQuery.predicateForSamplesForLoop(withStart: Date(timeIntervalSinceNow: -maxPurgeInterval), end: end, options: [])
+            let predicate = HKQuery.predicateForSamples(forCurrentAppOnly: forCurrentAppOnly, withStart: Date(timeIntervalSinceNow: -maxPurgeInterval), end: end, options: [])
 
             healthStore.deleteObjects(of: glucoseType, predicate: predicate) { (success, count, error) -> Void in
                 // error is expected and ignored if protected data is unavailable
@@ -317,7 +318,7 @@ extension GlucoseStore {
     ///   - completion: A closure called once the values have been retrieved
     ///   - result: An array of glucose values, in chronological order by startDate
     public func getGlucoseSamples(start: Date, end: Date? = nil, completion: @escaping (_ result: GlucoseStoreResult<[StoredGlucoseSample]>) -> Void) {
-        let predicate = HKQuery.predicateForSamplesForLoop(withStart: start, end: end)
+        let predicate = HKQuery.predicateForSamples(forCurrentAppOnly: forCurrentAppOnly, withStart: start, end: end)
         let sortDescriptors = [NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)]
 
         let query = HKSampleQuery(sampleType: glucoseType, predicate: predicate, limit: HKObjectQueryNoLimit, sortDescriptors: sortDescriptors) { (_, samples, error) -> Void in

--- a/LoopKit/GlucoseKit/GlucoseStore.swift
+++ b/LoopKit/GlucoseKit/GlucoseStore.swift
@@ -267,7 +267,7 @@ extension GlucoseStore {
         if let managedDataDate = managedDataDate, let managedDataInterval = managedDataInterval {
             let end = min(Date(timeIntervalSinceNow: -managedDataInterval), managedDataDate)
 
-            let predicate = HKQuery.predicateForSamples(withStart: Date(timeIntervalSinceNow: -maxPurgeInterval), end: end, options: [])
+            let predicate = HKQuery.predicateForSamplesForLoop(withStart: Date(timeIntervalSinceNow: -maxPurgeInterval), end: end, options: [])
 
             healthStore.deleteObjects(of: glucoseType, predicate: predicate) { (success, count, error) -> Void in
                 // error is expected and ignored if protected data is unavailable
@@ -317,7 +317,7 @@ extension GlucoseStore {
     ///   - completion: A closure called once the values have been retrieved
     ///   - result: An array of glucose values, in chronological order by startDate
     public func getGlucoseSamples(start: Date, end: Date? = nil, completion: @escaping (_ result: GlucoseStoreResult<[StoredGlucoseSample]>) -> Void) {
-        let predicate = HKQuery.predicateForSamples(withStart: start, end: end)
+        let predicate = HKQuery.predicateForSamplesForLoop(withStart: start, end: end)
         let sortDescriptors = [NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)]
 
         let query = HKSampleQuery(sampleType: glucoseType, predicate: predicate, limit: HKObjectQueryNoLimit, sortDescriptors: sortDescriptors) { (_, samples, error) -> Void in

--- a/LoopKit/GlucoseKit/GlucoseStore.swift
+++ b/LoopKit/GlucoseKit/GlucoseStore.swift
@@ -100,7 +100,7 @@ public final class GlucoseStore: HealthKitSampleStore {
 
     public init(
         healthStore: HKHealthStore,
-        forCurrentAppOnly: Bool,
+        observeHealthKitForCurrentAppOnly: Bool,
         cacheStore: PersistenceController,
         observationEnabled: Bool = true,
         cacheLength: TimeInterval = 60 /* minutes */ * 60 /* seconds */,
@@ -114,7 +114,7 @@ public final class GlucoseStore: HealthKitSampleStore {
         self.cacheLength = cacheLength
         self.observationInterval = observationInterval ?? cacheLength
 
-        super.init(healthStore: healthStore, forCurrentAppOnly: forCurrentAppOnly, type: glucoseType, observationStart: Date(timeIntervalSinceNow: -self.observationInterval), observationEnabled: observationEnabled)
+        super.init(healthStore: healthStore, observeHealthKitForCurrentAppOnly: observeHealthKitForCurrentAppOnly, type: glucoseType, observationStart: Date(timeIntervalSinceNow: -self.observationInterval), observationEnabled: observationEnabled)
 
         cacheStore.onReady { (error) in
             self.dataAccessQueue.async {
@@ -268,7 +268,7 @@ extension GlucoseStore {
         if let managedDataDate = managedDataDate, let managedDataInterval = managedDataInterval {
             let end = min(Date(timeIntervalSinceNow: -managedDataInterval), managedDataDate)
 
-            let predicate = HKQuery.predicateForSamples(forCurrentAppOnly: forCurrentAppOnly, withStart: Date(timeIntervalSinceNow: -maxPurgeInterval), end: end, options: [])
+            let predicate = HKQuery.predicateForSamples(observeHealthKitForCurrentAppOnly: observeHealthKitForCurrentAppOnly, withStart: Date(timeIntervalSinceNow: -maxPurgeInterval), end: end, options: [])
 
             healthStore.deleteObjects(of: glucoseType, predicate: predicate) { (success, count, error) -> Void in
                 // error is expected and ignored if protected data is unavailable
@@ -318,7 +318,7 @@ extension GlucoseStore {
     ///   - completion: A closure called once the values have been retrieved
     ///   - result: An array of glucose values, in chronological order by startDate
     public func getGlucoseSamples(start: Date, end: Date? = nil, completion: @escaping (_ result: GlucoseStoreResult<[StoredGlucoseSample]>) -> Void) {
-        let predicate = HKQuery.predicateForSamples(forCurrentAppOnly: forCurrentAppOnly, withStart: start, end: end)
+        let predicate = HKQuery.predicateForSamples(observeHealthKitForCurrentAppOnly: observeHealthKitForCurrentAppOnly, withStart: start, end: end)
         let sortDescriptors = [NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)]
 
         let query = HKSampleQuery(sampleType: glucoseType, predicate: predicate, limit: HKObjectQueryNoLimit, sortDescriptors: sortDescriptors) { (_, samples, error) -> Void in

--- a/LoopKit/HealthKitSampleStore.swift
+++ b/LoopKit/HealthKitSampleStore.swift
@@ -36,6 +36,9 @@ public class HealthKitSampleStore {
 
     /// The health store used for underlying queries
     public let healthStore: HKHealthStore
+    
+    /// Whether the store should only fetch data that was written to HealthKit from Loop, or from any other source
+    internal let forCurrentAppOnly: Bool
 
     /// Whether the store is observing changes to types
     public let observationEnabled: Bool
@@ -55,12 +58,14 @@ public class HealthKitSampleStore {
 
     public init(
         healthStore: HKHealthStore,
+        forCurrentAppOnly: Bool,
         type: HKSampleType,
         observationStart: Date,
         observationEnabled: Bool,
         test_currentDate: Date? = nil
     ) {
         self.healthStore = healthStore
+        self.forCurrentAppOnly = forCurrentAppOnly
         self.sampleType = type
         self.observationStart = observationStart
         self.observationEnabled = observationEnabled
@@ -218,7 +223,7 @@ extension HealthKitSampleStore {
             return
         }
 
-        let predicate = HKQuery.predicateForSamplesForLoop(withStart: observationStart, end: nil)
+        let predicate = HKQuery.predicateForSamples(forCurrentAppOnly: forCurrentAppOnly, withStart: observationStart, end: nil)
 
         observerQuery = HKObserverQuery(sampleType: sampleType, predicate: predicate) { [weak self] (query, completionHandler, error) in
             self?.observeUpdates(to: query, error: error)

--- a/LoopKit/HealthKitSampleStore.swift
+++ b/LoopKit/HealthKitSampleStore.swift
@@ -38,7 +38,7 @@ public class HealthKitSampleStore {
     public let healthStore: HKHealthStore
     
     /// Whether the store should only fetch data that was written to HealthKit from Loop, or from any other source
-    internal let forCurrentAppOnly: Bool
+    internal let observeHealthKitForCurrentAppOnly: Bool
 
     /// Whether the store is observing changes to types
     public let observationEnabled: Bool
@@ -58,14 +58,14 @@ public class HealthKitSampleStore {
 
     public init(
         healthStore: HKHealthStore,
-        forCurrentAppOnly: Bool,
+        observeHealthKitForCurrentAppOnly: Bool,
         type: HKSampleType,
         observationStart: Date,
         observationEnabled: Bool,
         test_currentDate: Date? = nil
     ) {
         self.healthStore = healthStore
-        self.forCurrentAppOnly = forCurrentAppOnly
+        self.observeHealthKitForCurrentAppOnly = observeHealthKitForCurrentAppOnly
         self.sampleType = type
         self.observationStart = observationStart
         self.observationEnabled = observationEnabled
@@ -223,7 +223,7 @@ extension HealthKitSampleStore {
             return
         }
 
-        let predicate = HKQuery.predicateForSamples(forCurrentAppOnly: forCurrentAppOnly, withStart: observationStart, end: nil)
+        let predicate = HKQuery.predicateForSamples(observeHealthKitForCurrentAppOnly: observeHealthKitForCurrentAppOnly, withStart: observationStart, end: nil)
 
         observerQuery = HKObserverQuery(sampleType: sampleType, predicate: predicate) { [weak self] (query, completionHandler, error) in
             self?.observeUpdates(to: query, error: error)

--- a/LoopKit/HealthKitSampleStore.swift
+++ b/LoopKit/HealthKitSampleStore.swift
@@ -218,7 +218,7 @@ extension HealthKitSampleStore {
             return
         }
 
-        let predicate = HKQuery.predicateForSamples(withStart: observationStart, end: nil)
+        let predicate = HKQuery.predicateForSamplesForLoop(withStart: observationStart, end: nil)
 
         observerQuery = HKObserverQuery(sampleType: sampleType, predicate: predicate) { [weak self] (query, completionHandler, error) in
             self?.observeUpdates(to: query, error: error)

--- a/LoopKit/InsulinKit/DoseStore.swift
+++ b/LoopKit/InsulinKit/DoseStore.swift
@@ -198,6 +198,7 @@ public final class DoseStore {
     ///
     /// - Parameters:
     ///   - healthStore: The HealthKit store for reading & writing insulin delivery
+    ///   - forCurrentAppOnly: Whether or not this Store should only read HealthKit data written by this app
     ///   - cacheStore: The cache store for reading & writing short-term intermediate data
     ///   - observationEnabled: Whether the store should observe changes from HealthKit
     ///   - insulinModel: The model of insulin effect over time
@@ -207,6 +208,7 @@ public final class DoseStore {
     ///   - lastPumpEventsReconciliation: The date the PumpManger last reconciled with the pump
     public init(
         healthStore: HKHealthStore,
+        forCurrentAppOnly: Bool,
         cacheStore: PersistenceController,
         observationEnabled: Bool = true,
         cacheLength: TimeInterval = 24 /* hours */ * 60 /* minutes */ * 60 /* seconds */,
@@ -220,6 +222,7 @@ public final class DoseStore {
     ) {
         self.insulinDeliveryStore = InsulinDeliveryStore(
             healthStore: healthStore,
+            forCurrentAppOnly: forCurrentAppOnly,
             cacheStore: cacheStore,
             observationEnabled: observationEnabled,
             test_currentDate: test_currentDate

--- a/LoopKit/InsulinKit/DoseStore.swift
+++ b/LoopKit/InsulinKit/DoseStore.swift
@@ -198,7 +198,7 @@ public final class DoseStore {
     ///
     /// - Parameters:
     ///   - healthStore: The HealthKit store for reading & writing insulin delivery
-    ///   - forCurrentAppOnly: Whether or not this Store should only read HealthKit data written by this app
+    ///   - observeHealthKitForCurrentAppOnly: Whether or not this Store should only read HealthKit data written by this app
     ///   - cacheStore: The cache store for reading & writing short-term intermediate data
     ///   - observationEnabled: Whether the store should observe changes from HealthKit
     ///   - insulinModel: The model of insulin effect over time
@@ -208,7 +208,7 @@ public final class DoseStore {
     ///   - lastPumpEventsReconciliation: The date the PumpManger last reconciled with the pump
     public init(
         healthStore: HKHealthStore,
-        forCurrentAppOnly: Bool,
+        observeHealthKitForCurrentAppOnly: Bool,
         cacheStore: PersistenceController,
         observationEnabled: Bool = true,
         cacheLength: TimeInterval = 24 /* hours */ * 60 /* minutes */ * 60 /* seconds */,
@@ -222,7 +222,7 @@ public final class DoseStore {
     ) {
         self.insulinDeliveryStore = InsulinDeliveryStore(
             healthStore: healthStore,
-            forCurrentAppOnly: forCurrentAppOnly,
+            observeHealthKitForCurrentAppOnly: observeHealthKitForCurrentAppOnly,
             cacheStore: cacheStore,
             observationEnabled: observationEnabled,
             test_currentDate: test_currentDate

--- a/LoopKit/InsulinKit/InsulinDeliveryStore.swift
+++ b/LoopKit/InsulinKit/InsulinDeliveryStore.swift
@@ -50,6 +50,7 @@ public class InsulinDeliveryStore: HealthKitSampleStore {
 
     public init(
         healthStore: HKHealthStore,
+        forCurrentAppOnly: Bool,
         cacheStore: PersistenceController,
         observationEnabled: Bool = true,
         cacheLength: TimeInterval = 24 /* hours */ * 60 /* minutes */ * 60 /* seconds */,
@@ -60,6 +61,7 @@ public class InsulinDeliveryStore: HealthKitSampleStore {
 
         super.init(
             healthStore: healthStore,
+            forCurrentAppOnly: forCurrentAppOnly,
             type: insulinType,
             observationStart: (test_currentDate ?? Date()).addingTimeInterval(-cacheLength),
             observationEnabled: observationEnabled,
@@ -232,7 +234,7 @@ extension InsulinDeliveryStore {
     }
 
     private func getSamples(start: Date, end: Date? = nil, isChronological: Bool = true, _ completion: @escaping (_ result: InsulinDeliveryStoreResult<[HKQuantitySample]>) -> Void) {
-        let predicate = HKQuery.predicateForSamplesForLoop(withStart: start, end: end, options: [])
+        let predicate = HKQuery.predicateForSamples(forCurrentAppOnly: forCurrentAppOnly, withStart: start, end: end, options: [])
         getSamples(matching: predicate, isChronological: isChronological, completion)
     }
 

--- a/LoopKit/InsulinKit/InsulinDeliveryStore.swift
+++ b/LoopKit/InsulinKit/InsulinDeliveryStore.swift
@@ -232,7 +232,7 @@ extension InsulinDeliveryStore {
     }
 
     private func getSamples(start: Date, end: Date? = nil, isChronological: Bool = true, _ completion: @escaping (_ result: InsulinDeliveryStoreResult<[HKQuantitySample]>) -> Void) {
-        let predicate = HKQuery.predicateForSamples(withStart: start, end: end, options: [])
+        let predicate = HKQuery.predicateForSamplesForLoop(withStart: start, end: end, options: [])
         getSamples(matching: predicate, isChronological: isChronological, completion)
     }
 

--- a/LoopKit/InsulinKit/InsulinDeliveryStore.swift
+++ b/LoopKit/InsulinKit/InsulinDeliveryStore.swift
@@ -50,7 +50,7 @@ public class InsulinDeliveryStore: HealthKitSampleStore {
 
     public init(
         healthStore: HKHealthStore,
-        forCurrentAppOnly: Bool,
+        observeHealthKitForCurrentAppOnly: Bool,
         cacheStore: PersistenceController,
         observationEnabled: Bool = true,
         cacheLength: TimeInterval = 24 /* hours */ * 60 /* minutes */ * 60 /* seconds */,
@@ -61,7 +61,7 @@ public class InsulinDeliveryStore: HealthKitSampleStore {
 
         super.init(
             healthStore: healthStore,
-            forCurrentAppOnly: forCurrentAppOnly,
+            observeHealthKitForCurrentAppOnly: observeHealthKitForCurrentAppOnly,
             type: insulinType,
             observationStart: (test_currentDate ?? Date()).addingTimeInterval(-cacheLength),
             observationEnabled: observationEnabled,
@@ -234,7 +234,7 @@ extension InsulinDeliveryStore {
     }
 
     private func getSamples(start: Date, end: Date? = nil, isChronological: Bool = true, _ completion: @escaping (_ result: InsulinDeliveryStoreResult<[HKQuantitySample]>) -> Void) {
-        let predicate = HKQuery.predicateForSamples(forCurrentAppOnly: forCurrentAppOnly, withStart: start, end: end, options: [])
+        let predicate = HKQuery.predicateForSamples(observeHealthKitForCurrentAppOnly: observeHealthKitForCurrentAppOnly, withStart: start, end: end, options: [])
         getSamples(matching: predicate, isChronological: isChronological, completion)
     }
 

--- a/LoopKitTests/CarbStoreTests.swift
+++ b/LoopKitTests/CarbStoreTests.swift
@@ -19,7 +19,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
         super.setUp()
         
         healthStore = HKHealthStoreMock()
-        carbStore = CarbStore(healthStore: healthStore, forCurrentAppOnly: false, cacheStore: cacheStore)
+        carbStore = CarbStore(healthStore: healthStore, observeHealthKitForCurrentAppOnly: false, cacheStore: cacheStore)
         carbStore.testQueryStore = healthStore
         carbStore.delegate = self
     }
@@ -383,7 +383,7 @@ class CarbStoreQueryTests: PersistenceControllerTestCase {
     override func setUp() {
         super.setUp()
         
-        carbStore = CarbStore(healthStore: HKHealthStoreMock(), forCurrentAppOnly: false, cacheStore: cacheStore)
+        carbStore = CarbStore(healthStore: HKHealthStoreMock(), observeHealthKitForCurrentAppOnly: false, cacheStore: cacheStore)
         completion = expectation(description: "Completion")
         queryAnchor = CarbStore.QueryAnchor()
         limit = Int.max

--- a/LoopKitTests/CarbStoreTests.swift
+++ b/LoopKitTests/CarbStoreTests.swift
@@ -19,7 +19,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
         super.setUp()
         
         healthStore = HKHealthStoreMock()
-        carbStore = CarbStore(healthStore: healthStore, cacheStore: cacheStore)
+        carbStore = CarbStore(healthStore: healthStore, forCurrentAppOnly: false, cacheStore: cacheStore)
         carbStore.testQueryStore = healthStore
         carbStore.delegate = self
     }
@@ -383,7 +383,7 @@ class CarbStoreQueryTests: PersistenceControllerTestCase {
     override func setUp() {
         super.setUp()
         
-        carbStore = CarbStore(healthStore: HKHealthStoreMock(), cacheStore: cacheStore)
+        carbStore = CarbStore(healthStore: HKHealthStoreMock(), forCurrentAppOnly: false, cacheStore: cacheStore)
         completion = expectation(description: "Completion")
         queryAnchor = CarbStore.QueryAnchor()
         limit = Int.max

--- a/LoopKitTests/DoseStoreTests.swift
+++ b/LoopKitTests/DoseStoreTests.swift
@@ -67,7 +67,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
 
         let doseStore = DoseStore(
             healthStore: healthStore,
-            forCurrentAppOnly: false,
+            observeHealthKitForCurrentAppOnly: false,
             cacheStore: cacheStore,
             observationEnabled: false,
             insulinModel: WalshInsulinModel(actionDuration: .hours(4)),
@@ -177,7 +177,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
 
         let doseStore = DoseStore(
             healthStore: healthStore,
-            forCurrentAppOnly: false,
+            observeHealthKitForCurrentAppOnly: false,
             cacheStore: cacheStore,
             observationEnabled: false,
             insulinModel: WalshInsulinModel(actionDuration: .hours(4)),
@@ -373,7 +373,7 @@ class DoseStoreQueryTests: PersistenceControllerTestCase {
         super.setUp()
         
         doseStore = DoseStore(healthStore: HKHealthStoreMock(),
-                              forCurrentAppOnly: false,
+                              observeHealthKitForCurrentAppOnly: false,
                               cacheStore: cacheStore,
                               observationEnabled: false,
                               insulinModel: insulinModel,

--- a/LoopKitTests/DoseStoreTests.swift
+++ b/LoopKitTests/DoseStoreTests.swift
@@ -67,6 +67,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
 
         let doseStore = DoseStore(
             healthStore: healthStore,
+            forCurrentAppOnly: false,
             cacheStore: cacheStore,
             observationEnabled: false,
             insulinModel: WalshInsulinModel(actionDuration: .hours(4)),
@@ -176,6 +177,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
 
         let doseStore = DoseStore(
             healthStore: healthStore,
+            forCurrentAppOnly: false,
             cacheStore: cacheStore,
             observationEnabled: false,
             insulinModel: WalshInsulinModel(actionDuration: .hours(4)),
@@ -370,7 +372,13 @@ class DoseStoreQueryTests: PersistenceControllerTestCase {
     override func setUp() {
         super.setUp()
         
-        doseStore = DoseStore(healthStore: HKHealthStoreMock(), cacheStore: cacheStore, observationEnabled: false, insulinModel: insulinModel, basalProfile: basalProfile, insulinSensitivitySchedule: insulinSensitivitySchedule)
+        doseStore = DoseStore(healthStore: HKHealthStoreMock(),
+                              forCurrentAppOnly: false,
+                              cacheStore: cacheStore,
+                              observationEnabled: false,
+                              insulinModel: insulinModel,
+                              basalProfile: basalProfile,
+                              insulinSensitivitySchedule: insulinSensitivitySchedule)
         completion = expectation(description: "Completion")
         queryAnchor = DoseStore.QueryAnchor()
         limit = Int.max

--- a/LoopKitTests/GlucoseStoreTests.swift
+++ b/LoopKitTests/GlucoseStoreTests.swift
@@ -64,7 +64,9 @@ class GlucoseStoreQueryTests: PersistenceControllerTestCase {
     override func setUp() {
         super.setUp()
         
-        glucoseStore = GlucoseStore(healthStore: HKHealthStoreMock(), cacheStore: cacheStore)
+        glucoseStore = GlucoseStore(healthStore: HKHealthStoreMock(),
+                                    forCurrentAppOnly: false,
+                                    cacheStore: cacheStore)
         completion = expectation(description: "Completion")
         queryAnchor = GlucoseStore.QueryAnchor()
         limit = Int.max

--- a/LoopKitTests/GlucoseStoreTests.swift
+++ b/LoopKitTests/GlucoseStoreTests.swift
@@ -65,7 +65,7 @@ class GlucoseStoreQueryTests: PersistenceControllerTestCase {
         super.setUp()
         
         glucoseStore = GlucoseStore(healthStore: HKHealthStoreMock(),
-                                    forCurrentAppOnly: false,
+                                    observeHealthKitForCurrentAppOnly: false,
                                     cacheStore: cacheStore)
         completion = expectation(description: "Completion")
         queryAnchor = GlucoseStore.QueryAnchor()


### PR DESCRIPTION
This adds a condition to all HKQuery samples to exclude data from sources other than this app.

I thought about elaborate ways to expose a flag in `LoopKit` but eventually landed on a simple global variable, `excludeHealthKitDataFromOtherApps` whose default is `false` (the DIY default).  I'm open to changing this.

See also https://github.com/tidepool-org/Loop/pull/120
LW PR: https://github.com/tidepool-org/LoopWorkspace/pull/128

[LOOP-1395](https://tidepool.atlassian.net/browse/LOOP-1395)
**Note** this also addresses [LOOP-490](https://tidepool.atlassian.net/browse/LOOP-490) and [LOOP-1214](https://tidepool.atlassian.net/browse/LOOP-1214)