### PR TITLE
Avoid tangled implicit dependencies on absorption times

### DIFF
--- a/LoopKit Example/Managers/DeviceDataManager.swift
+++ b/LoopKit Example/Managers/DeviceDataManager.swift
@@ -21,6 +21,9 @@ class DeviceDataManager : CarbStoreDelegate {
             healthStore: healthStore,
             observeHealthKitForCurrentAppOnly: false,
             cacheStore: cacheStore,
+            cacheLength: .hours(24),
+            defaultAbsorptionTimes: (fast: .minutes(30), medium: .hours(3), slow: .hours(5)),
+            observationInterval: .hours(24),
             carbRatioSchedule: carbRatioSchedule,
             insulinSensitivitySchedule: insulinSensitivitySchedule
         )

--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -675,6 +675,7 @@
 		C188B83422CC16AC0051760A /* InsulinSensitivityScheduleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C188B83322CC16AC0051760A /* InsulinSensitivityScheduleViewController.swift */; };
 		C1A174EC23DEAD670034DF11 /* DeviceLogEntry+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F8403723DB84B700673141 /* DeviceLogEntry+CoreDataClass.swift */; };
 		C1A174ED23DEAD6A0034DF11 /* DeviceLogEntry+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F8403823DB84B700673141 /* DeviceLogEntry+CoreDataProperties.swift */; };
+		C1A3F5BE24AA6EE200329152 /* NSTimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D8FDF21C7290350073BE78 /* NSTimeInterval.swift */; };
 		C1E4B305242E98E900E70CCB /* ProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E4B303242E98E900E70CCB /* ProgressView.swift */; };
 		C1E4B306242E98E900E70CCB /* ProgressIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E4B304242E98E900E70CCB /* ProgressIndicatorView.swift */; };
 		C1E4B308242E995200E70CCB /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E4B307242E995200E70CCB /* ActivityIndicator.swift */; };
@@ -2858,6 +2859,7 @@
 				1DEE226F24A676A300693C32 /* GlucoseStoreHKFilterTests.swift in Sources */,
 				1DEE227724A676A300693C32 /* HKHealthStoreMock.swift in Sources */,
 				1DEE228424A676A300693C32 /* CarbStoreHKFilterTests.swift in Sources */,
