### PR TITLE
LOOP-940: Support for new settings view

### DIFF
--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		1DABAD3A2453615200ACF708 /* IssueAlertTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DABAD392453615200ACF708 /* IssueAlertTableViewController.swift */; };
 		1DD1964E248AE88000420876 /* HorizontalSizeClassOverride.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD1964D248AE88000420876 /* HorizontalSizeClassOverride.swift */; };
 		1DD3DEB624451C3300BD8E40 /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649AA2445174400F61E75 /* Alert.swift */; };
+		1DE35E7A24ABEC720086F9AE /* DeviceManagerUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE35E7924ABEC720086F9AE /* DeviceManagerUI.swift */; };
 		1DEE226F24A676A300693C32 /* GlucoseStoreHKFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DEE226024A6642300693C32 /* GlucoseStoreHKFilterTests.swift */; };
 		1DEE227724A676A300693C32 /* HKHealthStoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 437AFF1E203A763F008C4892 /* HKHealthStoreMock.swift */; };
 		1DEE228424A676A300693C32 /* CarbStoreHKFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DEE226224A6642400693C32 /* CarbStoreHKFilterTests.swift */; };
@@ -816,6 +817,7 @@
 		1DA649AA2445174400F61E75 /* Alert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Alert.swift; sourceTree = "<group>"; };
 		1DABAD392453615200ACF708 /* IssueAlertTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueAlertTableViewController.swift; sourceTree = "<group>"; };
 		1DD1964D248AE88000420876 /* HorizontalSizeClassOverride.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalSizeClassOverride.swift; sourceTree = "<group>"; };
+		1DE35E7924ABEC720086F9AE /* DeviceManagerUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceManagerUI.swift; sourceTree = "<group>"; };
 		1DEE226024A6642300693C32 /* GlucoseStoreHKFilterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GlucoseStoreHKFilterTests.swift; sourceTree = "<group>"; };
 		1DEE226124A6642300693C32 /* DoseStoreHKFilterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DoseStoreHKFilterTests.swift; sourceTree = "<group>"; };
 		1DEE226224A6642400693C32 /* CarbStoreHKFilterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CarbStoreHKFilterTests.swift; sourceTree = "<group>"; };
@@ -1797,6 +1799,7 @@
 				43BA719920203EF30058961E /* CarbKit.storyboard */,
 				43A8EC3B210CEEA500A81379 /* CGMManagerUI.swift */,
 				892A5D9F2231E12F008961AB /* CompletionNotifying.swift */,
+				1DE35E7924ABEC720086F9AE /* DeviceManagerUI.swift */,
 				895FE07022011EDD00FCF18A /* EmojiInputController.storyboard */,
 				B42C950824A3BCC200857C73 /* GlucoseValueType+Color.swift */,
 				892A5DA12231E136008961AB /* HUDProvider.swift */,
@@ -3043,6 +3046,7 @@
 				B4C004D22416961300B40429 /* GuideNavigationButton.swift in Sources */,
 				89627B16244115A400BEB424 /* CardList.swift in Sources */,
 				89F6E311244A1AAB00CB9E15 /* SettingDescription.swift in Sources */,
