### PR TITLE
[LOOP-1565] Fix delivery limits crasher; make pump simulator increments configurable

### DIFF
--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -322,6 +322,8 @@
 		7D68A9B81FE0A3D100522C49 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7D68A9BA1FE0A3D100522C49 /* InfoPlist.strings */; };
 		7D68A9C21FE0A3D200522C49 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7D68A9C41FE0A3D200522C49 /* InfoPlist.strings */; };
 		8907E35921A9D0EC00335852 /* GlucoseEntryTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8907E35821A9D0EC00335852 /* GlucoseEntryTableViewController.swift */; };
+		89186C0524BEC9CA0003D0F3 /* SegmentedControlTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89186C0424BEC9CA0003D0F3 /* SegmentedControlTableViewCell.swift */; };
+		89186C0724BF7FC70003D0F3 /* Guardrail+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89186C0624BF7FC70003D0F3 /* Guardrail+UI.swift */; };
 		891A3FC72247268F00378B27 /* Math.swift in Sources */ = {isa = PBXBuildFile; fileRef = 891A3FC62247268F00378B27 /* Math.swift */; };
 		891A3FD12249948A00378B27 /* TemporaryScheduleOverrideHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 891A3FD02249948A00378B27 /* TemporaryScheduleOverrideHistoryTests.swift */; };
 		891A3FD32249990900378B27 /* DailyValueSchedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 891A3FD22249990900378B27 /* DailyValueSchedule.swift */; };
@@ -1215,6 +1217,8 @@
 		7D68AAC61FE31BE900522C49 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8907E35821A9D0EC00335852 /* GlucoseEntryTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GlucoseEntryTableViewController.swift; sourceTree = "<group>"; };
 		8907E35A21A9D1B200335852 /* SineCurveParametersTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SineCurveParametersTableViewController.swift; sourceTree = "<group>"; };
+		89186C0424BEC9CA0003D0F3 /* SegmentedControlTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentedControlTableViewCell.swift; sourceTree = "<group>"; };
+		89186C0624BF7FC70003D0F3 /* Guardrail+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Guardrail+UI.swift"; sourceTree = "<group>"; };
 		891A3FC62247268F00378B27 /* Math.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Math.swift; sourceTree = "<group>"; };
 		891A3FD02249948A00378B27 /* TemporaryScheduleOverrideHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemporaryScheduleOverrideHistoryTests.swift; sourceTree = "<group>"; };
 		891A3FD22249990900378B27 /* DailyValueSchedule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyValueSchedule.swift; sourceTree = "<group>"; };
@@ -1719,6 +1723,7 @@
 				43D8FE0B1C7290530073BE78 /* RepeatingScheduleValueTableViewCell.xib */,
 				892A5DB62231E19F008961AB /* ReservoirVolumeHUDView.swift */,
 				892A5DB52231E19F008961AB /* ReservoirVolumeHUDView.xib */,
+				89186C0424BEC9CA0003D0F3 /* SegmentedControlTableViewCell.swift */,
 				432CF86620D76AB90066B889 /* SettingsTableViewCell.swift */,
 				432CF86820D76B320066B889 /* SetupButton.swift */,
 				432CF86A20D76B9C0066B889 /* SetupIndicatorView.swift */,
@@ -2344,6 +2349,7 @@
 				B41A60B123D1DBC700636320 /* UIFont.swift */,
 				E916F56A24AD346D00BE3547 /* UIColor+LoopKit.swift */,
 				E96175AD24B7BE38008E5080 /* Dictionary.swift */,
+				89186C0624BF7FC70003D0F3 /* Guardrail+UI.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -3022,6 +3028,7 @@
 				895FE08022011F0C00FCF18A /* EmojiDataSource.swift in Sources */,
 				432CF86920D76B320066B889 /* SetupButton.swift in Sources */,
 				898E6E702241EDB70019E459 /* PercentageTextFieldTableViewController.swift in Sources */,
+				89186C0724BF7FC70003D0F3 /* Guardrail+UI.swift in Sources */,
 				432CF87420D774520066B889 /* NumberFormatter.swift in Sources */,
 				1F5DAB212118C95700048054 /* LocalizedString.swift in Sources */,
 				43FB60E520DCBA02002B996B /* SetupTableViewController.swift in Sources */,
