### PR TITLE
Unify Therapy Settings copy from the text from IFU-24

### DIFF
--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		1D1FCE2524BD42EF000300A8 /* TherapySettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FCE2424BD42EF000300A8 /* TherapySettingsViewModel.swift */; };
 		1D1FCE2724BE4DE2000300A8 /* CorrectionRangeOverrides.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FCE2624BE4DE2000300A8 /* CorrectionRangeOverrides.swift */; };
 		1D1FCE2924BE4F11000300A8 /* TherapySetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FCE2824BE4F11000300A8 /* TherapySetting.swift */; };
+		1D1FCE2B24BE704A000300A8 /* TherapySettingExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FCE2A24BE704A000300A8 /* TherapySettingExtension.swift */; };
 		1D25C22E246A2A1A00E87FA0 /* critical.caf in Resources */ = {isa = PBXBuildFile; fileRef = 1D25C22D246A2A1A00E87FA0 /* critical.caf */; };
 		1D4990E624A17564005CC357 /* HKQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4990E524A17564005CC357 /* HKQuery.swift */; };
 		1D4990E724A17898005CC357 /* HKQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4990E524A17564005CC357 /* HKQuery.swift */; };
@@ -835,6 +836,7 @@
 		1D1FCE2424BD42EF000300A8 /* TherapySettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TherapySettingsViewModel.swift; sourceTree = "<group>"; };
 		1D1FCE2624BE4DE2000300A8 /* CorrectionRangeOverrides.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectionRangeOverrides.swift; sourceTree = "<group>"; };
 		1D1FCE2824BE4F11000300A8 /* TherapySetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TherapySetting.swift; sourceTree = "<group>"; };
+		1D1FCE2A24BE704A000300A8 /* TherapySettingExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TherapySettingExtension.swift; sourceTree = "<group>"; };
 		1D25C22D246A2A1A00E87FA0 /* critical.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = critical.caf; sourceTree = "<group>"; };
 		1D4990E524A17564005CC357 /* HKQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HKQuery.swift; sourceTree = "<group>"; };
 		1D640FF524524284008F9755 /* sub.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = sub.caf; sourceTree = "<group>"; };
@@ -2416,6 +2418,7 @@
 				898B4E7A246DC6A70053C484 /* CorrectionRangeScheduleEditor.swift */,
 				89FC688A245A2D670075CF59 /* InsulinSensitivityScheduleEditor.swift */,
 				E96DCB5924AF74AC007117BC /* SuspendThresholdEditor.swift */,
+				1D1FCE2A24BE704A000300A8 /* TherapySettingExtension.swift */,
 				1D1A019D24B678BF0077D86E /* TherapySettingsView.swift */,
 				1D1FCE2424BD42EF000300A8 /* TherapySettingsViewModel.swift */,
 			);
@@ -3022,6 +3025,7 @@
 				893C9F8C2447DBD900CD4185 /* CardBuilder.swift in Sources */,
 				89BE75C524649C8100B145D9 /* NewScheduleItemEditor.swift in Sources */,
 				89653C822473592600E1BAA5 /* CarbRatioScheduleEditor.swift in Sources */,
+				1D1FCE2B24BE704A000300A8 /* TherapySettingExtension.swift in Sources */,
 				4369F08F208859E6000E3E45 /* PaddedTextField.swift in Sources */,
 				A9498D8823386CAF00DAA9B9 /* ServiceViewController.swift in Sources */,
 				892A5D9E2231E122008961AB /* StateColorPalette.swift in Sources */,

--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		1D1A019E24B678BF0077D86E /* TherapySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1A019D24B678BF0077D86E /* TherapySettingsView.swift */; };
 		1D1FCE2324BD13A2000300A8 /* CorrectionRangeOverridesExpandableSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FCE2224BD13A2000300A8 /* CorrectionRangeOverridesExpandableSetting.swift */; };
 		1D1FCE2524BD42EF000300A8 /* TherapySettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FCE2424BD42EF000300A8 /* TherapySettingsViewModel.swift */; };
+		1D1FCE2724BE4DE2000300A8 /* CorrectionRangeOverrides.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FCE2624BE4DE2000300A8 /* CorrectionRangeOverrides.swift */; };
+		1D1FCE2924BE4F11000300A8 /* TherapySetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FCE2824BE4F11000300A8 /* TherapySetting.swift */; };
 		1D25C22E246A2A1A00E87FA0 /* critical.caf in Resources */ = {isa = PBXBuildFile; fileRef = 1D25C22D246A2A1A00E87FA0 /* critical.caf */; };
 		1D4990E624A17564005CC357 /* HKQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4990E524A17564005CC357 /* HKQuery.swift */; };
 		1D4990E724A17898005CC357 /* HKQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4990E524A17564005CC357 /* HKQuery.swift */; };