+				1DE35E7A24ABEC720086F9AE /* DeviceManagerUI.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LoopKitUI/CGMManagerUI.swift
+++ b/LoopKitUI/CGMManagerUI.swift
@@ -8,14 +8,6 @@
 import LoopKit
 import HealthKit
 
-
-public protocol DeviceManagerUI {
-    // An image representing the device configuration
-    static var smallImage: UIImage? { get }
-    static var name: String { get }
-    static var details: String { get }
-}
-
 public protocol CGMManagerUI: CGMManager, DeviceManagerUI {
     /// Provides a view controller for setting up and configuring the manager if needed.
     ///
@@ -30,7 +22,6 @@ public protocol CGMManagerUI: CGMManager, DeviceManagerUI {
     /// the completed percent of the progress bar to display in the status bar
     var progressPercentCompleted: Double? { get }
 }
-
 
 public protocol CGMManagerSetupViewController {
     var setupDelegate: CGMManagerSetupViewControllerDelegate? { get set }

--- a/LoopKitUI/CGMManagerUI.swift
+++ b/LoopKitUI/CGMManagerUI.swift
@@ -9,15 +9,20 @@ import LoopKit
 import HealthKit
 
 
-public protocol CGMManagerUI: CGMManager {
+public protocol DeviceManagerUI {
+    // An image representing the device configuration
+    static var smallImage: UIImage? { get }
+    static var name: String { get }
+    static var details: String { get }
+}
+
+public protocol CGMManagerUI: CGMManager, DeviceManagerUI {
     /// Provides a view controller for setting up and configuring the manager if needed.
     ///
     /// If this method returns nil, it's expected that `init?(rawState: [:])` creates a non-nil manager
     static func setupViewController() -> (UIViewController & CGMManagerSetupViewController & CompletionNotifying)?
 
     func settingsViewController(for glucoseUnit: HKUnit) -> (UIViewController & CompletionNotifying)
-
-    var smallImage: UIImage? { get }
     
     /// a message from the cgm that needs to be brought to the user's attention in the status bar
     var cgmStatusHighlight: DeviceStatusHighlight? { get }

--- a/LoopKitUI/DeviceManagerUI.swift
+++ b/LoopKitUI/DeviceManagerUI.swift
@@ -6,23 +6,21 @@
 //  Copyright © 2020 LoopKit Authors. All rights reserved.
 //
 
-public protocol DeviceManagerUI {
-    /// An image representing the device configuration
-    static var image: UIImage? { get }
-    /// A localized name of the device to display to the user
-    static var name: String { get }
-    /// A localized detail description of the device to display to the user
-    static var details: String { get }
+import LoopKit
+
+public protocol DeviceManagerUI: DeviceManager {
+    /// An image representing this device (staticly available for presenting before the user chooses to set it up)
+    static var smallImage: UIImage? { get }
+    /// An image representing a device configuration after it is set up
+    var smallImage: UIImage? { get }
 }
 
 public extension DeviceManagerUI {
-    static var image: UIImage? { return nil }
-    static var name: String { return "" }
-    static var details: String { return "" }
+    static var smallImage: UIImage? { return nil }
 }
 
 public extension DeviceManagerUI {
     var smallImage: UIImage? {
-        return type(of: self).image
+        return type(of: self).smallImage
     }
 }

--- a/LoopKitUI/DeviceManagerUI.swift
+++ b/LoopKitUI/DeviceManagerUI.swift
@@ -9,16 +9,11 @@
 import LoopKit
 
 public protocol DeviceManagerUI: DeviceManager {
-    /// An image representing this device (staticly available for presenting before the user chooses to set it up)
-    static var smallImage: UIImage? { get }
     /// An image representing a device configuration after it is set up
     var smallImage: UIImage? { get }
 }
 
 public extension DeviceManagerUI {
     /// Default implementations
-    static var smallImage: UIImage? { return nil }
-    var smallImage: UIImage? {
-        return type(of: self).smallImage
-    }
+    var smallImage: UIImage? { return nil }
 }

--- a/LoopKitUI/DeviceManagerUI.swift
+++ b/LoopKitUI/DeviceManagerUI.swift
@@ -1,0 +1,28 @@
+//
+//  DeviceManagerUI.swift
+//  LoopKitUI
+//
+//  Created by Rick Pasetto on 6/30/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+public protocol DeviceManagerUI {
+    /// An image representing the device configuration
+    static var image: UIImage? { get }
+    /// A localized name of the device to display to the user
+    static var name: String { get }
+    /// A localized detail description of the device to display to the user
+    static var details: String { get }
+}
+
+public extension DeviceManagerUI {
+    static var image: UIImage? { return nil }
+    static var name: String { return "" }
+    static var details: String { return "" }
+}
+
+public extension DeviceManagerUI {
+    var smallImage: UIImage? {
+        return type(of: self).image
+    }
+}

--- a/LoopKitUI/DeviceManagerUI.swift
+++ b/LoopKitUI/DeviceManagerUI.swift
@@ -16,10 +16,8 @@ public protocol DeviceManagerUI: DeviceManager {
 }
 
 public extension DeviceManagerUI {
+    /// Default implementations
     static var smallImage: UIImage? { return nil }
-}
-
-public extension DeviceManagerUI {
     var smallImage: UIImage? {
         return type(of: self).smallImage
     }

--- a/LoopKitUI/DeviceManagerUI.swift
+++ b/LoopKitUI/DeviceManagerUI.swift
@@ -12,8 +12,3 @@ public protocol DeviceManagerUI: DeviceManager {
     /// An image representing a device configuration after it is set up
     var smallImage: UIImage? { get }
 }
-
-public extension DeviceManagerUI {
-    /// Default implementations
-    var smallImage: UIImage? { return nil }
-}

--- a/LoopKitUI/PumpManagerUI.swift
+++ b/LoopKitUI/PumpManagerUI.swift
@@ -8,14 +8,11 @@
 import UIKit
 import LoopKit
 
-public protocol PumpManagerUI: PumpManager, DeliveryLimitSettingsTableViewControllerSyncSource, BasalScheduleTableViewControllerSyncSource {
+public protocol PumpManagerUI: DeviceManagerUI, PumpManager, DeliveryLimitSettingsTableViewControllerSyncSource, BasalScheduleTableViewControllerSyncSource {
     
     static func setupViewController() -> (UIViewController & PumpManagerSetupViewController & CompletionNotifying)
 
     func settingsViewController() -> (UIViewController & CompletionNotifying)
-    
-    // An image representing the pump configuration
-    var smallImage: UIImage? { get }
     
     // Returns a class that can provide HUD views
     func hudProvider() -> HUDProvider?

--- a/MockKitUI/MockCGMManager+UI.swift
+++ b/MockKitUI/MockCGMManager+UI.swift
@@ -14,7 +14,7 @@ import MockKit
 
 
 extension MockCGMManager: CGMManagerUI {
-    public static var smallImage: UIImage? { UIImage(systemName: "dial") }
+    public var smallImage: UIImage? { UIImage(systemName: "dial") }
 
     public static func setupViewController() -> (UIViewController & CGMManagerSetupViewController & CompletionNotifying)? {
         return nil

--- a/MockKitUI/MockCGMManager+UI.swift
+++ b/MockKitUI/MockCGMManager+UI.swift
@@ -14,7 +14,7 @@ import MockKit
 
 
 extension MockCGMManager: CGMManagerUI {
-    public var smallImage: UIImage? { UIImage(systemName: "dial") }
+    public var smallImage: UIImage? { nil }  // TODO: come up with a better image
 
     public static func setupViewController() -> (UIViewController & CGMManagerSetupViewController & CompletionNotifying)? {
         return nil

--- a/MockKitUI/MockCGMManager+UI.swift
+++ b/MockKitUI/MockCGMManager+UI.swift
@@ -14,7 +14,7 @@ import MockKit
 
 
 extension MockCGMManager: CGMManagerUI {
-    public static var name: String { "CGM Simulator" }
+    public static var name: String { localizedTitle }
     public static var details: String { "Simulated CGM" }
     public static var image: UIImage? { UIImage(systemName: "dial") }
 

--- a/MockKitUI/MockCGMManager+UI.swift
+++ b/MockKitUI/MockCGMManager+UI.swift
@@ -16,7 +16,7 @@ import MockKit
 extension MockCGMManager: CGMManagerUI {
     public static var name: String { "CGM Simulator" }
     public static var details: String { "Simulated CGM" }
-    public static var smallImage: UIImage? { #imageLiteral(resourceName: "settings") }
+    public static var image: UIImage? { UIImage(systemName: "dial") }
 
     public static func setupViewController() -> (UIViewController & CGMManagerSetupViewController & CompletionNotifying)? {
         return nil

--- a/MockKitUI/MockCGMManager+UI.swift
+++ b/MockKitUI/MockCGMManager+UI.swift
@@ -14,6 +14,10 @@ import MockKit
 
 
 extension MockCGMManager: CGMManagerUI {
+    public static var name: String { "CGM Simulator" }
+    public static var details: String { "Simulated CGM" }
+    public static var smallImage: UIImage? { #imageLiteral(resourceName: "settings") }
+
     public static func setupViewController() -> (UIViewController & CGMManagerSetupViewController & CompletionNotifying)? {
         return nil
     }
@@ -22,10 +26,6 @@ extension MockCGMManager: CGMManagerUI {
         let settings = MockCGMManagerSettingsViewController(cgmManager: self, glucoseUnit: glucoseUnit)
         let nav = SettingsNavigationViewController(rootViewController: settings)
         return nav
-    }
-
-    public var smallImage: UIImage? {
-        return nil
     }
     
     public var cgmStatusHighlight: DeviceStatusHighlight? {

--- a/MockKitUI/MockCGMManager+UI.swift
+++ b/MockKitUI/MockCGMManager+UI.swift
@@ -14,9 +14,7 @@ import MockKit
 
 
 extension MockCGMManager: CGMManagerUI {
-    public static var name: String { localizedTitle }
-    public static var details: String { "Simulated CGM" }
-    public static var image: UIImage? { UIImage(systemName: "dial") }
+    public static var smallImage: UIImage? { UIImage(systemName: "dial") }
 
     public static func setupViewController() -> (UIViewController & CGMManagerSetupViewController & CompletionNotifying)? {
         return nil

--- a/MockKitUI/MockPumpManager+UI.swift
+++ b/MockKitUI/MockPumpManager+UI.swift
@@ -11,12 +11,9 @@ import LoopKit
 import LoopKitUI
 import MockKit
 
-private class FrameworkBundle {
-    static let main = Bundle(for: FrameworkBundle.self)
-}
 
 extension MockPumpManager: PumpManagerUI {
-    public var smallImage: UIImage? { return UIImage(named: "Simulator Small", in: FrameworkBundle.main, with: nil) }
+    public var smallImage: UIImage? { return UIImage(named: "Simulator Small", in: Bundle(for: MockPumpManagerSettingsViewController.self), compatibleWith: nil) }
 
     public static func setupViewController() -> (UIViewController & CompletionNotifying & PumpManagerSetupViewController) {
         return MockPumpManagerSetupViewController.instantiateFromStoryboard()

--- a/MockKitUI/MockPumpManager+UI.swift
+++ b/MockKitUI/MockPumpManager+UI.swift
@@ -18,7 +18,7 @@ private class FrameworkBundle {
 extension MockPumpManager: PumpManagerUI {
     public static var name: String { "Pump Simulator" }
     public static var details: String { "Simulated Pump" }
-    public static var smallImage: UIImage? { return UIImage(named: "Simulator Small", in: FrameworkBundle.main, with: nil) }
+    public static var image: UIImage? { return UIImage(named: "Simulator Small", in: FrameworkBundle.main, with: nil) }
 
     public static func setupViewController() -> (UIViewController & CompletionNotifying & PumpManagerSetupViewController) {
         return MockPumpManagerSetupViewController.instantiateFromStoryboard()

--- a/MockKitUI/MockPumpManager+UI.swift
+++ b/MockKitUI/MockPumpManager+UI.swift
@@ -11,8 +11,15 @@ import LoopKit
 import LoopKitUI
 import MockKit
 
+private class FrameworkBundle {
+    static let main = Bundle(for: FrameworkBundle.self)
+}
 
 extension MockPumpManager: PumpManagerUI {
+    public static var name: String { "Pump Simulator" }
+    public static var details: String { "Simulated Pump" }
+    public static var smallImage: UIImage? { return UIImage(named: "Simulator Small", in: FrameworkBundle.main, with: nil) }
+
     public static func setupViewController() -> (UIViewController & CompletionNotifying & PumpManagerSetupViewController) {
         return MockPumpManagerSetupViewController.instantiateFromStoryboard()
     }
@@ -21,10 +28,6 @@ extension MockPumpManager: PumpManagerUI {
         let settings = MockPumpManagerSettingsViewController(pumpManager: self)
         let nav = SettingsNavigationViewController(rootViewController: settings)
         return nav
-    }
-
-    public var smallImage: UIImage? {
-        return UIImage(named: "Simulator Small", in: Bundle(for: MockPumpManagerSettingsViewController.self), compatibleWith: nil)
     }
 
     public func hudProvider() -> HUDProvider? {

--- a/MockKitUI/MockPumpManager+UI.swift
+++ b/MockKitUI/MockPumpManager+UI.swift
@@ -16,7 +16,7 @@ private class FrameworkBundle {
 }
 
 extension MockPumpManager: PumpManagerUI {
-    public static var name: String { "Pump Simulator" }
+    public static var name: String { localizedTitle }
     public static var details: String { "Simulated Pump" }
     public static var image: UIImage? { return UIImage(named: "Simulator Small", in: FrameworkBundle.main, with: nil) }
 

--- a/MockKitUI/MockPumpManager+UI.swift
+++ b/MockKitUI/MockPumpManager+UI.swift
@@ -16,7 +16,7 @@ private class FrameworkBundle {
 }
 
 extension MockPumpManager: PumpManagerUI {
-    public static var smallImage: UIImage? { return UIImage(named: "Simulator Small", in: FrameworkBundle.main, with: nil) }
+    public var smallImage: UIImage? { return UIImage(named: "Simulator Small", in: FrameworkBundle.main, with: nil) }
 
     public static func setupViewController() -> (UIViewController & CompletionNotifying & PumpManagerSetupViewController) {
         return MockPumpManagerSetupViewController.instantiateFromStoryboard()

--- a/MockKitUI/MockPumpManager+UI.swift
+++ b/MockKitUI/MockPumpManager+UI.swift
@@ -16,9 +16,7 @@ private class FrameworkBundle {
 }
 
 extension MockPumpManager: PumpManagerUI {
-    public static var name: String { localizedTitle }
-    public static var details: String { "Simulated Pump" }
-    public static var image: UIImage? { return UIImage(named: "Simulator Small", in: FrameworkBundle.main, with: nil) }
+    public static var smallImage: UIImage? { return UIImage(named: "Simulator Small", in: FrameworkBundle.main, with: nil) }
 
     public static func setupViewController() -> (UIViewController & CompletionNotifying & PumpManagerSetupViewController) {
         return MockPumpManagerSetupViewController.instantiateFromStoryboard()


### PR DESCRIPTION
Includes:
- Adding new `DeviceManagerUI` protocol for vending device information as static information (i.e. before the device is set up, it can be queried from the list of available plugins without constructing the device)
- Mock support for above

Also see https://github.com/tidepool-org/Loop/pull/135

[LOOP-940](https://tidepool.atlassian.net/browse/LOOP-940)

LW PR: https://github.com/tidepool-org/LoopWorkspace/pull/140