@@ -3088,6 +3095,7 @@
 				43BA717B201EE6A40058961E /* NibLoadable.swift in Sources */,
 				E916F56F24AE2FFE00BE3547 /* CorrectionRangeOverrideInformationView.swift in Sources */,
 				89BE75C124649C2E00B145D9 /* ModalHeaderButtonBar.swift in Sources */,
+				89186C0524BEC9CA0003D0F3 /* SegmentedControlTableViewCell.swift in Sources */,
 				89F6E315244A1AB600CB9E15 /* GlucoseValuePicker.swift in Sources */,
 				895FE08122011F0C00FCF18A /* OverridePresetCollectionViewCell.swift in Sources */,
 				43FB60E320DCB9E0002B996B /* PumpManagerUI.swift in Sources */,

--- a/LoopKitUI/Extensions/Guardrail+UI.swift
+++ b/LoopKitUI/Extensions/Guardrail+UI.swift
@@ -1,0 +1,28 @@
+//
+//  Guardrail+UI.swift
+//  LoopKitUI
+//
+//  Created by Michael Pangburn on 7/15/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+import HealthKit
+import LoopKit
+
+
+extension Guardrail where Value == HKQuantity {
+    func color(for quantity: HKQuantity) -> Color {
+        switch classification(for: quantity) {
+        case .withinRecommendedRange:
+            return .primary
+        case .outsideRecommendedRange(let threshold):
+            switch threshold {
+            case .minimum, .maximum:
+                return .severeWarning
+            case .belowRecommended, .aboveRecommended:
+                return .warning
+            }
+        }
+    }
+}