@@ -830,6 +832,8 @@
 		1D1A019D24B678BF0077D86E /* TherapySettingsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TherapySettingsView.swift; sourceTree = "<group>"; };
 		1D1FCE2224BD13A2000300A8 /* CorrectionRangeOverridesExpandableSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectionRangeOverridesExpandableSetting.swift; sourceTree = "<group>"; };
 		1D1FCE2424BD42EF000300A8 /* TherapySettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TherapySettingsViewModel.swift; sourceTree = "<group>"; };
+		1D1FCE2624BE4DE2000300A8 /* CorrectionRangeOverrides.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectionRangeOverrides.swift; sourceTree = "<group>"; };
+		1D1FCE2824BE4F11000300A8 /* TherapySetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TherapySetting.swift; sourceTree = "<group>"; };
 		1D25C22D246A2A1A00E87FA0 /* critical.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = critical.caf; sourceTree = "<group>"; };
 		1D4990E524A17564005CC357 /* HKQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HKQuery.swift; sourceTree = "<group>"; };
 		1D640FF524524284008F9755 /* sub.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = sub.caf; sourceTree = "<group>"; };
@@ -1987,6 +1991,8 @@
 				C16DA83E22E8D88F008624C2 /* LoopPlugin.swift */,
 				89F6E30E244A1A5D00CB9E15 /* Guardrail.swift */,
 				E9086B3824B3CB4B0062F5C8 /* TherapySettings.swift */,
+				1D1FCE2624BE4DE2000300A8 /* CorrectionRangeOverrides.swift */,
+				1D1FCE2824BE4F11000300A8 /* TherapySetting.swift */,
 			);
 			path = LoopKit;
 			sourceTree = "<group>";
@@ -3263,6 +3269,8 @@
 				43FB60EB20DDC868002B996B /* SetBolusError.swift in Sources */,
 				4322B770202FA26F0002837D /* GlucoseStore.swift in Sources */,
 				C1814B8C226371DF008D2D8E /* WeakSynchronizedDelegate.swift in Sources */,
+				1D1FCE2724BE4DE2000300A8 /* CorrectionRangeOverrides.swift in Sources */,
+				1D1FCE2924BE4F11000300A8 /* TherapySetting.swift in Sources */,
 				4352A73C20DECF0700CAC200 /* CGMManager.swift in Sources */,
 				4353D16F203D104F007B4ECD /* CarbStoreError.swift in Sources */,
 				43AF1FB21C926CDD00EA2F3D /* HKQuantity.swift in Sources */,

--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		1D841AAD24577EE10069DBFF /* AlertSoundPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D841AAC24577EE10069DBFF /* AlertSoundPlayer.swift */; };
 		1DA649AB2445174400F61E75 /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649AA2445174400F61E75 /* Alert.swift */; };
 		1DABAD3A2453615200ACF708 /* IssueAlertTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DABAD392453615200ACF708 /* IssueAlertTableViewController.swift */; };
+		1DC64C7C24BF6BFD004A63A1 /* CorrectionRangeOverridesExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC64C7B24BF6BFD004A63A1 /* CorrectionRangeOverridesExtension.swift */; };
+		1DC64C7E24BF6EBC004A63A1 /* DeliveryLimits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC64C7D24BF6EBC004A63A1 /* DeliveryLimits.swift */; };
 		1DD1964E248AE88000420876 /* HorizontalSizeClassOverride.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD1964D248AE88000420876 /* HorizontalSizeClassOverride.swift */; };
 		1DD3DEB624451C3300BD8E40 /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649AA2445174400F61E75 /* Alert.swift */; };
 		1DE35E7A24ABEC720086F9AE /* DeviceManagerUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE35E7924ABEC720086F9AE /* DeviceManagerUI.swift */; };
@@ -843,6 +845,8 @@
 		1D841AAC24577EE10069DBFF /* AlertSoundPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertSoundPlayer.swift; sourceTree = "<group>"; };
 		1DA649AA2445174400F61E75 /* Alert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Alert.swift; sourceTree = "<group>"; };
 		1DABAD392453615200ACF708 /* IssueAlertTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueAlertTableViewController.swift; sourceTree = "<group>"; };
+		1DC64C7B24BF6BFD004A63A1 /* CorrectionRangeOverridesExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectionRangeOverridesExtension.swift; sourceTree = "<group>"; };
+		1DC64C7D24BF6EBC004A63A1 /* DeliveryLimits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryLimits.swift; sourceTree = "<group>"; };
 		1DD1964D248AE88000420876 /* HorizontalSizeClassOverride.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalSizeClassOverride.swift; sourceTree = "<group>"; };
 		1DE35E7924ABEC720086F9AE /* DeviceManagerUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceManagerUI.swift; sourceTree = "<group>"; };
 		1DEE226024A6642300693C32 /* GlucoseStoreHKFilterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GlucoseStoreHKFilterTests.swift; sourceTree = "<group>"; };
@@ -1997,6 +2001,7 @@
 				E9086B3824B3CB4B0062F5C8 /* TherapySettings.swift */,
 				1D1FCE2624BE4DE2000300A8 /* CorrectionRangeOverrides.swift */,
 				1D1FCE2824BE4F11000300A8 /* TherapySetting.swift */,