+				C1A3F5BE24AA6EE200329152 /* NSTimeInterval.swift in Sources */,
 				1DEE229724A676A300693C32 /* DoseStoreHKFilterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/LoopKit/CarbKit/CarbStore.swift
+++ b/LoopKit/CarbKit/CarbStore.swift
@@ -66,13 +66,6 @@ public final class CarbStore: HealthKitSampleStore {
 
     public typealias DefaultAbsorptionTimes = (fast: TimeInterval, medium: TimeInterval, slow: TimeInterval)
 
-    public static let defaultAbsorptionTimes: DefaultAbsorptionTimes = (fast: TimeInterval(hours: 2), medium: TimeInterval(hours: 3), slow: TimeInterval(hours: 4))
-
-    /// The default longest expected absorption time interval for carbohydrates: 8 hours.
-    public static var defaultMaximumAbsorptionTimeInterval: TimeInterval {
-        return defaultAbsorptionTimes.slow * 2
-    }
-
     public enum CarbStoreError: Error {
         // The store isn't correctly configured for the requested operation
         case notConfigured
@@ -187,10 +180,9 @@ public final class CarbStore: HealthKitSampleStore {
         healthStore: HKHealthStore,
         observeHealthKitForCurrentAppOnly: Bool,
         cacheStore: PersistenceController,
-        observationEnabled: Bool = true,
-        cacheLength: TimeInterval = defaultAbsorptionTimes.slow * 2,
-        defaultAbsorptionTimes: DefaultAbsorptionTimes = defaultAbsorptionTimes,
-        observationInterval: TimeInterval? = nil,
+        cacheLength: TimeInterval,
+        defaultAbsorptionTimes: DefaultAbsorptionTimes,
+        observationInterval: TimeInterval,
         carbRatioSchedule: CarbRatioSchedule? = nil,
         insulinSensitivitySchedule: InsulinSensitivitySchedule? = nil,
         overrideHistory: TemporaryScheduleOverrideHistory? = nil,
@@ -209,9 +201,11 @@ public final class CarbStore: HealthKitSampleStore {
         self.absorptionTimeOverrun = absorptionTimeOverrun
         self.delta = calculationDelta
         self.delay = effectDelay
-        self.cacheLength = max(cacheLength, observationInterval ?? 0, defaultAbsorptionTimes.slow * 2)
-        self.observationInterval = max(observationInterval ?? 0, defaultAbsorptionTimes.slow * 2)
+        self.cacheLength = cacheLength
+        self.observationInterval = observationInterval
         self.carbAbsorptionModel = carbAbsorptionModel
+        
+        let observationEnabled = observationInterval > 0
 
         super.init(healthStore: healthStore, observeHealthKitForCurrentAppOnly: observeHealthKitForCurrentAppOnly, type: carbType, observationStart: Date(timeIntervalSinceNow: -self.observationInterval), observationEnabled: observationEnabled)
 

--- a/LoopKit/TemporaryScheduleOverrideHistory.swift
+++ b/LoopKit/TemporaryScheduleOverrideHistory.swift
@@ -68,6 +68,8 @@ public final class TemporaryScheduleOverrideHistory {
     }
     
     private var modificationCounter: Int
+    
+    public var relevantTimeWindow: TimeInterval = TimeInterval.hours(8)
 
     public weak var delegate: TemporaryScheduleOverrideHistoryDelegate?
 
@@ -165,10 +167,9 @@ public final class TemporaryScheduleOverrideHistory {
     }
 
     private func relevantPeriod(relativeTo referenceDate: Date) -> DateInterval {
-        let window = CarbStore.defaultMaximumAbsorptionTimeInterval
         return DateInterval(
-            start: referenceDate.addingTimeInterval(-window),
-            end: referenceDate.addingTimeInterval(window)
+            start: referenceDate.addingTimeInterval(-relevantTimeWindow),
+            end: referenceDate.addingTimeInterval(relevantTimeWindow)
         )
     }
 

--- a/LoopKit/TemporaryScheduleOverrideHistory.swift
+++ b/LoopKit/TemporaryScheduleOverrideHistory.swift
@@ -69,7 +69,7 @@ public final class TemporaryScheduleOverrideHistory {
     
     private var modificationCounter: Int
     
-    public var relevantTimeWindow: TimeInterval = TimeInterval.hours(8)
+    public var relevantTimeWindow: TimeInterval = TimeInterval.hours(10)
 
     public weak var delegate: TemporaryScheduleOverrideHistoryDelegate?
 

--- a/LoopKitHostedTests/CarbStoreHKFilterTests.swift
+++ b/LoopKitHostedTests/CarbStoreHKFilterTests.swift
@@ -25,7 +25,14 @@ class CarbStoreHKFilterTests: XCTestCase {
     private func checkEntries(fromCurrentAppOnly: Bool, file: StaticString = #file, line: UInt = #line) {
         let pc = PersistenceController(directoryURL: URL.init(fileURLWithPath: ""))
         let mockHKStore = HKHealthStoreMock()
-        let carbStore = CarbStore(healthStore: mockHKStore, observeHealthKitForCurrentAppOnly: fromCurrentAppOnly, cacheStore: pc)
+        let carbStore = CarbStore(
+            healthStore: mockHKStore,
+            observeHealthKitForCurrentAppOnly: fromCurrentAppOnly,
+            cacheStore: pc,
+            cacheLength: .hours(24),
+            defaultAbsorptionTimes: (fast: .minutes(30), medium: .hours(3), slow: .hours(5)),
+            observationInterval: .hours(24)
+        )
         carbStore.getCarbEntries(start: Date.distantPast) { _ in }
         guard let predicate = try? XCTUnwrap(mockHKStore.lastQuery?.predicate, file: file, line: line) else { return }
         XCTAssertTrue(predicate.evaluate(with: sampleFromCurrentApp), file: file, line: line)

--- a/LoopKitTests/CarbStoreTests.swift
+++ b/LoopKitTests/CarbStoreTests.swift
@@ -17,9 +17,15 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
     
     override func setUp() {
         super.setUp()
-        
+
         healthStore = HKHealthStoreMock()
-        carbStore = CarbStore(healthStore: healthStore, observeHealthKitForCurrentAppOnly: false, cacheStore: cacheStore)
+        carbStore = CarbStore(
+            healthStore: healthStore,
+            observeHealthKitForCurrentAppOnly: false,
+            cacheStore: cacheStore,
+            cacheLength: .hours(24),
+            defaultAbsorptionTimes: (fast: .minutes(30), medium: .hours(3), slow: .hours(5)),
+            observationInterval: .hours(24))
         carbStore.testQueryStore = healthStore
         carbStore.delegate = self
     }
@@ -383,7 +389,13 @@ class CarbStoreQueryTests: PersistenceControllerTestCase {
     override func setUp() {
         super.setUp()
         
-        carbStore = CarbStore(healthStore: HKHealthStoreMock(), observeHealthKitForCurrentAppOnly: false, cacheStore: cacheStore)
+        carbStore = CarbStore(
+            healthStore: HKHealthStoreMock(),
+            observeHealthKitForCurrentAppOnly: false,
+            cacheStore: cacheStore,
+            cacheLength: .hours(24),
+            defaultAbsorptionTimes: (fast: .minutes(30), medium: .hours(3), slow: .hours(5)),
+            observationInterval: .hours(24))
         completion = expectation(description: "Completion")
         queryAnchor = CarbStore.QueryAnchor()
         limit = Int.max

--- a/LoopKitTests/TemporaryScheduleOverrideHistoryTests.swift
+++ b/LoopKitTests/TemporaryScheduleOverrideHistoryTests.swift
@@ -158,7 +158,7 @@ final class TemporaryScheduleOverrideHistoryTests: XCTestCase {
             RepeatingScheduleValue(startTime: .hours(2), value: 1.8),
             RepeatingScheduleValue(startTime: .hours(5), value: 1.2),
             RepeatingScheduleValue(startTime: .hours(6), value: 2.8),
-            RepeatingScheduleValue(startTime: .hours(8), value: 1.4),
+            RepeatingScheduleValue(startTime: .hours(10), value: 1.4),
             RepeatingScheduleValue(startTime: .hours(20), value: 1.0)
         ])!
 
@@ -206,8 +206,8 @@ final class TemporaryScheduleOverrideHistoryTests: XCTestCase {
         let expected = BasalRateSchedule(dailyItems: [
             RepeatingScheduleValue(startTime: .hours(0), value: 1.8),
             RepeatingScheduleValue(startTime: .hours(6), value: 2.1),
-            RepeatingScheduleValue(startTime: .hours(10), value: 1.4),
-            RepeatingScheduleValue(startTime: .hours(18), value: 2.1),
+            RepeatingScheduleValue(startTime: .hours(12), value: 1.4),
+            RepeatingScheduleValue(startTime: .hours(16), value: 2.1),
             RepeatingScheduleValue(startTime: .hours(20), value: 1.5)
         ])!
 
@@ -221,8 +221,8 @@ final class TemporaryScheduleOverrideHistoryTests: XCTestCase {
             RepeatingScheduleValue(startTime: .hours(0), value: 1.8),
             RepeatingScheduleValue(startTime: .hours(4), value: 1.2),
             RepeatingScheduleValue(startTime: .hours(6), value: 1.4),
-            RepeatingScheduleValue(startTime: .hours(20), value: 1.0),
-            RepeatingScheduleValue(startTime: .hours(22), value: 1.5),
+            RepeatingScheduleValue(startTime: .hours(20), value: 1.5),
+            //RepeatingScheduleValue(startTime: .hours(22), value: 1.5),
         ])!
 
         print(expected)

--- a/LoopKitTests/TemporaryScheduleOverrideHistoryTests.swift
+++ b/LoopKitTests/TemporaryScheduleOverrideHistoryTests.swift
@@ -222,10 +222,7 @@ final class TemporaryScheduleOverrideHistoryTests: XCTestCase {
             RepeatingScheduleValue(startTime: .hours(4), value: 1.2),
             RepeatingScheduleValue(startTime: .hours(6), value: 1.4),
             RepeatingScheduleValue(startTime: .hours(20), value: 1.5),
-            //RepeatingScheduleValue(startTime: .hours(22), value: 1.5),
         ])!
-
-        print(expected)
 
         XCTAssert(historyResolves(to: expected, referenceDateOffset: .hours(6)))
     }


### PR DESCRIPTION
This clears up some implicit dependencies that are non-obvious to change then default carb absorption is changed. 

https://tidepool.atlassian.net/browse/LOOP-492