--- a/LoopKitUI/Views/FractionalQuantityPicker.swift
+++ b/LoopKitUI/Views/FractionalQuantityPicker.swift
@@ -65,16 +65,7 @@ public struct FractionalQuantityPicker: View {
         self._whole = Binding(
             get: { doubleValue.wrappedValue.whole },
             set: { newWholeValue in
-                // If the new whole value supports the same fractional value, keep it; otherwise, truncate.
-                let supportedFractionValues = fractionalValuesByWhole[newWholeValue]!
-                let currentFraction = doubleValue.wrappedValue.fraction
-                let nearestSupportedFraction = currentFraction.roundedToNearest(of: supportedFractionValues)
-                let newFractionValue: Double
-                if abs(nearestSupportedFraction - currentFraction) <= pow(10.0, Double(-Self.maximumSupportedPrecision)) {
-                    newFractionValue = nearestSupportedFraction
-                } else {
-                    newFractionValue = currentFraction.truncating(toOneOf: supportedFractionValues)
-                }
+                let newFractionValue = Self.fractionForWhole(newWholeValue, currentFraction: doubleValue.wrappedValue.fraction, supportedFractionValues: fractionalValuesByWhole[newWholeValue]!)
                 let newDoubleValue = newWholeValue + newFractionValue
                 let maxValue = guardrail.absoluteBounds.upperBound.doubleValue(for: unit)
                 doubleValue.wrappedValue = min(newDoubleValue, maxValue)
@@ -93,6 +84,18 @@ public struct FractionalQuantityPicker: View {
         self.selectableWholeValues = selectableWholeValues
         self.fractionalValuesByWhole = fractionalValuesByWhole
         self.usageContext = usageContext
+    }
+
+    private static func fractionForWhole(
+        _ whole: Double,
+        currentFraction: Double,
+        supportedFractionValues: [Double]
+    ) -> Double {
+        // If the whole value supports the same fractional value, keep it; otherwise, truncate.
+        let nearestSupportedFraction = currentFraction.roundedToNearest(of: supportedFractionValues)
+        return abs(nearestSupportedFraction - currentFraction) <= pow(10.0, Double(-Self.maximumSupportedPrecision))
+            ? nearestSupportedFraction
+            : currentFraction.truncating(toOneOf: supportedFractionValues)
     }
 
     public var body: some View {
@@ -118,10 +121,10 @@ public struct FractionalQuantityPicker: View {
             QuantityPicker(
                 value: $whole.withUnit(unit),
                 unit: unit,
-                guardrail: wholeGuardrail,
                 selectableValues: selectableWholeValues,
                 formatter: Self.wholeFormatter,
-                isUnitLabelVisible: false
+                isUnitLabelVisible: false,
+                colorForValue: colorForWhole
             )
             // Ensure whole picker color updates when fraction updates
             .id(whole + fraction)
@@ -139,9 +142,9 @@ public struct FractionalQuantityPicker: View {
             QuantityPicker(
                 value: $fraction.withUnit(unit),
                 unit: unit,
-                guardrail: fractionalGuardrail,
                 selectableValues: fractionalValuesByWhole[whole]!,
-                formatter: fractionalFormatter
+                formatter: fractionalFormatter,
+                colorForValue: colorForFraction
             )
             // Ensure fractional picker values update when whole value updates
             .id(whole + fraction)
@@ -151,86 +154,21 @@ public struct FractionalQuantityPicker: View {
         }
     }
 
-    private var wholeGuardrail: Guardrail<HKQuantity> {
-        // Whether or not the whole value should be colored as 'out of range' depends only on the fraction value.
-        let lowerRecommendedBound = guardrail.recommendedBounds.lowerBound.doubleValue(for: unit)
-        if fraction < lowerRecommendedBound.fraction {
-            return guardrail
-        } else {
-            // Shift the lower bounds down one 'whole' value.
-            // Note: this shift doesn't affect which values are selectable, only the coloration of the selectable values.
-            // For example, if the real guardrail's lower bound is 3.00, the whole '3' should be colored only when '00' is selected
-            // in the fractional picker, regardless of the current whole value.
-            return Guardrail(
-                absoluteBounds: HKQuantity(unit: unit, doubleValue: guardrail.absoluteBounds.lowerBound.doubleValue(for: unit) - 1)...guardrail.absoluteBounds.upperBound,
-                recommendedBounds: HKQuantity(unit: unit, doubleValue: lowerRecommendedBound - 1)...guardrail.recommendedBounds.upperBound
-            )
-        }
+    private func colorForWhole(_ whole: Double) -> Color {
+        assert(whole.whole == whole)
+
+        let fractionIfWholeSelected = Self.fractionForWhole(whole, currentFraction: fraction, supportedFractionValues: fractionalValuesByWhole[whole]!)
+        let valueIfWholeSelected = whole + fractionIfWholeSelected
+        let quantityIfWholeSelected = HKQuantity(unit: unit, doubleValue: valueIfWholeSelected)
+        return guardrail.color(for: quantityIfWholeSelected)
     }
 
-    private var fractionalGuardrail: Guardrail<HKQuantity>? {
-        let lowerAbsoluteBound = guardrail.absoluteBounds.lowerBound.doubleValue(for: unit)
-        let upperAbsoluteBound = guardrail.absoluteBounds.upperBound.doubleValue(for: unit)
-        let lowerRecommendedBound = guardrail.recommendedBounds.lowerBound.doubleValue(for: unit)
-        let upperRecommendedBound = guardrail.recommendedBounds.upperBound.doubleValue(for: unit)
+    private func colorForFraction(_ fraction: Double) -> Color {
+        assert(fraction.fraction == fraction)
 
-        // Thresholds for use in defining recommended bounds,
-        // to simplify the expression of (e.g.) "all selectable values are smaller than recommended",
-        // resulting in 'warning'-colored picker values.
-        let valueTooSmallToSelect: Double = -1
-        let valueTooLargeToSelect: Double = 1
-
-        switch whole {
-        case lowerAbsoluteBound.whole:
-            let smallestSelectableValue = fractionalValuesByWhole[whole]!.first!
-            let fractionalLowerRecommendedBound = lowerAbsoluteBound.whole == lowerRecommendedBound.whole
-                ? max(lowerRecommendedBound.fraction, smallestSelectableValue)
-                : valueTooLargeToSelect
-            let fractionalUpperRecommendedBound = lowerAbsoluteBound.whole == upperRecommendedBound.whole
-                ? upperRecommendedBound.fraction
-                : valueTooLargeToSelect
-            return Guardrail(
-                absoluteBounds: smallestSelectableValue...valueTooLargeToSelect,
-                recommendedBounds: fractionalLowerRecommendedBound...fractionalUpperRecommendedBound,
-                unit: unit
-            )
-        case ..<lowerRecommendedBound.whole:
-            return Guardrail(
-                absoluteBounds: valueTooSmallToSelect...valueTooLargeToSelect,
-                recommendedBounds: valueTooLargeToSelect...valueTooLargeToSelect,
-                unit: unit
-            )
-        case lowerRecommendedBound.whole:
-            let fractionalLowerRecommendedBound = lowerRecommendedBound.fraction + pow(10.0, -Double(Self.maximumSupportedPrecision))
-            return Guardrail(
-                absoluteBounds: valueTooSmallToSelect...valueTooLargeToSelect,
-                recommendedBounds: fractionalLowerRecommendedBound...valueTooLargeToSelect,
-                unit: unit
-            )
-        case ..<upperRecommendedBound.whole:
-            return nil
-        case upperRecommendedBound.whole:
-            return Guardrail(
-                absoluteBounds: valueTooSmallToSelect...valueTooLargeToSelect,
-                recommendedBounds: valueTooSmallToSelect...upperRecommendedBound.fraction,
-                unit: unit
-            )
-        case ..<upperAbsoluteBound.whole:
-            return Guardrail(
-                absoluteBounds: valueTooSmallToSelect...valueTooLargeToSelect,
-                recommendedBounds: valueTooSmallToSelect...valueTooSmallToSelect,
-                unit: unit
-            )
-        case upperAbsoluteBound.whole:
-            return Guardrail(
-                absoluteBounds: valueTooSmallToSelect...fractionalValuesByWhole[whole]!.last!,
-                recommendedBounds: valueTooSmallToSelect...valueTooSmallToSelect,
-                unit: unit
-            )
-        default:
-            assertionFailure("unreachable")
-            return nil
-        }
+        let valueIfFractionSelected = whole + fraction
+        let quantityIfFractionSelected = HKQuantity(unit: unit, doubleValue: valueIfFractionSelected)
+        return guardrail.color(for: quantityIfFractionSelected)
     }
 
     private var fractionalFormatter: NumberFormatter {

--- a/LoopKitUI/Views/FractionalQuantityPicker.swift
+++ b/LoopKitUI/Views/FractionalQuantityPicker.swift
@@ -65,7 +65,7 @@ public struct FractionalQuantityPicker: View {
         self._whole = Binding(
             get: { doubleValue.wrappedValue.whole },
             set: { newWholeValue in
-                let newFractionValue = Self.fractionForWhole(newWholeValue, currentFraction: doubleValue.wrappedValue.fraction, supportedFractionValues: fractionalValuesByWhole[newWholeValue]!)
+                let newFractionValue = Self.matchingFraction(for: doubleValue.wrappedValue.fraction, from: fractionalValuesByWhole[newWholeValue]!)
                 let newDoubleValue = newWholeValue + newFractionValue
                 let maxValue = guardrail.absoluteBounds.upperBound.doubleValue(for: unit)
                 doubleValue.wrappedValue = min(newDoubleValue, maxValue)
@@ -86,10 +86,9 @@ public struct FractionalQuantityPicker: View {
         self.usageContext = usageContext
     }
 
-    private static func fractionForWhole(
-        _ whole: Double,
-        currentFraction: Double,
-        supportedFractionValues: [Double]
+    private static func matchingFraction(
+        for currentFraction: Double,
+        from supportedFractionValues: [Double]
     ) -> Double {
         // If the whole value supports the same fractional value, keep it; otherwise, truncate.
         let nearestSupportedFraction = currentFraction.roundedToNearest(of: supportedFractionValues)
@@ -157,7 +156,7 @@ public struct FractionalQuantityPicker: View {
     private func colorForWhole(_ whole: Double) -> Color {
         assert(whole.whole == whole)
 
-        let fractionIfWholeSelected = Self.fractionForWhole(whole, currentFraction: fraction, supportedFractionValues: fractionalValuesByWhole[whole]!)
+        let fractionIfWholeSelected = Self.matchingFraction(for: fraction, from: fractionalValuesByWhole[whole]!)
         let valueIfWholeSelected = whole + fractionIfWholeSelected
         let quantityIfWholeSelected = HKQuantity(unit: unit, doubleValue: valueIfWholeSelected)
         return guardrail.color(for: quantityIfWholeSelected)

--- a/LoopKitUI/Views/SegmentedControlTableViewCell.swift
+++ b/LoopKitUI/Views/SegmentedControlTableViewCell.swift
@@ -1,0 +1,71 @@
+//
+//  SegmentedControlTableViewCell.swift
+//  LoopKitUI
+//
+//  Created by Michael Pangburn on 7/14/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import UIKit
+
+
+open class SegmentedControlTableViewCell: UITableViewCell {
+    public var segmentedControl = UISegmentedControl(frame: .zero)
+
+    public var options: [String] = [] {
+        didSet {
+            segmentedControl.removeAllSegments()
+            for (index, option) in options.enumerated() {
+                segmentedControl.insertSegment(withTitle: option, at: index, animated: false)
+            }
+        }
+    }
+
+    private var select: (_ index: Int) -> Void = { _ in }
+
+    public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: .value1, reuseIdentifier: Self.className)
+
+        setUp()
+    }
+
+    required public init?(coder: NSCoder) {
+        super.init(coder: coder)
+
+        setUp()
+    }
+
+    private func setUp() {
+        contentView.addSubview(segmentedControl)
+        segmentedControl.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            segmentedControl.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+            segmentedControl.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            segmentedControl.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.5),
+        ])
+    }
+
+    override open func layoutSubviews() {
+        super.layoutSubviews()
+
+        contentView.layoutMargins.left = separatorInset.left
+        contentView.layoutMargins.right = separatorInset.left
+    }
+
+    override open func prepareForReuse() {
+        super.prepareForReuse()
+
+        segmentedControl.removeTarget(nil, action: nil, for: .valueChanged)
+        select = { _ in }
+    }
+
+    public func onSelection(_ select: @escaping (_ index: Int) -> Void) {
+        self.select = select
+        segmentedControl.addTarget(self, action: #selector(handleSelection), for: .valueChanged)
+    }
+
+    @objc private func handleSelection() {
+        select(segmentedControl.selectedSegmentIndex)
+    }
+}
+

--- a/LoopKitUI/Views/Settings Editors/BasalRateScheduleEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/BasalRateScheduleEditor.swift
@@ -47,9 +47,12 @@ public struct BasalRateScheduleEditor: View {
             self.supportedBasalRates = supportedBasalRates
         }
 
+        let recommendedLowerBound = supportedBasalRates.first == 0
+            ? supportedBasalRates.dropFirst().first!
+            : supportedBasalRates.first!
         self.guardrail = Guardrail(
             absoluteBounds: supportedBasalRates.first!...supportedBasalRates.last!,
-            recommendedBounds: supportedBasalRates.dropFirst().first!...supportedBasalRates.last!,
+            recommendedBounds: recommendedLowerBound...supportedBasalRates.last!,
             unit: .internationalUnitsPerHour
         )
         self.maximumScheduleEntryCount = maximumScheduleEntryCount

--- a/MockKit/Extensions/Collection.swift
+++ b/MockKit/Extensions/Collection.swift
@@ -35,4 +35,9 @@ extension Collection {
             completion(transformed)
         }
     }
+
+    /// Returns a sequence containing adjacent pairs of elements in the ordered collection.
+    func adjacentPairs() -> Zip2Sequence<Self, SubSequence> {
+        return zip(self, dropFirst())
+    }
 }

--- a/MockKit/MockPumpManager.swift
+++ b/MockKit/MockPumpManager.swift
@@ -70,11 +70,11 @@ public final class MockPumpManager: TestingPumpManager {
     }
 
     public var supportedBolusVolumes: [Double] {
-        return supportedBasalRates
+        return state.supportedBolusVolumes
     }
 
     public var supportedBasalRates: [Double] {
-        return (0...700).map { Double($0) / Double(type(of: self).pulsesPerUnit) }
+        return state.supportedBasalRates
     }
 
     public var maximumBasalScheduleEntryCount: Int {
@@ -238,6 +238,7 @@ public final class MockPumpManager: TestingPumpManager {
 
     public init() {
         state = MockPumpManagerState(
+            deliverableIncrements: .medtronicX22,
             reservoirUnitsRemaining: MockPumpManager.pumpReservoirCapacity,
             tempBasalEnactmentShouldError: false,
             bolusEnactmentShouldError: false,

--- a/MockKitUI/View Controllers/MockPumpManagerSettingsViewController.swift
+++ b/MockKitUI/View Controllers/MockPumpManagerSettingsViewController.swift
@@ -39,6 +39,7 @@ final class MockPumpManagerSettingsViewController: UITableViewController {
         tableView.sectionHeaderHeight = UITableView.automaticDimension
         tableView.estimatedSectionHeaderHeight = 55
 
+        tableView.register(SegmentedControlTableViewCell.self, forCellReuseIdentifier: SegmentedControlTableViewCell.className)
         tableView.register(SettingsTableViewCell.self, forCellReuseIdentifier: SettingsTableViewCell.className)
         tableView.register(BoundSwitchTableViewCell.self, forCellReuseIdentifier: BoundSwitchTableViewCell.className)
         tableView.register(TextButtonTableViewCell.self, forCellReuseIdentifier: TextButtonTableViewCell.className)
@@ -79,7 +80,8 @@ final class MockPumpManagerSettingsViewController: UITableViewController {
     }
 
     private enum SettingsRow: Int, CaseIterable {
-        case reservoirRemaining = 0
+        case deliverableIncrements = 0
+        case reservoirRemaining
         case batteryRemaining
         case tempBasalErrorToggle
         case bolusErrorToggle
@@ -153,6 +155,25 @@ final class MockPumpManagerSettingsViewController: UITableViewController {
             }
         case .settings:
             switch SettingsRow(rawValue: indexPath.row)! {
+            case .deliverableIncrements:
+                let cell = tableView.dequeueReusableCell(withIdentifier: SegmentedControlTableViewCell.className, for: indexPath) as! SegmentedControlTableViewCell
+                let possibleDeliverableIncrements = MockPumpManagerState.DeliverableIncrements.allCases
+                cell.textLabel?.text = "Increments"
+                cell.options = possibleDeliverableIncrements.map { increments in
+                    switch increments {
+                    case .omnipod:
+                        return "Pod"
+                    case .medtronicX22:
+                        return "x22"
+                    case .medtronicX23:
+                        return "x23"
+                    }
+                }
+                cell.segmentedControl.selectedSegmentIndex = possibleDeliverableIncrements.firstIndex(of: pumpManager.state.deliverableIncrements)!
+                cell.onSelection { [pumpManager] index in
+                    pumpManager.state.deliverableIncrements = possibleDeliverableIncrements[index]
+                }
+                return cell
             case .reservoirRemaining:
                 let cell = tableView.dequeueReusableCell(withIdentifier: SettingsTableViewCell.className, for: indexPath)
                 cell.textLabel?.text = "Reservoir Remaining"
@@ -249,6 +270,8 @@ final class MockPumpManagerSettingsViewController: UITableViewController {
             }
         case .settings:
             switch SettingsRow(rawValue: indexPath.row)! {
+            case .deliverableIncrements:
+                break
             case .reservoirRemaining:
                 let vc = TextFieldTableViewController()
                 vc.value = String(format: "%.1f", pumpManager.state.reservoirUnitsRemaining)


### PR DESCRIPTION
- Constructing 'fake' guardrails for whole and fractional values in FractionalQuantityPicker was ugly, complex, and error-prone. Simplify the logic.
- Fix a quirk where BasalRateScheduleEditor would show a low value warning even when the minimum supported value was nonzero.
- Augment the pump simulator to make deliverable increments configurable.

Some notes on the new simulator functionality:
- 'x22' and 'x23' refer to Medtronic Minimed models 522/722 and 523/723, i.e. those supported by DIY Loop, which have different precisions.
- At this time, changing the pump simulator's increments does not propagate the change in supported bolus volumes to the watch.
- If you've selected an increment that is supported by one model but not another, then switch models, it will crash when trying to edit the setting—effectively equivalent to https://tidepool.atlassian.net/browse/LOOP-1483