+				1DC64C7D24BF6EBC004A63A1 /* DeliveryLimits.swift */,
 			);
 			path = LoopKit;
 			sourceTree = "<group>";
@@ -2415,6 +2420,7 @@
 				89653C812473592600E1BAA5 /* CarbRatioScheduleEditor.swift */,
 				E916F56824AD32F000BE3547 /* CorrectionRangeOverridesEditor.swift */,
 				1D1FCE2224BD13A2000300A8 /* CorrectionRangeOverridesExpandableSetting.swift */,
+				1DC64C7B24BF6BFD004A63A1 /* CorrectionRangeOverridesExtension.swift */,
 				898B4E7A246DC6A70053C484 /* CorrectionRangeScheduleEditor.swift */,
 				89FC688A245A2D670075CF59 /* InsulinSensitivityScheduleEditor.swift */,
 				E96DCB5924AF74AC007117BC /* SuspendThresholdEditor.swift */,
@@ -3087,6 +3093,7 @@
 				1DD1964E248AE88000420876 /* HorizontalSizeClassOverride.swift in Sources */,
 				892A5D9C2231E118008961AB /* UIAlertController.swift in Sources */,
 				43BA7181201EE7090058961E /* RepeatingScheduleValueTableViewCell.swift in Sources */,
+				1DC64C7C24BF6BFD004A63A1 /* CorrectionRangeOverridesExtension.swift in Sources */,
 				43BA716E201E49220058961E /* DecimalTextFieldTableViewCell.swift in Sources */,
 				891A3FC72247268F00378B27 /* Math.swift in Sources */,
 				895FE08722011F0C00FCF18A /* EmojiInputCell.swift in Sources */,
@@ -3273,6 +3280,7 @@
 				433BC7AB20538D4C000B1200 /* CachedGlucoseObject+CoreDataProperties.swift in Sources */,
 				43FB610720DDF19B002B996B /* PumpManagerError.swift in Sources */,
 				89AE2232228BC68600BDFD85 /* UnfairLock.swift in Sources */,
+				1DC64C7E24BF6EBC004A63A1 /* DeliveryLimits.swift in Sources */,
 				A9498D8423386C3300DAA9B9 /* DiagnosticLog.swift in Sources */,
 				43FB60EB20DDC868002B996B /* SetBolusError.swift in Sources */,
 				4322B770202FA26F0002837D /* GlucoseStore.swift in Sources */,

--- a/LoopKit/CorrectionRangeOverrides.swift
+++ b/LoopKit/CorrectionRangeOverrides.swift
@@ -27,8 +27,17 @@ public struct CorrectionRangeOverrides: Equatable {
     public var workout: ClosedRange<HKQuantity>? { ranges[.workout] }
 }
 
-extension CorrectionRangeOverrides.Preset {
-    public var descriptiveText: String {
+public extension CorrectionRangeOverrides.Preset {
+    var title: String {
+        switch self {
+        case .preMeal:
+            return LocalizedString("Pre-Meal", comment: "Title for pre-meal mode")
+        case .workout:
+            return LocalizedString("Workout", comment: "Title for workout mode")
+        }
+    }
+    
+    var descriptiveText: String {
         switch self {
         case .preMeal:
             return LocalizedString("Temporarily lower your glucose target before a meal to impact post-meal glucose spikes.", comment: "Description of pre-meal mode")

--- a/LoopKit/CorrectionRangeOverrides.swift
+++ b/LoopKit/CorrectionRangeOverrides.swift
@@ -1,0 +1,39 @@
+//
+//  CorrectionRangeOverrides.swift
+//  LoopKit
+//
+//  Created by Rick Pasetto on 7/14/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import HealthKit
+import Foundation
+
+public struct CorrectionRangeOverrides: Equatable {
+    public enum Preset: Hashable, CaseIterable {
+        case preMeal
+        case workout
+    }
+
+    public var ranges: [Preset: ClosedRange<HKQuantity>]
+
+    public init(preMeal: DoubleRange?, workout: DoubleRange?, unit: HKUnit) {
+        ranges = [:]
+        ranges[.preMeal] = preMeal?.quantityRange(for: unit)
+        ranges[.workout] = workout?.quantityRange(for: unit)
+    }
+
+    public var preMeal: ClosedRange<HKQuantity>? { ranges[.preMeal] }
+    public var workout: ClosedRange<HKQuantity>? { ranges[.workout] }
+}
+
+extension CorrectionRangeOverrides.Preset {
+    public var descriptiveText: String {
+        switch self {
+        case .preMeal:
+            return LocalizedString("Temporarily lower your glucose target before a meal to impact post-meal glucose spikes.", comment: "Description of pre-meal mode")
+        case .workout:
+            return LocalizedString("Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events.", comment: "Description of workout mode")
+        }
+    }
+}

--- a/LoopKit/DeliveryLimits.swift
+++ b/LoopKit/DeliveryLimits.swift
@@ -1,0 +1,56 @@
+//
+//  DeliveryLimits.swift
+//  LoopKit
+//
+//  Created by Rick Pasetto on 7/15/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import HealthKit
+
+public struct DeliveryLimits: Equatable {
+    public enum Setting: Equatable {
+        case maximumBasalRate
+        case maximumBolus
+    }
+
+    private var settings: [Setting: HKQuantity]
+
+    public init(maximumBasalRate: HKQuantity?, maximumBolus: HKQuantity?) {
+        settings = [:]
+        settings[.maximumBasalRate] = maximumBasalRate
+        settings[.maximumBolus] = maximumBolus
+    }
+
+    public var maximumBasalRate: HKQuantity? {
+        get { settings[.maximumBasalRate] }
+        set { settings[.maximumBasalRate] = newValue }
+    }
+
+    public var maximumBolus: HKQuantity? {
+        get { settings[.maximumBolus] }
+        set { settings[.maximumBolus] = newValue }
+    }
+}
+
+public extension DeliveryLimits.Setting {
+    // The following comes from https://tidepool.atlassian.net/browse/IFU-24
+    var title: String {
+        switch self {
+        case .maximumBasalRate:
+            return LocalizedString("Maximum Basal Rate", comment: "Title text for maximum basal rate configuration")
+        case .maximumBolus:
+            return LocalizedString("Maximum Bolus", comment: "Title text for maximum bolus configuration")
+        }
+    }
+    
+    var descriptiveText: String {
+        switch self {
+        case .maximumBasalRate:
+            return LocalizedString("Maximum basal rate is the highest temporary basal rate Tidepool Loop is allowed to set automatically.", comment: "Descriptive text for maximum basal rate")
+        case .maximumBolus:
+            return LocalizedString("Maximum bolus is the highest bolus amount you can deliver at one time to cover carbs or bring down high glucose.", comment: "Descriptive text for maximum bolus")
+        }
+    }
+}
+

--- a/LoopKit/TherapySetting.swift
+++ b/LoopKit/TherapySetting.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 LoopKit Authors. All rights reserved.
 //
 
+
 public enum TherapySetting: Int {
     case glucoseTargetRange
     case correctionRangeOverrides
@@ -20,26 +21,54 @@ public enum TherapySetting: Int {
 
 public extension TherapySetting {
     
+    // The following comes from https://tidepool.atlassian.net/browse/IFU-24
+    var title: String {
+        switch self {
+        case .glucoseTargetRange:
+            return LocalizedString("Correction Range", comment: "Title text for glucose target range")
+        case .correctionRangeOverrides:
+            return LocalizedString("Pre-Meal and Workout Correction Range", comment: "Title text for correction range overrides")
+        case .suspendThreshold:
+            return LocalizedString("Suspend Threshold", comment: "Title text for suspend threshold")
+        case .basalRate:
+            return LocalizedString("Basal Rate", comment: "Title text for basal rate")
+        case .deliveryLimits:
+            return LocalizedString("Delivery Limits", comment: "Title text for delivery limits")
+        case .insulinModel:
+            return LocalizedString("Insulin Model", comment: "Title text for insulin model")
+        case .carbRatio:
+            return LocalizedString("Carb Ratio", comment: "Title text for carb ratio")
+        case .insulinSensitivity:
+            return LocalizedString("Insulin Sensitivities", comment: "Title text for insulin sensitivity")
+        case .none:
+            return ""
+        }
+    }
+    
     var descriptiveText: String {
         switch self {
         case .glucoseTargetRange:
-            <#code#>
+            return LocalizedString("Correction range is the glucose value (or range of values) that you want Tidepool Loop to aim for in adjusting your basal insulin.", comment: "Descriptive text for glucose target range")
         case .correctionRangeOverrides:
-            <#code#>
+            return LocalizedString("Pre-Meal and Workout ranges temporarily adjust your glucose target based on your selected activity.", comment: "Descriptive text for correction range overrides")
         case .suspendThreshold:
-            <#code#>
+            return LocalizedString("When your glucose is predicted to go below this value, the app will recommend a basal rate of 0 U and will not recommend a bolus.", comment: "Descriptive text for suspend threshold")
         case .basalRate:
-            <#code#>
+            return LocalizedString("Your basal rate of insulin is the number of units per hour that you want to use to cover your background insulin needs.", comment: "Descriptive text for basal rate")
         case .deliveryLimits:
-            <#code#>
+            return LocalizedString("""
+                Maximum basal rate is the highest temporary basal rate Tidepool Loop is allowed to set automatically.
+
+                Maximum bolus is the highest bolus amount you can deliver at one time to cover carbs or bring down high glucose.
+            """, comment: "Descriptive text for delivery limits")
         case .insulinModel:
-            <#code#>
+            return LocalizedString("The app assumes insulin is actively working for 6 hours. You can choose from two different models for how the app measures the insulin’s peak activity.", comment: "Descriptive text for insulin model")
         case .carbRatio:
-            <#code#>
+            return LocalizedString("Your carb ratio is the number of grams of carbohydrate covered by one unit of insulin.", comment: "Descriptive text for carb ratio")
         case .insulinSensitivity:
-            <#code#>
+            return LocalizedString("Your insulin sensitivities refer to the mg/dL drop in glucose expected from one unit of insulin.", comment: "Descriptive text for insulin sensitivity")
         case .none:
-            <#code#>
+            return ""
         }
     }
 }

--- a/LoopKit/TherapySetting.swift
+++ b/LoopKit/TherapySetting.swift
@@ -1,0 +1,45 @@
+//
+//  TherapySetting.swift
+//  LoopKit
+//
+//  Created by Rick Pasetto on 7/14/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+public enum TherapySetting: Int {
+    case glucoseTargetRange
+    case correctionRangeOverrides
+    case suspendThreshold
+    case basalRate
+    case deliveryLimits
+    case insulinModel
+    case carbRatio
+    case insulinSensitivity
+    case none
+}
+
+public extension TherapySetting {
+    
+    var descriptiveText: String {
+        switch self {
+        case .glucoseTargetRange:
+            <#code#>
+        case .correctionRangeOverrides:
+            <#code#>
+        case .suspendThreshold:
+            <#code#>
+        case .basalRate:
+            <#code#>
+        case .deliveryLimits:
+            <#code#>
+        case .insulinModel:
+            <#code#>
+        case .carbRatio:
+            <#code#>
+        case .insulinSensitivity:
+            <#code#>
+        case .none:
+            <#code#>
+        }
+    }
+}

--- a/LoopKit/TherapySetting.swift
+++ b/LoopKit/TherapySetting.swift
@@ -52,21 +52,17 @@ public extension TherapySetting {
         case .correctionRangeOverrides:
             return LocalizedString("Pre-Meal and Workout ranges temporarily adjust your glucose target based on your selected activity.", comment: "Descriptive text for correction range overrides")
         case .suspendThreshold:
-            return LocalizedString("When your glucose is predicted to go below this value, the app will recommend a basal rate of 0 U and will not recommend a bolus.", comment: "Descriptive text for suspend threshold")
+            return LocalizedString("When your glucose is predicted to go below this value, the app will recommend a basal rate of 0 U/hr and will not recommend a bolus.", comment: "Descriptive text for suspend threshold")
         case .basalRate:
             return LocalizedString("Your basal rate of insulin is the number of units per hour that you want to use to cover your background insulin needs.", comment: "Descriptive text for basal rate")
         case .deliveryLimits:
-            return LocalizedString("""
-                Maximum basal rate is the highest temporary basal rate Tidepool Loop is allowed to set automatically.
-
-                Maximum bolus is the highest bolus amount you can deliver at one time to cover carbs or bring down high glucose.
-            """, comment: "Descriptive text for delivery limits")
+            return "\(DeliveryLimits.Setting.maximumBasalRate.descriptiveText)\n\n\(DeliveryLimits.Setting.maximumBolus.descriptiveText)"
         case .insulinModel:
             return LocalizedString("The app assumes insulin is actively working for 6 hours. You can choose from two different models for how the app measures the insulin’s peak activity.", comment: "Descriptive text for insulin model")
         case .carbRatio:
             return LocalizedString("Your carb ratio is the number of grams of carbohydrate covered by one unit of insulin.", comment: "Descriptive text for carb ratio")
         case .insulinSensitivity:
-            return LocalizedString("Your insulin sensitivities refer to the mg/dL drop in glucose expected from one unit of insulin.", comment: "Descriptive text for insulin sensitivity")
+            return LocalizedString("Your insulin sensitivities refer to the drop in glucose expected from one unit of insulin.", comment: "Descriptive text for insulin sensitivity")
         case .none:
             return ""
         }

--- a/LoopKit/TherapySetting.swift
+++ b/LoopKit/TherapySetting.swift
@@ -27,7 +27,7 @@ public extension TherapySetting {
         case .glucoseTargetRange:
             return LocalizedString("Correction Range", comment: "Title text for glucose target range")
         case .correctionRangeOverrides:
-            return LocalizedString("Pre-Meal and Workout Correction Range", comment: "Title text for correction range overrides")
+            return LocalizedString("Temporary Correction Ranges", comment: "Title text for temporary correction ranges")
         case .suspendThreshold:
             return LocalizedString("Suspend Threshold", comment: "Title text for suspend threshold")
         case .basalRate:

--- a/LoopKitUI/Views/Information Screens/CorrectionRangeOverrideInformationView.swift
+++ b/LoopKitUI/Views/Information Screens/CorrectionRangeOverrideInformationView.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 LoopKit Authors. All rights reserved.
 //
 
+import LoopKit
 import SwiftUI
 
 public struct CorrectionRangeOverrideInformationView: View {

--- a/LoopKitUI/Views/SettingDescription.swift
+++ b/LoopKitUI/Views/SettingDescription.swift
@@ -8,32 +8,6 @@
 
 import SwiftUI
 
-public enum TherapySetting: Int {
-    case glucoseTargetRange
-    case correctionRangeOverrides
-    case suspendThreshold
-    case basalRate
-    case deliveryLimits
-    case insulinModel
-    case carbRatio
-    case insulinSensitivity
-    case none
-    
-    public func helpScreen() -> some View {
-        switch self {
-        case .glucoseTargetRange:
-            return AnyView(CorrectionRangeInformationView(onExit: nil, mode: .modal))
-        case .correctionRangeOverrides:
-            return AnyView(CorrectionRangeOverrideInformationView(onExit: nil, mode: .modal))
-        case .suspendThreshold:
-            return AnyView(SuspendThresholdInformationView(onExit: nil, mode: .modal))
-        // ANNA TODO: add more once other instructional screens are created
-        default:
-            return AnyView(Text("To be implemented"))
-        }
-    }
-}
-
 public struct SettingDescription<InformationalContent: View>: View {
     var text: Text
     var informationalContent: InformationalContent

--- a/LoopKitUI/Views/Settings Editors/BasalRateScheduleEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/BasalRateScheduleEditor.swift
@@ -57,7 +57,7 @@ public struct BasalRateScheduleEditor: View {
 
     public var body: some View {
         QuantityScheduleEditor(
-            title: Text("Basal Rates", comment: "Title of basal rate settings page"),
+            title: Text(TherapySetting.basalRate.title),
             description: description,
             schedule: schedule,
             unit: .internationalUnitsPerHour,
@@ -91,7 +91,7 @@ public struct BasalRateScheduleEditor: View {
     }
 
     private var description: Text {
-        Text("Your basal rate of insulin is the number of units per hour that you want to use to cover your background insulin needs.", comment: "Basal rate setting description")
+        Text(TherapySetting.basalRate.descriptiveText)
     }
 
     private var confirmationAlertContent: AlertContent {

--- a/LoopKitUI/Views/Settings Editors/CarbRatioScheduleEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CarbRatioScheduleEditor.swift
@@ -45,7 +45,7 @@ public struct CarbRatioScheduleEditor: View {
 
     public var body: some View {
         QuantityScheduleEditor(
-            title: Text("Carb Ratios", comment: "Title of carb ratio settings page"),
+            title: Text(TherapySetting.carbRatio.title),
             description: description,
             schedule: schedule,
             unit: .realCarbRatioScheduleUnit,
@@ -63,7 +63,7 @@ public struct CarbRatioScheduleEditor: View {
     }
 
     private var description: Text {
-        Text("Your carb ratio is the number of grams of carbohydrate covered by one unit of insulin.", comment: "Carb ratio setting description")
+        Text(TherapySetting.carbRatio.descriptiveText)
     }
 
     private var confirmationAlertContent: AlertContent {

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
@@ -72,7 +72,7 @@ public struct CorrectionRangeOverridesEditor: View {
 
     public var body: some View {
         ConfigurationPage(
-            title: Text("Temporary\nCorrection Ranges", comment: "Title for temporary correction ranges page"),
+            title: Text(TherapySetting.correctionRangeOverrides.title),
             actionButtonTitle: buttonText,
             actionButtonState: value != initialValue || mode == .flow ? .enabled : .disabled,
             cards: {

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
@@ -10,23 +10,21 @@ import SwiftUI
 import HealthKit
 import LoopKit
 
-
-public struct CorrectionRangeOverrides: Equatable {
-    enum Preset: Hashable, CaseIterable {
-        case preMeal
-        case workout
+extension TherapySetting {
+    
+    public func helpScreen() -> some View {
+        switch self {
+        case .glucoseTargetRange:
+            return AnyView(CorrectionRangeInformationView(onExit: nil, mode: .modal))
+        case .correctionRangeOverrides:
+            return AnyView(CorrectionRangeOverrideInformationView(onExit: nil, mode: .modal))
+        case .suspendThreshold:
+            return AnyView(SuspendThresholdInformationView(onExit: nil, mode: .modal))
+        // ANNA TODO: add more once other instructional screens are created
+        default:
+            return AnyView(Text("To be implemented"))
+        }
     }
-
-    var ranges: [Preset: ClosedRange<HKQuantity>]
-
-    public init(preMeal: DoubleRange?, workout: DoubleRange?, unit: HKUnit) {
-        ranges = [:]
-        ranges[.preMeal] = preMeal?.quantityRange(for: unit)
-        ranges[.workout] = workout?.quantityRange(for: unit)
-    }
-
-    public var preMeal: ClosedRange<HKQuantity>? { ranges[.preMeal] }
-    public var workout: ClosedRange<HKQuantity>? { ranges[.workout] }
 }
 
 public struct CorrectionRangeOverridesEditor: View {
@@ -138,9 +136,9 @@ public struct CorrectionRangeOverridesEditor: View {
     private func description(of preset: CorrectionRangeOverrides.Preset) -> Text {
         switch preset {
         case .preMeal:
-            return Text("Temporarily lower your glucose target before a meal to impact post-meal glucose spikes.", comment: "Description of pre-meal mode")
+            return Text(preset.descriptiveText)
         case .workout:
-            return Text("Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events.", comment: "Description of workout mode")
+            return Text(preset.descriptiveText)
         }
     }
     

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
@@ -10,23 +10,6 @@ import SwiftUI
 import HealthKit
 import LoopKit
 
-extension TherapySetting {
-    
-    public func helpScreen() -> some View {
-        switch self {
-        case .glucoseTargetRange:
-            return AnyView(CorrectionRangeInformationView(onExit: nil, mode: .modal))
-        case .correctionRangeOverrides:
-            return AnyView(CorrectionRangeOverrideInformationView(onExit: nil, mode: .modal))
-        case .suspendThreshold:
-            return AnyView(SuspendThresholdInformationView(onExit: nil, mode: .modal))
-        // ANNA TODO: add more once other instructional screens are created
-        default:
-            return AnyView(Text("To be implemented"))
-        }
-    }
-}
-
 public struct CorrectionRangeOverridesEditor: View {
     var initialValue: CorrectionRangeOverrides
     var unit: HKUnit

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesExpandableSetting.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesExpandableSetting.swift
@@ -24,8 +24,8 @@ public struct CorrectionRangeOverridesExpandableSetting<ExpandedContent: View>: 
             isEditing: $isEditing,
             leadingValueContent: {
                 HStack {
-                    icon(for: preset)
-                    name(of: preset)
+                    preset.icon
+                    Text(preset.title)
                 }
             },
             trailingValueContent: {
@@ -40,31 +40,7 @@ public struct CorrectionRangeOverridesExpandableSetting<ExpandedContent: View>: 
             expandedContent: expandedContent
         )
     }
-    
-    private func name(of preset: CorrectionRangeOverrides.Preset) -> Text {
-        switch preset {
-        case .preMeal:
-            return Text("Pre-Meal", comment: "Title for pre-meal mode configuration section")
-        case .workout:
-            return Text("Workout", comment: "Title for workout mode configuration section")
-        }
-    }
 
-    private func icon(for preset: CorrectionRangeOverrides.Preset) -> some View {
-        switch preset {
-        case .preMeal:
-            return icon(named: "Pre-Meal", tinted: Color(.COBTintColor))
-        case .workout:
-            return icon(named: "workout", tinted: Color(.glucoseTintColor))
-        }
-    }
-    
-    private func icon(named name: String, tinted color: Color) -> some View {
-        Image(name)
-            .renderingMode(.template)
-            .foregroundColor(color)
-    }
-    
     private func guardrail(for preset: CorrectionRangeOverrides.Preset) -> Guardrail<HKQuantity> {
         return Guardrail.correctionRangeOverridePreset(preset, correctionRangeScheduleRange: correctionRangeScheduleRange)
     }

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesExtension.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesExtension.swift
@@ -1,0 +1,27 @@
+//
+//  CorrectionRangeOverridesExtension.swift
+//  LoopKitUI
+//
+//  Created by Rick Pasetto on 7/15/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import LoopKit
+import SwiftUI
+
+extension CorrectionRangeOverrides.Preset {
+    var icon: some View {
+        switch self {
+        case .preMeal:
+            return icon(named: "Pre-Meal", tinted: Color(.COBTintColor))
+        case .workout:
+            return icon(named: "workout", tinted: Color(.glucoseTintColor))
+        }
+    }
+    
+    private func icon(named name: String, tinted color: Color) -> some View {
+        Image(name)
+            .renderingMode(.template)
+            .foregroundColor(color)
+    }
+}

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeScheduleEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeScheduleEditor.swift
@@ -42,7 +42,7 @@ public struct CorrectionRangeScheduleEditor: View {
 
     public var body: some View {
         ScheduleEditor(
-            title: Text("Correction Ranges", comment: "Title of correction range schedule editor"),
+            title: Text(TherapySetting.glucoseTargetRange.title),
             description: description,
             buttonText: buttonText,
             scheduleItems: $scheduleItems,
@@ -97,7 +97,7 @@ public struct CorrectionRangeScheduleEditor: View {
     }
 
     var description: Text {
-        Text("The app adjusts insulin delivery in an effort to bring your glucose into your correction range.", comment: "Description of correction range setting")
+        Text(TherapySetting.glucoseTargetRange.descriptiveText)
     }
 
     var saveConfirmation: SaveConfirmation {

--- a/LoopKitUI/Views/Settings Editors/InsulinSensitivityScheduleEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/InsulinSensitivityScheduleEditor.swift
@@ -43,7 +43,7 @@ public struct InsulinSensitivityScheduleEditor: View {
 
     public var body: some View {
         QuantityScheduleEditor(
-            title: Text("Insulin Sensitivities", comment: "Title of insulin sensitivity settings page"),
+            title: Text(TherapySetting.insulinSensitivity.title),
             description: description,
             schedule: schedule,
             unit: sensitivityUnit,
@@ -60,7 +60,7 @@ public struct InsulinSensitivityScheduleEditor: View {
     }
 
     private var description: Text {
-        Text("Your insulin sensitivity factor (ISF) is the drop in glucose expected from one unit of insulin.", comment: "Insulin sensitivity setting description")
+        Text(TherapySetting.insulinSensitivity.descriptiveText)
     }
 
     private var sensitivityUnit: HKUnit {

--- a/LoopKitUI/Views/Settings Editors/SuspendThresholdEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/SuspendThresholdEditor.swift
@@ -58,7 +58,7 @@ public struct SuspendThresholdEditor: View {
 
     public var body: some View {
         ConfigurationPage(
-            title: Text("Suspend Threshold", comment: "Title for suspend threshold configuration page"),
+            title: Text(TherapySetting.suspendThreshold.title),
             actionButtonTitle: buttonText,
             actionButtonState: saveButtonState,
             cards: {
@@ -115,7 +115,7 @@ public struct SuspendThresholdEditor: View {
     }
 
     var description: Text {
-        Text(LocalizedString("When your glucose is predicted to go below this value, the app will recommend a basal rate of 0 U/hr and will not recommend a bolus.", comment: "Information about suspend threshold"))
+        Text(TherapySetting.suspendThreshold.descriptiveText)
     }
     
     private var instructionalContentIfNecessary: some View {

--- a/LoopKitUI/Views/Settings Editors/TherapySettingExtension.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingExtension.swift
@@ -1,0 +1,30 @@
+//
+//  TherapySettingExtension.swift
+//  LoopKitUI
+//
+//  Created by Rick Pasetto on 7/14/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import LoopKit
+import SwiftUI
+
+extension TherapySetting {
+    
+    public func helpScreen() -> some View {
+        switch self {
+        case .glucoseTargetRange:
+            return AnyView(CorrectionRangeInformationView(onExit: nil, mode: .modal))
+        case .correctionRangeOverrides:
+            return AnyView(CorrectionRangeOverrideInformationView(onExit: nil, mode: .modal))
+        case .suspendThreshold:
+            return AnyView(SuspendThresholdInformationView(onExit: nil, mode: .modal))
+        case .basalRate:
+            return AnyView(BasalRatesInformationView(onExit: nil, mode: .modal))
+        // ANNA TODO: add more once other instructional screens are created
+        default:
+            return AnyView(Text("To be implemented"))
+        }
+    }
+}
+

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -129,8 +129,8 @@ extension TherapySettingsView {
     
     private var correctionRangeSection: some View {
         SectionWithEdit(isEditing: $isEditing,
-                        title: LocalizedString("Correction Range", comment: "Correction Range section title"),
-                        descriptiveText: "Correction range is the glucose value (or range of values) that you want Tidepool Loop to aim for in adjusting your basal insulin.",
+                        title: TherapySetting.glucoseTargetRange.title,
+                        descriptiveText: TherapySetting.glucoseTargetRange.descriptiveText,
                         editAction: { self.delegate?.gotoEdit(therapySetting: TherapySetting.glucoseTargetRange) })
         {
             Group {
@@ -147,8 +147,8 @@ extension TherapySettingsView {
     
     private var temporaryCorrectionRangesSection: some View {
         SectionWithEdit(isEditing: $isEditing,
-                        title: LocalizedString("Temporary Correction Ranges", comment: "Temporary Correction Ranges section title"),
-                        descriptiveText: "Pre-Meal and Workout ranges temporarily adjust your glucose target based on your selected activity.",
+                        title: TherapySetting.correctionRangeOverrides.title,
+                        descriptiveText: TherapySetting.correctionRangeOverrides.descriptiveText,
                         editAction: { self.delegate?.gotoEdit(therapySetting: TherapySetting.correctionRangeOverrides) })
         {
             Group {


### PR DESCRIPTION
This consolidates the Therapy Settings _title_ and _descriptiveText_ into one place, sourced from [IFU-24](https://tidepool.atlassian.net/browse/IFU-24)

Note: I moved `CorrectionRangeOverrides.swift` and `TherapySetting.swift` into LoopKit, because they seemed generally useful.  I don't feel strongly about that, though, so if you disagree I can move them back.