### PR TITLE
LOOP-1492: therapy settings navigation

### DIFF
--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -24,6 +24,11 @@
 		1D4990E624A17564005CC357 /* HKQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4990E524A17564005CC357 /* HKQuery.swift */; };
 		1D4990E724A17898005CC357 /* HKQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4990E524A17564005CC357 /* HKQuery.swift */; };
 		1D640FF724525228008F9755 /* sub.caf in Resources */ = {isa = PBXBuildFile; fileRef = 1D640FF524524284008F9755 /* sub.caf */; };
+		1D66303924C6563000F2EF6E /* CorrectionRangeReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D66303824C6562F00F2EF6E /* CorrectionRangeReviewView.swift */; };
+		1D66303B24C65E7C00F2EF6E /* CorrectionRangeOverrideReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D66303A24C65E7B00F2EF6E /* CorrectionRangeOverrideReview.swift */; };
+		1D66303D24C661FD00F2EF6E /* SuspendThresholdReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D66303C24C661FC00F2EF6E /* SuspendThresholdReview.swift */; };
+		1D66304024C662ED00F2EF6E /* DeliveryLimitsReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D66303E24C662ED00F2EF6E /* DeliveryLimitsReviewView.swift */; };
+		1D66304124C662ED00F2EF6E /* BasalRatesReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D66303F24C662ED00F2EF6E /* BasalRatesReview.swift */; };
 		1D6EAB9124C12C090081249D /* PumpSupportedIncrements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6EAB9024C12C090081249D /* PumpSupportedIncrements.swift */; };
 		1D841AAD24577EE10069DBFF /* AlertSoundPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D841AAC24577EE10069DBFF /* AlertSoundPlayer.swift */; };
 		1DA649AB2445174400F61E75 /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649AA2445174400F61E75 /* Alert.swift */; };
@@ -864,6 +869,11 @@
 		1D25C22D246A2A1A00E87FA0 /* critical.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = critical.caf; sourceTree = "<group>"; };
 		1D4990E524A17564005CC357 /* HKQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HKQuery.swift; sourceTree = "<group>"; };
 		1D640FF524524284008F9755 /* sub.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = sub.caf; sourceTree = "<group>"; };
+		1D66303824C6562F00F2EF6E /* CorrectionRangeReviewView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CorrectionRangeReviewView.swift; sourceTree = "<group>"; };
+		1D66303A24C65E7B00F2EF6E /* CorrectionRangeOverrideReview.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CorrectionRangeOverrideReview.swift; sourceTree = "<group>"; };
+		1D66303C24C661FC00F2EF6E /* SuspendThresholdReview.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuspendThresholdReview.swift; sourceTree = "<group>"; };
+		1D66303E24C662ED00F2EF6E /* DeliveryLimitsReviewView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeliveryLimitsReviewView.swift; sourceTree = "<group>"; };
+		1D66303F24C662ED00F2EF6E /* BasalRatesReview.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasalRatesReview.swift; sourceTree = "<group>"; };
 		1D6EAB9024C12C090081249D /* PumpSupportedIncrements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PumpSupportedIncrements.swift; sourceTree = "<group>"; };
 		1D841AAC24577EE10069DBFF /* AlertSoundPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertSoundPlayer.swift; sourceTree = "<group>"; };
 		1DA649AA2445174400F61E75 /* Alert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Alert.swift; sourceTree = "<group>"; };
@@ -2468,17 +2478,22 @@
 			isa = PBXGroup;
 			children = (
 				89653C8324738D2B00E1BAA5 /* BasalRateScheduleEditor.swift */,
+				1D66303F24C662ED00F2EF6E /* BasalRatesReview.swift */,
 				89653C812473592600E1BAA5 /* CarbRatioScheduleEditor.swift */,
+				1D66303A24C65E7B00F2EF6E /* CorrectionRangeOverrideReview.swift */,
 				E916F56824AD32F000BE3547 /* CorrectionRangeOverridesEditor.swift */,
 				1D1FCE2224BD13A2000300A8 /* CorrectionRangeOverridesExpandableSetting.swift */,
 				1DC64C7B24BF6BFD004A63A1 /* CorrectionRangeOverridesExtension.swift */,
+				1D66303824C6562F00F2EF6E /* CorrectionRangeReviewView.swift */,
 				898B4E7A246DC6A70053C484 /* CorrectionRangeScheduleEditor.swift */,
 				E949E38A24B35DA400024DA0 /* DeliveryLimitsEditor.swift */,
+				1D66303E24C662ED00F2EF6E /* DeliveryLimitsReviewView.swift */,
 				1D1FCE2C24BEA669000300A8 /* Guardrail+Settings.swift */,
 				89FC688A245A2D670075CF59 /* InsulinSensitivityScheduleEditor.swift */,
 				1D6EAB9024C12C090081249D /* PumpSupportedIncrements.swift */,
 				1DEF977424C62F8400D630CB /* SupportedInsulinModelSettings.swift */,
 				E96DCB5924AF74AC007117BC /* SuspendThresholdEditor.swift */,
+				1D66303C24C661FC00F2EF6E /* SuspendThresholdReview.swift */,
 				1D1FCE2A24BE704A000300A8 /* TherapySetting+Settings.swift */,
 				1D1A019D24B678BF0077D86E /* TherapySettingsView.swift */,
 				1D1FCE2424BD42EF000300A8 /* TherapySettingsViewModel.swift */,
@@ -3038,6 +3053,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1D66304124C662ED00F2EF6E /* BasalRatesReview.swift in Sources */,
 				898E6E6E2241ED9F0019E459 /* SuspendResumeTableViewCell.swift in Sources */,
 				B4C004D12416961300B40429 /* GuidePage.swift in Sources */,
 				898B4E7E246DEB920053C484 /* GuardrailConstrainedQuantityRangeView.swift in Sources */,
@@ -3068,6 +3084,7 @@
 				43F5035A21059AF7009FA89A /* AuthenticationTableViewCell.swift in Sources */,
 				E916F56924AD32F000BE3547 /* CorrectionRangeOverridesEditor.swift in Sources */,
 				43BA7163201E490D0058961E /* InsulinDeliveryTableViewController.swift in Sources */,
+				1D66304024C662ED00F2EF6E /* DeliveryLimitsReviewView.swift in Sources */,
 				C1E4B30A242E99A800E70CCB /* Image.swift in Sources */,
 				43BA718A201EE8CF0058961E /* NSTimeInterval.swift in Sources */,
 				B4A2AAB1240830A30066563F /* LabeledTextField.swift in Sources */,
@@ -3089,6 +3106,7 @@
 				893C9F8C2447DBD900CD4185 /* CardBuilder.swift in Sources */,
 				89BE75C524649C8100B145D9 /* NewScheduleItemEditor.swift in Sources */,
 				89653C822473592600E1BAA5 /* CarbRatioScheduleEditor.swift in Sources */,
+				1D66303D24C661FD00F2EF6E /* SuspendThresholdReview.swift in Sources */,
 				1D1FCE2B24BE704A000300A8 /* TherapySetting+Settings.swift in Sources */,
 				4369F08F208859E6000E3E45 /* PaddedTextField.swift in Sources */,
 				A9498D8823386CAF00DAA9B9 /* ServiceViewController.swift in Sources */,
@@ -3147,6 +3165,7 @@
 				43BA7188201EE85B0058961E /* HKUnit.swift in Sources */,
 				B4F3D24F24AF59B50095CE44 /* DeviceLifecycleProgressState+Color.swift in Sources */,
 				89F6E30D2449713600CB9E15 /* CardStack.swift in Sources */,
+				1D66303924C6563000F2EF6E /* CorrectionRangeReviewView.swift in Sources */,
 				89BE75C324649C4C00B145D9 /* RoundedCorners.swift in Sources */,
 				C1E4B306242E98E900E70CCB /* ProgressIndicatorView.swift in Sources */,
 				4369F092208B0DFF000E3E45 /* DateAndDurationTableViewCell.swift in Sources */,
@@ -3194,6 +3213,7 @@
 				B46B62AD23FF0A87001E69BA /* LabeledDateView.swift in Sources */,
 				895FE06E22011E9A00FCF18A /* OverrideEmojiDataSource.swift in Sources */,
 				43BA716A201E49220058961E /* CarbEntryTableViewController.swift in Sources */,
+				1D66303B24C65E7C00F2EF6E /* CorrectionRangeOverrideReview.swift in Sources */,
 				43BA716B201E49220058961E /* CarbEntryValidationNavigationDelegate.swift in Sources */,
 				89AF78C02447E285002B4FCC /* CardStackBuilder.swift in Sources */,
 				43BA7185201EE7090058961E /* DailyValueScheduleTableViewController.swift in Sources */,

--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -24,10 +24,10 @@
 		1D4990E624A17564005CC357 /* HKQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4990E524A17564005CC357 /* HKQuery.swift */; };
 		1D4990E724A17898005CC357 /* HKQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4990E524A17564005CC357 /* HKQuery.swift */; };
 		1D640FF724525228008F9755 /* sub.caf in Resources */ = {isa = PBXBuildFile; fileRef = 1D640FF524524284008F9755 /* sub.caf */; };
-		1D66303924C6563000F2EF6E /* CorrectionRangeReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D66303824C6562F00F2EF6E /* CorrectionRangeReviewView.swift */; };
+		1D66303924C6563000F2EF6E /* CorrectionRangeReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D66303824C6562F00F2EF6E /* CorrectionRangeReview.swift */; };
 		1D66303B24C65E7C00F2EF6E /* CorrectionRangeOverrideReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D66303A24C65E7B00F2EF6E /* CorrectionRangeOverrideReview.swift */; };
 		1D66303D24C661FD00F2EF6E /* SuspendThresholdReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D66303C24C661FC00F2EF6E /* SuspendThresholdReview.swift */; };
-		1D66304024C662ED00F2EF6E /* DeliveryLimitsReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D66303E24C662ED00F2EF6E /* DeliveryLimitsReviewView.swift */; };
+		1D66304024C662ED00F2EF6E /* DeliveryLimitsReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D66303E24C662ED00F2EF6E /* DeliveryLimitsReview.swift */; };
 		1D66304124C662ED00F2EF6E /* BasalRatesReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D66303F24C662ED00F2EF6E /* BasalRatesReview.swift */; };
 		1D6EAB9124C12C090081249D /* PumpSupportedIncrements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6EAB9024C12C090081249D /* PumpSupportedIncrements.swift */; };
 		1D841AAD24577EE10069DBFF /* AlertSoundPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D841AAC24577EE10069DBFF /* AlertSoundPlayer.swift */; };
@@ -870,10 +870,10 @@
 		1D25C22D246A2A1A00E87FA0 /* critical.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = critical.caf; sourceTree = "<group>"; };
 		1D4990E524A17564005CC357 /* HKQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HKQuery.swift; sourceTree = "<group>"; };
 		1D640FF524524284008F9755 /* sub.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = sub.caf; sourceTree = "<group>"; };
-		1D66303824C6562F00F2EF6E /* CorrectionRangeReviewView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CorrectionRangeReviewView.swift; sourceTree = "<group>"; };
+		1D66303824C6562F00F2EF6E /* CorrectionRangeReview.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CorrectionRangeReview.swift; sourceTree = "<group>"; };
 		1D66303A24C65E7B00F2EF6E /* CorrectionRangeOverrideReview.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CorrectionRangeOverrideReview.swift; sourceTree = "<group>"; };
 		1D66303C24C661FC00F2EF6E /* SuspendThresholdReview.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuspendThresholdReview.swift; sourceTree = "<group>"; };
-		1D66303E24C662ED00F2EF6E /* DeliveryLimitsReviewView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeliveryLimitsReviewView.swift; sourceTree = "<group>"; };
+		1D66303E24C662ED00F2EF6E /* DeliveryLimitsReview.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeliveryLimitsReview.swift; sourceTree = "<group>"; };
 		1D66303F24C662ED00F2EF6E /* BasalRatesReview.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasalRatesReview.swift; sourceTree = "<group>"; };
 		1D6EAB9024C12C090081249D /* PumpSupportedIncrements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PumpSupportedIncrements.swift; sourceTree = "<group>"; };
 		1D841AAC24577EE10069DBFF /* AlertSoundPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertSoundPlayer.swift; sourceTree = "<group>"; };
@@ -2486,10 +2486,10 @@
 				E916F56824AD32F000BE3547 /* CorrectionRangeOverridesEditor.swift */,
 				1D1FCE2224BD13A2000300A8 /* CorrectionRangeOverridesExpandableSetting.swift */,
 				1DC64C7B24BF6BFD004A63A1 /* CorrectionRangeOverridesExtension.swift */,
-				1D66303824C6562F00F2EF6E /* CorrectionRangeReviewView.swift */,
+				1D66303824C6562F00F2EF6E /* CorrectionRangeReview.swift */,
 				898B4E7A246DC6A70053C484 /* CorrectionRangeScheduleEditor.swift */,
 				E949E38A24B35DA400024DA0 /* DeliveryLimitsEditor.swift */,
-				1D66303E24C662ED00F2EF6E /* DeliveryLimitsReviewView.swift */,
+				1D66303E24C662ED00F2EF6E /* DeliveryLimitsReview.swift */,
 				1D1FCE2C24BEA669000300A8 /* Guardrail+Settings.swift */,
 				89FC688A245A2D670075CF59 /* InsulinSensitivityScheduleEditor.swift */,
 				1D6EAB9024C12C090081249D /* PumpSupportedIncrements.swift */,
@@ -3087,7 +3087,7 @@
 				43F5035A21059AF7009FA89A /* AuthenticationTableViewCell.swift in Sources */,
 				E916F56924AD32F000BE3547 /* CorrectionRangeOverridesEditor.swift in Sources */,
 				43BA7163201E490D0058961E /* InsulinDeliveryTableViewController.swift in Sources */,
-				1D66304024C662ED00F2EF6E /* DeliveryLimitsReviewView.swift in Sources */,
+				1D66304024C662ED00F2EF6E /* DeliveryLimitsReview.swift in Sources */,
 				C1E4B30A242E99A800E70CCB /* Image.swift in Sources */,
 				43BA718A201EE8CF0058961E /* NSTimeInterval.swift in Sources */,
 				B4A2AAB1240830A30066563F /* LabeledTextField.swift in Sources */,
@@ -3168,7 +3168,7 @@
 				43BA7188201EE85B0058961E /* HKUnit.swift in Sources */,
 				B4F3D24F24AF59B50095CE44 /* DeviceLifecycleProgressState+Color.swift in Sources */,
 				89F6E30D2449713600CB9E15 /* CardStack.swift in Sources */,
-				1D66303924C6563000F2EF6E /* CorrectionRangeReviewView.swift in Sources */,
+				1D66303924C6563000F2EF6E /* CorrectionRangeReview.swift in Sources */,
 				89BE75C324649C4C00B145D9 /* RoundedCorners.swift in Sources */,
 				C1E4B306242E98E900E70CCB /* ProgressIndicatorView.swift in Sources */,
 				4369F092208B0DFF000E3E45 /* DateAndDurationTableViewCell.swift in Sources */,

--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -735,6 +735,7 @@
 		E96DCB5824AEF50F007117BC /* SuspendThresholdInformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E96DCB5724AEF50F007117BC /* SuspendThresholdInformationView.swift */; };
 		E96DCB5A24AF74AC007117BC /* SuspendThresholdEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E96DCB5924AF74AC007117BC /* SuspendThresholdEditor.swift */; };
 		E96DCB5E24AF7DC7007117BC /* BasalRatesInformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E96DCB5D24AF7DC7007117BC /* BasalRatesInformationView.swift */; };
+		E9D95F6524C7BC400079F47D /* PresentationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D95F6424C7BC400079F47D /* PresentationMode.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1508,6 +1509,7 @@
 		E96DCB5724AEF50F007117BC /* SuspendThresholdInformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuspendThresholdInformationView.swift; sourceTree = "<group>"; };
 		E96DCB5924AF74AC007117BC /* SuspendThresholdEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuspendThresholdEditor.swift; sourceTree = "<group>"; };
 		E96DCB5D24AF7DC7007117BC /* BasalRatesInformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasalRatesInformationView.swift; sourceTree = "<group>"; };
+		E9D95F6424C7BC400079F47D /* PresentationMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationMode.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2497,6 +2499,7 @@
 				1D1FCE2A24BE704A000300A8 /* TherapySetting+Settings.swift */,
 				1D1A019D24B678BF0077D86E /* TherapySettingsView.swift */,
 				1D1FCE2424BD42EF000300A8 /* TherapySettingsViewModel.swift */,
+				E9D95F6424C7BC400079F47D /* PresentationMode.swift */,
 			);
 			path = "Settings Editors";
 			sourceTree = "<group>";
@@ -3187,6 +3190,7 @@
 				43BA717B201EE6A40058961E /* NibLoadable.swift in Sources */,
 				E916F56F24AE2FFE00BE3547 /* CorrectionRangeOverrideInformationView.swift in Sources */,
 				89BE75C124649C2E00B145D9 /* ModalHeaderButtonBar.swift in Sources */,
+				E9D95F6524C7BC400079F47D /* PresentationMode.swift in Sources */,
 				89186C0524BEC9CA0003D0F3 /* SegmentedControlTableViewCell.swift in Sources */,
 				89F6E315244A1AB600CB9E15 /* GlucoseValuePicker.swift in Sources */,
 				895FE08122011F0C00FCF18A /* OverridePresetCollectionViewCell.swift in Sources */,
@@ -3326,7 +3330,6 @@
 				434C5F9C2098352500B2FD1A /* QuantityFormatter.swift in Sources */,
 				43F503642106C78C009FA89A /* ServiceAuthentication.swift in Sources */,
 				89F53E9422B4328E0024A67C /* MutableCollection.swift in Sources */,
-				1D096C0124C24C220078B6B5 /* WalshInsulinModel+RawRepresentable.swift in Sources */,
 				433BC7A720523DB7000B1200 /* NewGlucoseSample.swift in Sources */,
 				4322B78E202FA2B30002837D /* InsulinMath.swift in Sources */,
 				C17F39D023CE34B100FA1113 /* StoredDeviceLogEntry.swift in Sources */,
@@ -3556,7 +3559,6 @@
 				A9E6759922713F4700E25293 /* GlucoseSampleValue.swift in Sources */,
 				A9E6759A22713F4700E25293 /* SensorDisplayable.swift in Sources */,
 				A9E6759B22713F4700E25293 /* PersistenceController.swift in Sources */,
-				1D096C0824C627130078B6B5 /* WalshInsulinModel+RawRepresentable.swift in Sources */,
 				B4B85FD024A2318A00A296A3 /* GlucoseValueType.swift in Sources */,
 				A9E6759C22713F4700E25293 /* InsulinDeliveryStore.swift in Sources */,
 				A9E6759D22713F4700E25293 /* DeviceManager.swift in Sources */,

--- a/LoopKit/DeviceManager/PumpManager.swift
+++ b/LoopKit/DeviceManager/PumpManager.swift
@@ -170,6 +170,8 @@ public protocol PumpManager: DeviceManager {
     ///   - rate: The maximum rate the pumpmanager should expect to receive in an enactTempBasal command.
     func setMaximumTempBasalRate(_ rate: Double)
 
+    typealias SyncSchedule = (_ items: [RepeatingScheduleValue<Double>], _ completion: @escaping (Result<BasalRateSchedule, Error>) -> Void) -> Void
+
     /// Sync the schedule of basal rates to the pump, annotating the result with the proper time zone.
     ///
     /// - Precondition:

--- a/LoopKit/Insulin/InsulinModelSettings.swift
+++ b/LoopKit/Insulin/InsulinModelSettings.swift
@@ -90,6 +90,21 @@ extension InsulinModelSettings: RawRepresentable {
     }
 }
 
+public extension InsulinModelSettings {
+    init?(from storedSettingsInsulinModel: StoredSettings.InsulinModel) {
+        switch storedSettingsInsulinModel.modelType {
+        case .fiasp:
+            self = .exponentialPreset(.fiasp)
+        case .rapidAdult:
+            self = .exponentialPreset(.humalogNovologAdult)
+        case .rapidChild:
+            self = .exponentialPreset(.humalogNovologChild)
+        case .walsh:
+            self = .walsh(WalshInsulinModel(actionDuration: storedSettingsInsulinModel.actionDuration))
+        }
+    }
+}
+
 public extension StoredSettings.InsulinModel {
     init?(_ insulinModelSettings: InsulinModelSettings?) {
         guard let insulinModelSettings = insulinModelSettings else {

--- a/LoopKitUI/Views/Information Screens/BasalRatesInformationView.swift
+++ b/LoopKitUI/Views/Information Screens/BasalRatesInformationView.swift
@@ -15,8 +15,7 @@ public struct BasalRatesInformationView: View {
     
     @Environment(\.presentationMode) var presentationMode
     
-    public init(onExit: (() -> Void)?,
-                mode: PresentationMode = .flow) {
+    public init(onExit: (() -> Void)?, mode: PresentationMode = .acceptanceFlow) {
         self.onExit = onExit
         self.mode = mode
     }

--- a/LoopKitUI/Views/Information Screens/CorrectionRangeInformationView.swift
+++ b/LoopKitUI/Views/Information Screens/CorrectionRangeInformationView.swift
@@ -15,8 +15,7 @@ public struct CorrectionRangeInformationView: View {
     
     @Environment(\.presentationMode) var presentationMode
     
-    public init(onExit: (() -> Void)?,
-                mode: PresentationMode = .flow) {
+    public init(onExit: (() -> Void)?, mode: PresentationMode = .acceptanceFlow) {
         self.onExit = onExit
         self.mode = mode
     }

--- a/LoopKitUI/Views/Information Screens/CorrectionRangeOverrideInformationView.swift
+++ b/LoopKitUI/Views/Information Screens/CorrectionRangeOverrideInformationView.swift
@@ -25,7 +25,7 @@ public struct CorrectionRangeOverrideInformationView: View {
     
     public var body: some View {
         InformationView(
-            title: Text(TherapySetting.correctionRangeOverrides.title),
+            title: Text(TherapySetting.correctionRangeOverrides.smallTitle),
             buttonText: Text(LocalizedString("Next: Review Setting", comment: "Button to advance to setting editor")),
             informationalContent: {
                 VStack (alignment: .leading, spacing: 20) {

--- a/LoopKitUI/Views/Information Screens/CorrectionRangeOverrideInformationView.swift
+++ b/LoopKitUI/Views/Information Screens/CorrectionRangeOverrideInformationView.swift
@@ -17,7 +17,7 @@ public struct CorrectionRangeOverrideInformationView: View {
     
     public init(
         onExit: (() -> Void)?,
-        mode: PresentationMode = .flow
+        mode: PresentationMode = .acceptanceFlow
     ) {
         self.onExit = onExit
         self.mode = mode

--- a/LoopKitUI/Views/Information Screens/DeliveryLimitsInformationView.swift
+++ b/LoopKitUI/Views/Information Screens/DeliveryLimitsInformationView.swift
@@ -15,7 +15,7 @@ public struct DeliveryLimitsInformationView: View {
     
     @Environment(\.presentationMode) var presentationMode
     
-    public init(onExit: (() -> Void)?, mode: PresentationMode = .flow) {
+    public init(onExit: (() -> Void)?, mode: PresentationMode = .acceptanceFlow) {
         self.onExit = onExit
         self.mode = mode
     }

--- a/LoopKitUI/Views/Information Screens/InformationView.swift
+++ b/LoopKitUI/Views/Information Screens/InformationView.swift
@@ -8,10 +8,6 @@
 
 import SwiftUI
 
-public enum PresentationMode {
-    case modal, flow
-}
-
 struct InformationView<InformationalContent: View> : View {
     var informationalContent: InformationalContent
     var title: Text
@@ -24,7 +20,7 @@ struct InformationView<InformationalContent: View> : View {
         buttonText: Text,
         @ViewBuilder informationalContent: () -> InformationalContent,
         onExit: @escaping () -> Void,
-        mode: PresentationMode = .flow
+        mode: PresentationMode = .acceptanceFlow
     ) {
         self.title = title
         self.buttonText = buttonText
@@ -43,9 +39,9 @@ struct InformationView<InformationalContent: View> : View {
     
     private var bodyWithCancelButtonIfNeeded: some View {
         switch mode {
-        case .flow:
+        case .acceptanceFlow:
             return AnyView(bodyWithBottomButton)
-        case .modal:
+        case .settings, .legacySettings:
             return AnyView(bodyWithCancelButton)
         }
     }

--- a/LoopKitUI/Views/Information Screens/SuspendThresholdInformationView.swift
+++ b/LoopKitUI/Views/Information Screens/SuspendThresholdInformationView.swift
@@ -17,7 +17,7 @@ public struct SuspendThresholdInformationView: View {
     
     public init(
         onExit: (() -> Void)?,
-        mode: PresentationMode = .flow
+        mode: PresentationMode = .acceptanceFlow
     ){
         self.onExit = onExit
         self.mode = mode

--- a/LoopKitUI/Views/QuantityScheduleEditor.swift
+++ b/LoopKitUI/Views/QuantityScheduleEditor.swift
@@ -109,7 +109,7 @@ struct QuantityScheduleEditor<ActionAreaContent: View>: View {
     
     private var instructionalContentIfNecessary: some View {
         return Group {
-            if mode == .flow && !userDidTap {
+            if mode == .acceptanceFlow && !userDidTap {
                 instructionalContent
             }
         }
@@ -130,7 +130,7 @@ struct QuantityScheduleEditor<ActionAreaContent: View>: View {
     private var guardrailWarningIfNecessary: some View {
         let crossedThresholds = self.crossedThresholds
         return Group {
-            if !crossedThresholds.isEmpty {
+            if !crossedThresholds.isEmpty && (userDidTap || mode == .settings || mode == .legacySettings) {
                 guardrailWarning(crossedThresholds)
             }
         }
@@ -167,7 +167,7 @@ extension QuantityScheduleEditor {
         confirmationAlertContent: AlertContent,
         @ViewBuilder guardrailWarning: @escaping (_ thresholds: [SafetyClassification.Threshold]) -> ActionAreaContent,
         onSave savingMechanism: SavingMechanism<DailyQuantitySchedule<Double>>,
-        mode: PresentationMode = .modal,
+        mode: PresentationMode = .legacySettings,
         settingType: TherapySetting = .none
     ) {
         self.buttonText = buttonText

--- a/LoopKitUI/Views/QuantityScheduleEditor.swift
+++ b/LoopKitUI/Views/QuantityScheduleEditor.swift
@@ -36,7 +36,6 @@ struct QuantityScheduleEditor<ActionAreaContent: View>: View {
     var buttonText: Text
     var settingType: TherapySetting
     
-    @Environment(\.dismiss) var dismiss
     @State private var userDidTap: Bool = false
 
     var body: some View {
@@ -200,7 +199,9 @@ extension QuantityScheduleEditor {
         scheduleItemLimit: Int = 48,
         confirmationAlertContent: AlertContent,
         @ViewBuilder guardrailWarning: @escaping (_ thresholds: [SafetyClassification.Threshold]) -> ActionAreaContent,
-        onSave save: @escaping (DailyQuantitySchedule<Double>) -> Void
+        onSave save: @escaping (DailyQuantitySchedule<Double>) -> Void,
+        mode: PresentationMode = .legacySettings,
+        settingType: TherapySetting = .none
     ) {
         let selectableValues = guardrail.allValues(stridingBy: selectableValueStride, unit: unit)
         self.init(
@@ -215,7 +216,9 @@ extension QuantityScheduleEditor {
             scheduleItemLimit: scheduleItemLimit,
             confirmationAlertContent: confirmationAlertContent,
             guardrailWarning: guardrailWarning,
-            onSave: .synchronous(save)
+            onSave: .synchronous(save),
+            mode: mode,
+            settingType: settingType
         )
     }
 }

--- a/LoopKitUI/Views/ScheduleEditor.swift
+++ b/LoopKitUI/Views/ScheduleEditor.swift
@@ -88,7 +88,7 @@ struct ScheduleEditor<Value: Equatable, ValueContent: View, ValuePicker: View, A
         @ViewBuilder valuePicker: @escaping (_ item: Binding<RepeatingScheduleValue<Value>>, _ availableWidth: CGFloat) -> ValuePicker,
         @ViewBuilder actionAreaContent: () -> ActionAreaContent,
         savingMechanism: SavingMechanism<[RepeatingScheduleValue<Value>]>,
-        mode: PresentationMode = .modal,
+        mode: PresentationMode = .legacySettings,
         therapySettingType: TherapySetting = .none
     ) {
         self.title = title
@@ -140,9 +140,9 @@ struct ScheduleEditor<Value: Equatable, ValueContent: View, ValuePicker: View, A
     
     private var setupConfigurationPage: some View {
         switch mode {
-        case .modal:
+        case .legacySettings:
             return AnyView(wrappedPage)
-        case .flow:
+        case .acceptanceFlow, .settings:
             return AnyView(configurationPage)
         }
     }
@@ -199,7 +199,7 @@ struct ScheduleEditor<Value: Equatable, ValueContent: View, ValuePicker: View, A
         }
 
         let isEnabled = !scheduleItems.isEmpty
-            && (scheduleItems != initialScheduleItems || mode == .flow)
+            && (scheduleItems != initialScheduleItems || mode == .acceptanceFlow)
             && tableDeletionState == .disabled
 
         return isEnabled ? .enabled : .disabled
@@ -306,9 +306,9 @@ struct ScheduleEditor<Value: Equatable, ValueContent: View, ValuePicker: View, A
     
     private var buttonText: Text {
         switch mode {
-        case .modal:
+        case .settings, .legacySettings:
             return Text("Save", comment: "The button text for saving on a configuration page")
-        case .flow:
+        case .acceptanceFlow:
             return scheduleItems == initialScheduleItems ? Text(LocalizedString("Accept Setting", comment: "The button text for accepting the prescribed setting")) : Text(LocalizedString("Save Setting", comment: "The button text for saving the edited setting"))
         }
     }
@@ -364,7 +364,7 @@ struct ScheduleEditor<Value: Equatable, ValueContent: View, ValuePicker: View, A
         switch savingMechanism {
         case .synchronous(let save):
             save(scheduleItems)
-            if mode == .modal {
+            if mode == .legacySettings {
                 dismiss()
             }
         case .asynchronous(let save):
@@ -380,7 +380,7 @@ struct ScheduleEditor<Value: Equatable, ValueContent: View, ValuePicker: View, A
                             self.isSyncing = false
                         }
                         self.presentedAlert = .saveError(error)
-                    } else if self.mode == .modal {
+                    } else if self.mode == .legacySettings {
                         self.dismiss()
                     }
                 }

--- a/LoopKitUI/Views/Settings Editors/BasalRateScheduleEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/BasalRateScheduleEditor.swift
@@ -28,7 +28,7 @@ public struct BasalRateScheduleEditor: View {
         maximumScheduleEntryCount: Int,
         syncSchedule: PumpManager.SyncSchedule?,
         onSave save: @escaping (BasalRateSchedule) -> Void,
-        mode: PresentationMode = .modal
+        mode: PresentationMode = .legacySettings
     ) {
         self.schedule = schedule.map { schedule in
             DailyQuantitySchedule(
@@ -88,7 +88,7 @@ public struct BasalRateScheduleEditor: View {
     
     private var savingMechanism: SavingMechanism<DailyQuantitySchedule<Double>> {
         switch mode {
-        case .modal:
+        case .settings, .legacySettings:
             return .asynchronous { quantitySchedule, completion in
                 self.syncSchedule?(quantitySchedule.items) { result in
                     switch result {
@@ -103,7 +103,7 @@ public struct BasalRateScheduleEditor: View {
 
                 }
             }
-        case .flow:
+        case .acceptanceFlow:
             // TODO: get timezone from pump
             return .synchronous { quantitySchedule in
                 let schedule = BasalRateSchedule(dailyItems: quantitySchedule.items, timeZone: .currentFixed)!

--- a/LoopKitUI/Views/Settings Editors/BasalRateScheduleEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/BasalRateScheduleEditor.swift
@@ -16,7 +16,7 @@ public struct BasalRateScheduleEditor: View {
     var supportedBasalRates: [Double]
     var guardrail: Guardrail<HKQuantity>
     var maximumScheduleEntryCount: Int
-    var syncSchedule: (_ items: [RepeatingScheduleValue<Double>], _ completion: @escaping (Result<BasalRateSchedule, Error>) -> Void) -> Void
+    var syncSchedule: PumpManager.SyncSchedule?
     var save: (BasalRateSchedule) -> Void
     let mode: PresentationMode
 
@@ -26,10 +26,7 @@ public struct BasalRateScheduleEditor: View {
         supportedBasalRates: [Double],
         maximumBasalRate: Double?,
         maximumScheduleEntryCount: Int,
-        syncSchedule: @escaping (
-            _ items: [RepeatingScheduleValue<Double>],
-            _ completion: @escaping (Result<BasalRateSchedule, Error>) -> Void
-        ) -> Void,
+        syncSchedule: PumpManager.SyncSchedule?,
         onSave save: @escaping (BasalRateSchedule) -> Void,
         mode: PresentationMode = .modal
     ) {
@@ -93,7 +90,7 @@ public struct BasalRateScheduleEditor: View {
         switch mode {
         case .modal:
             return .asynchronous { quantitySchedule, completion in
-                self.syncSchedule(quantitySchedule.items) { result in
+                self.syncSchedule?(quantitySchedule.items) { result in
                     switch result {
                     case .success(let syncedSchedule):
                         DispatchQueue.main.async {

--- a/LoopKitUI/Views/Settings Editors/BasalRateScheduleEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/BasalRateScheduleEditor.swift
@@ -90,6 +90,7 @@ public struct BasalRateScheduleEditor: View {
         switch mode {
         case .settings, .legacySettings:
             return .asynchronous { quantitySchedule, completion in
+                precondition(self.syncSchedule != nil)
                 self.syncSchedule?(quantitySchedule.items) { result in
                     switch result {
                     case .success(let syncedSchedule):
@@ -100,7 +101,6 @@ public struct BasalRateScheduleEditor: View {
                     case .failure(let error):
                         completion(error)
                     }
-
                 }
             }
         case .acceptanceFlow:

--- a/LoopKitUI/Views/Settings Editors/BasalRatesReview.swift
+++ b/LoopKitUI/Views/Settings Editors/BasalRatesReview.swift
@@ -16,25 +16,22 @@ public struct BasalRatesReview: View {
     
     public init(mode: PresentationMode = .acceptanceFlow, viewModel: TherapySettingsViewModel) {
         precondition(viewModel.therapySettings.glucoseUnit != nil)
+        precondition(viewModel.pumpSupportedIncrements != nil)
         self.viewModel = viewModel
         self.mode = mode
     }
     
     @ViewBuilder public var body: some View {
-        if viewModel.pumpSupportedIncrements != nil {
-            BasalRateScheduleEditor(
-                schedule: viewModel.therapySettings.basalRateSchedule,
-                supportedBasalRates: viewModel.pumpSupportedIncrements!.basalRates ,
-                maximumBasalRate: viewModel.therapySettings.maximumBasalRatePerHour,
-                maximumScheduleEntryCount: viewModel.pumpSupportedIncrements!.maximumBasalScheduleEntryCount,
-                syncSchedule: viewModel.pumpSyncSchedule,
-                onSave: { newRates in
-                    self.viewModel.saveBasalRates(basalRates: newRates)
-                },
-                mode: mode
-            )
-        } else {
-            Text("No Pump")
-        }
+        return BasalRateScheduleEditor(
+            schedule: viewModel.therapySettings.basalRateSchedule,
+            supportedBasalRates: viewModel.pumpSupportedIncrements!.basalRates ,
+            maximumBasalRate: viewModel.therapySettings.maximumBasalRatePerHour,
+            maximumScheduleEntryCount: viewModel.pumpSupportedIncrements!.maximumBasalScheduleEntryCount,
+            syncSchedule: viewModel.pumpSyncSchedule,
+            onSave: { newRates in
+                self.viewModel.saveBasalRates(basalRates: newRates)
+        },
+            mode: mode
+        )
     }
 }

--- a/LoopKitUI/Views/Settings Editors/BasalRatesReview.swift
+++ b/LoopKitUI/Views/Settings Editors/BasalRatesReview.swift
@@ -14,7 +14,7 @@ public struct BasalRatesReview: View {
     @ObservedObject var viewModel: TherapySettingsViewModel
     private let mode: PresentationMode
     
-    public init(mode: PresentationMode = .flow, viewModel: TherapySettingsViewModel) {
+    public init(mode: PresentationMode = .acceptanceFlow, viewModel: TherapySettingsViewModel) {
         precondition(viewModel.therapySettings.glucoseUnit != nil)
         self.viewModel = viewModel
         self.mode = mode

--- a/LoopKitUI/Views/Settings Editors/BasalRatesReview.swift
+++ b/LoopKitUI/Views/Settings Editors/BasalRatesReview.swift
@@ -30,7 +30,6 @@ public struct BasalRatesReview: View {
                 syncSchedule: viewModel.pumpSyncSchedule,
                 onSave: { newRates in
                     self.viewModel.saveBasalRates(basalRates: newRates)
-                    self.viewModel.didFinishEditing?()
                 },
                 mode: mode
             )

--- a/LoopKitUI/Views/Settings Editors/BasalRatesReview.swift
+++ b/LoopKitUI/Views/Settings Editors/BasalRatesReview.swift
@@ -1,0 +1,41 @@
+//
+//  BasalRatesReview.swift
+//  TidepoolServiceKitUI
+//
+//  Created by Anna Quinlan on 7/3/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+import LoopKit
+import HealthKit
+
+public struct BasalRatesReview: View {
+    @ObservedObject var viewModel: TherapySettingsViewModel
+    private let mode: PresentationMode
+    
+    public init(mode: PresentationMode = .flow, viewModel: TherapySettingsViewModel) {
+        precondition(viewModel.therapySettings.glucoseUnit != nil)
+        self.viewModel = viewModel
+        self.mode = mode
+    }
+    
+    @ViewBuilder public var body: some View {
+        if viewModel.pumpSupportedIncrements != nil {
+            BasalRateScheduleEditor(
+                schedule: viewModel.therapySettings.basalRateSchedule,
+                supportedBasalRates: viewModel.pumpSupportedIncrements!.basalRates ,
+                maximumBasalRate: viewModel.therapySettings.maximumBasalRatePerHour,
+                maximumScheduleEntryCount: viewModel.pumpSupportedIncrements!.maximumBasalScheduleEntryCount,
+                syncSchedule: viewModel.pumpSyncSchedule,
+                onSave: { newRates in
+                    self.viewModel.saveBasalRates(basalRates: newRates)
+                    self.viewModel.didFinishEditing?()
+                },
+                mode: mode
+            )
+        } else {
+            Text("No Pump")
+        }
+    }
+}

--- a/LoopKitUI/Views/Settings Editors/BasalRatesReview.swift
+++ b/LoopKitUI/Views/Settings Editors/BasalRatesReview.swift
@@ -1,6 +1,6 @@
 //
 //  BasalRatesReview.swift
-//  TidepoolServiceKitUI
+//  LoopKitUI
 //
 //  Created by Anna Quinlan on 7/3/20.
 //  Copyright © 2020 LoopKit Authors. All rights reserved.

--- a/LoopKitUI/Views/Settings Editors/CarbRatioScheduleEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CarbRatioScheduleEditor.swift
@@ -63,7 +63,7 @@ public struct CarbRatioScheduleEditor: View {
                 self.save(DailyQuantitySchedule(unit: .storedCarbRatioScheduleUnit, dailyItems: $0.items)!)
             },
             mode: mode,
-            settingType: TherapySetting.carbRatio
+            settingType: .carbRatio
         )
     }
 

--- a/LoopKitUI/Views/Settings Editors/CarbRatioScheduleEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CarbRatioScheduleEditor.swift
@@ -26,10 +26,12 @@ extension Guardrail where Value == HKQuantity {
 
 public struct CarbRatioScheduleEditor: View {
     private var schedule: DailyQuantitySchedule<Double>?
+    private var mode: PresentationMode
     private var save: (CarbRatioSchedule) -> Void
 
     public init(
         schedule: CarbRatioSchedule?,
+        mode: PresentationMode = .legacySettings,
         onSave save: @escaping (CarbRatioSchedule) -> Void
     ) {
         // CarbRatioSchedule stores only the gram unit.
@@ -40,6 +42,7 @@ public struct CarbRatioScheduleEditor: View {
                 dailyItems: schedule.items
             )!
         }
+        self.mode = mode
         self.save = save
     }
 
@@ -58,7 +61,9 @@ public struct CarbRatioScheduleEditor: View {
             onSave: {
                 // Convert back to the expected gram-unit-only schedule.
                 self.save(DailyQuantitySchedule(unit: .storedCarbRatioScheduleUnit, dailyItems: $0.items)!)
-            }
+            },
+            mode: mode,
+            settingType: TherapySetting.carbRatio
         )
     }
 

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeOverrideReview.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeOverrideReview.swift
@@ -12,6 +12,7 @@ import HealthKit
 
 public struct CorrectionRangeOverrideReview: View {
     @ObservedObject var viewModel: TherapySettingsViewModel
+    private let sensitivityOverridesEnabled: Bool
     private let mode: PresentationMode
     private var unit: HKUnit {
         self.viewModel.therapySettings.glucoseUnit!
@@ -22,6 +23,7 @@ public struct CorrectionRangeOverrideReview: View {
         precondition(viewModel.therapySettings.glucoseTargetRangeSchedule != nil)
         self.mode = mode
         self.viewModel = viewModel
+        self.sensitivityOverridesEnabled = viewModel.sensitivityOverridesEnabled
     }
     
     public var body: some View {
@@ -32,12 +34,12 @@ public struct CorrectionRangeOverrideReview: View {
                 unit: unit
             ),
             unit: unit,
-            correctionRangeScheduleRange: (viewModel.therapySettings.glucoseTargetRangeSchedule?.scheduleRange())!,
+            correctionRangeScheduleRange: viewModel.therapySettings.glucoseTargetRangeSchedule!.scheduleRange(),
             minValue: viewModel.therapySettings.suspendThreshold?.quantity,
             onSave: { overrides in
                 self.viewModel.saveCorrectionRangeOverrides(overrides: overrides, unit: self.unit)
             },
-            sensitivityOverridesEnabled: false,
+            sensitivityOverridesEnabled: sensitivityOverridesEnabled,
             mode: mode
         )
     }

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeOverrideReview.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeOverrideReview.swift
@@ -1,0 +1,45 @@
+//
+//  CorrectionRangeOverrideReviewView.swift
+//  LoopKitUI
+//
+//  Created by Anna Quinlan on 7/1/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+import LoopKit
+import HealthKit
+
+public struct CorrectionRangeOverrideReview: View {
+    @ObservedObject var viewModel: TherapySettingsViewModel
+    private let mode: PresentationMode
+    private var unit: HKUnit {
+        self.viewModel.therapySettings.glucoseUnit!
+    }
+
+    public init(mode: PresentationMode = .flow, viewModel: TherapySettingsViewModel) {
+        precondition(viewModel.therapySettings.glucoseUnit != nil)
+        precondition(viewModel.therapySettings.glucoseTargetRangeSchedule != nil)
+        self.mode = mode
+        self.viewModel = viewModel
+    }
+    
+    public var body: some View {
+        CorrectionRangeOverridesEditor(
+            value: CorrectionRangeOverrides(
+                preMeal: viewModel.therapySettings.preMealTargetRange,
+                workout: viewModel.therapySettings.workoutTargetRange,
+                unit: unit
+            ),
+            unit: unit,
+            correctionRangeScheduleRange: (viewModel.therapySettings.glucoseTargetRangeSchedule?.scheduleRange())!,
+            minValue: viewModel.therapySettings.suspendThreshold?.quantity,
+            onSave: { overrides in
+                self.viewModel.saveCorrectionRangeOverrides(overrides: overrides, unit: self.unit)
+                self.viewModel.didFinishEditing?()
+            },
+            sensitivityOverridesEnabled: false,
+            mode: mode
+        )
+    }
+}

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeOverrideReview.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeOverrideReview.swift
@@ -17,7 +17,7 @@ public struct CorrectionRangeOverrideReview: View {
         self.viewModel.therapySettings.glucoseUnit!
     }
 
-    public init(mode: PresentationMode = .flow, viewModel: TherapySettingsViewModel) {
+    public init(mode: PresentationMode = .acceptanceFlow, viewModel: TherapySettingsViewModel) {
         precondition(viewModel.therapySettings.glucoseUnit != nil)
         precondition(viewModel.therapySettings.glucoseTargetRangeSchedule != nil)
         self.mode = mode

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeOverrideReview.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeOverrideReview.swift
@@ -36,7 +36,6 @@ public struct CorrectionRangeOverrideReview: View {
             minValue: viewModel.therapySettings.suspendThreshold?.quantity,
             onSave: { overrides in
                 self.viewModel.saveCorrectionRangeOverrides(overrides: overrides, unit: self.unit)
-                self.viewModel.didFinishEditing?()
             },
             sensitivityOverridesEnabled: false,
             mode: mode

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
@@ -41,7 +41,7 @@ public struct CorrectionRangeOverridesEditor: View {
         minValue: HKQuantity?,
         onSave save: @escaping (_ overrides: CorrectionRangeOverrides) -> Void,
         sensitivityOverridesEnabled: Bool,
-        mode: PresentationMode = .modal
+        mode: PresentationMode = .legacySettings
     ) {
         self._value = State(initialValue: value)
         self.initialValue = value
@@ -57,7 +57,7 @@ public struct CorrectionRangeOverridesEditor: View {
         ConfigurationPage(
             title: Text(TherapySetting.correctionRangeOverrides.smallTitle),
             actionButtonTitle: buttonText,
-            actionButtonState: value != initialValue || mode == .flow ? .enabled : .disabled,
+            actionButtonState: value != initialValue || mode == .acceptanceFlow ? .enabled : .disabled,
             cards: {
                 card(for: .preMeal)
                 if !sensitivityOverridesEnabled {
@@ -77,6 +77,7 @@ public struct CorrectionRangeOverridesEditor: View {
             }
         )
         .alert(isPresented: $showingConfirmationAlert, content: confirmationAlert)
+        .navigationBarTitle("", displayMode: .inline)
         .onTapGesture {
             self.userDidTap = true
         }
@@ -131,16 +132,16 @@ public struct CorrectionRangeOverridesEditor: View {
 
     private var buttonText: Text {
         switch mode {
-        case .modal:
+        case .settings, .legacySettings:
             return Text("Save", comment: "The button text for saving on a configuration page")
-        case .flow:
+        case .acceptanceFlow:
             return self.initialValue == self.value ? Text(LocalizedString("Accept Setting", comment: "The button text for accepting the prescribed setting")) : Text(LocalizedString("Save Setting", comment: "The button text for saving the edited setting"))
         }
     }
     
     private var instructionalContentIfNecessary: some View {
         return Group {
-            if mode == .flow && !userDidTap {
+            if mode == .acceptanceFlow && !userDidTap {
                 instructionalContent
             }
         }
@@ -179,7 +180,7 @@ public struct CorrectionRangeOverridesEditor: View {
     private var guardrailWarningIfNecessary: some View {
         let crossedThresholds = self.crossedThresholds
         return Group {
-            if !crossedThresholds.isEmpty && (userDidTap || mode == .modal) {
+            if !crossedThresholds.isEmpty && (userDidTap || mode == .settings || mode == .legacySettings) {
                 CorrectionRangeOverridesGuardrailWarning(crossedThresholds: crossedThresholds)
             }
         }
@@ -216,7 +217,7 @@ public struct CorrectionRangeOverridesEditor: View {
 
     private func saveAndDismiss() {
         save(value)
-        if mode == .modal {
+        if mode == .legacySettings {
             dismiss()
         }
     }

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeReview.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeReview.swift
@@ -1,5 +1,5 @@
 //
-//  CorrectionRangeReviewView.swift
+//  CorrectionRangeReview.swift
 //  LoopKitUI
 //
 //  Created by Anna Quinlan on 6/29/20.
@@ -9,7 +9,7 @@ import SwiftUI
 import LoopKit
 
 
-public struct CorrectionRangeReviewView: View {
+public struct CorrectionRangeReview: View {
     @ObservedObject var viewModel: TherapySettingsViewModel
     
     private let mode: PresentationMode

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeReviewView.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeReviewView.swift
@@ -14,7 +14,7 @@ public struct CorrectionRangeReviewView: View {
     
     private let mode: PresentationMode
     
-    public init(mode: PresentationMode = .flow, viewModel: TherapySettingsViewModel) {
+    public init(mode: PresentationMode = .acceptanceFlow, viewModel: TherapySettingsViewModel) {
         precondition(viewModel.therapySettings.glucoseUnit != nil)
         self.mode = mode
         self.viewModel = viewModel
@@ -29,7 +29,7 @@ public struct CorrectionRangeReviewView: View {
                 self.viewModel.saveCorrectionRange(range: newSchedule)
                 self.viewModel.didFinishEditing?()
             },
-            mode: self.mode
+            mode: mode
         )
     }
 }

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeReviewView.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeReviewView.swift
@@ -1,0 +1,35 @@
+//
+//  CorrectionRangeReviewView.swift
+//  LoopKitUI
+//
+//  Created by Anna Quinlan on 6/29/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+import SwiftUI
+import LoopKit
+
+
+public struct CorrectionRangeReviewView: View {
+    @ObservedObject var viewModel: TherapySettingsViewModel
+    
+    private let mode: PresentationMode
+    
+    public init(mode: PresentationMode = .flow, viewModel: TherapySettingsViewModel) {
+        precondition(viewModel.therapySettings.glucoseUnit != nil)
+        self.mode = mode
+        self.viewModel = viewModel
+    }
+    
+    public var body: some View {
+        CorrectionRangeScheduleEditor(
+            schedule: viewModel.therapySettings.glucoseTargetRangeSchedule,
+            unit: viewModel.therapySettings.glucoseUnit!,
+            minValue: viewModel.therapySettings.suspendThreshold?.quantity,
+            onSave: { newSchedule in
+                self.viewModel.saveCorrectionRange(range: newSchedule)
+                self.viewModel.didFinishEditing?()
+            },
+            mode: self.mode
+        )
+    }
+}

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeReviewView.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeReviewView.swift
@@ -27,7 +27,6 @@ public struct CorrectionRangeReviewView: View {
             minValue: viewModel.therapySettings.suspendThreshold?.quantity,
             onSave: { newSchedule in
                 self.viewModel.saveCorrectionRange(range: newSchedule)
-                self.viewModel.didFinishEditing?()
             },
             mode: mode
         )

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeScheduleEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeScheduleEditor.swift
@@ -30,7 +30,7 @@ public struct CorrectionRangeScheduleEditor: View {
         unit: HKUnit,
         minValue: HKQuantity?,
         onSave save: @escaping (GlucoseRangeSchedule) -> Void,
-        mode: PresentationMode = .modal
+        mode: PresentationMode = .legacySettings
     ) {
         self.initialSchedule = schedule
         self._scheduleItems = State(initialValue: schedule?.items ?? [])
@@ -105,7 +105,7 @@ public struct CorrectionRangeScheduleEditor: View {
     
     var instructionalContentIfNecessary: some View {
         return Group {
-            if mode == .flow && !userDidTap {
+            if mode == .acceptanceFlow && !userDidTap {
                 instructionalContent
             }
         }
@@ -126,7 +126,7 @@ public struct CorrectionRangeScheduleEditor: View {
     var guardrailWarningIfNecessary: some View {
         let crossedThresholds = self.crossedThresholds
         return Group {
-            if !crossedThresholds.isEmpty && (userDidTap || mode == .modal) {
+            if !crossedThresholds.isEmpty && (userDidTap || mode == .settings || mode == .legacySettings) {
                 CorrectionRangeGuardrailWarning(crossedThresholds: crossedThresholds)
             }
         }

--- a/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
@@ -82,7 +82,7 @@ public struct DeliveryLimitsEditor: View {
             return .disabled
         }
 
-        return value == initialValue || mode != .acceptanceFlow ? .disabled : .enabled
+        return value == initialValue ? .disabled : .enabled
     }
 
     var maximumBasalRateGuardrail: Guardrail<HKQuantity> {
@@ -200,7 +200,11 @@ public struct DeliveryLimitsEditor: View {
     }
     
     private var buttonText: Text {
-        return self.initialValue == self.value ? Text(LocalizedString("Accept Setting", comment: "The button text for accepting the prescribed setting")) : Text(LocalizedString("Save Setting", comment: "The button text for saving the edited setting"))
+        if self.initialValue != self.value || mode == .legacySettings || mode == .settings {
+            return Text(LocalizedString("Save Setting", comment: "The button text for saving the edited setting"))
+        } else {
+            return Text(LocalizedString("Accept Setting", comment: "The button text for accepting the prescribed setting"))
+        }
     }
 
     private var guardrailWarningIfNecessary: some View {

--- a/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
@@ -81,6 +81,10 @@ public struct DeliveryLimitsEditor: View {
         guard value.maximumBasalRate != nil, value.maximumBolus != nil else {
             return .disabled
         }
+        
+        if mode == .acceptanceFlow {
+            return .enabled
+        }
 
         return value == initialValue ? .disabled : .enabled
     }

--- a/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
@@ -33,7 +33,7 @@ public struct DeliveryLimitsEditor: View {
         scheduledBasalRange: ClosedRange<Double>?,
         supportedBolusVolumes: [Double],
         onSave save: @escaping (_ deliveryLimits: DeliveryLimits) -> Void,
-        mode: PresentationMode = .modal
+        mode: PresentationMode = .legacySettings
     ) {
         self._value = State(initialValue: value)
         self.initialValue = value
@@ -71,6 +71,7 @@ public struct DeliveryLimitsEditor: View {
             }
         )
         .alert(isPresented: $showingConfirmationAlert, content: confirmationAlert)
+        .navigationBarTitle("", displayMode: .inline)
         .onTapGesture {
             self.userDidTap = true
         }
@@ -81,7 +82,7 @@ public struct DeliveryLimitsEditor: View {
             return .disabled
         }
 
-        return value == initialValue && mode == .modal ? .disabled : .enabled
+        return value == initialValue || mode != .acceptanceFlow ? .disabled : .enabled
     }
 
     var maximumBasalRateGuardrail: Guardrail<HKQuantity> {
@@ -183,7 +184,7 @@ public struct DeliveryLimitsEditor: View {
     
     private var instructionalContentIfNecessary: some View {
         return Group {
-            if mode == .flow && !userDidTap {
+            if mode == .acceptanceFlow && !userDidTap {
                 instructionalContent
             }
         }
@@ -205,7 +206,7 @@ public struct DeliveryLimitsEditor: View {
     private var guardrailWarningIfNecessary: some View {
         let crossedThresholds = self.crossedThresholds
         return Group {
-            if !crossedThresholds.isEmpty && (userDidTap || mode == .modal) {
+            if !crossedThresholds.isEmpty && (userDidTap || mode == .settings || mode == .legacySettings) {
                 DeliveryLimitsGuardrailWarning(crossedThresholds: crossedThresholds, maximumScheduledBasalRate: scheduledBasalRange?.upperBound)
             }
         }

--- a/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
@@ -250,7 +250,9 @@ public struct DeliveryLimitsEditor: View {
 
     private func saveAndDismiss() {
         save(value)
-        dismiss()
+        if mode == .legacySettings {
+            dismiss()
+        }
     }
 }
 

--- a/LoopKitUI/Views/Settings Editors/DeliveryLimitsReview.swift
+++ b/LoopKitUI/Views/Settings Editors/DeliveryLimitsReview.swift
@@ -1,5 +1,5 @@
 //
-//  DeliveryLimitsReviewView.swift
+//  DeliveryLimitsReview.swift
 //  LoopKitUI
 //
 //  Created by Anna Quinlan on 7/6/20.
@@ -11,7 +11,7 @@ import LoopKit
 import HealthKit
 
 
-public struct DeliveryLimitsReviewView: View {
+public struct DeliveryLimitsReview: View {
     @ObservedObject var viewModel: TherapySettingsViewModel
     let mode: PresentationMode
     

--- a/LoopKitUI/Views/Settings Editors/DeliveryLimitsReviewView.swift
+++ b/LoopKitUI/Views/Settings Editors/DeliveryLimitsReviewView.swift
@@ -15,7 +15,7 @@ public struct DeliveryLimitsReviewView: View {
     @ObservedObject var viewModel: TherapySettingsViewModel
     let mode: PresentationMode
     
-    public init(mode: PresentationMode = .flow, viewModel: TherapySettingsViewModel){
+    public init(mode: PresentationMode = .acceptanceFlow, viewModel: TherapySettingsViewModel){
         self.viewModel = viewModel
         self.mode = mode
     }

--- a/LoopKitUI/Views/Settings Editors/DeliveryLimitsReviewView.swift
+++ b/LoopKitUI/Views/Settings Editors/DeliveryLimitsReviewView.swift
@@ -1,0 +1,46 @@
+//
+//  DeliveryLimitsReviewView.swift
+//  LoopKitUI
+//
+//  Created by Anna Quinlan on 7/6/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+import LoopKit
+import HealthKit
+
+
+public struct DeliveryLimitsReviewView: View {
+    @ObservedObject var viewModel: TherapySettingsViewModel
+    let mode: PresentationMode
+    
+    public init(mode: PresentationMode = .flow, viewModel: TherapySettingsViewModel){
+        self.viewModel = viewModel
+        self.mode = mode
+    }
+    
+    @ViewBuilder public var body: some View {
+        if viewModel.pumpSupportedIncrements != nil {
+            DeliveryLimitsEditor(
+                value: DeliveryLimits(maximumBasalRate: maxBasal, maximumBolus: maxBolus),
+                supportedBasalRates: viewModel.pumpSupportedIncrements!.basalRates,
+                scheduledBasalRange: viewModel.therapySettings.basalRateSchedule?.valueRange(),
+                supportedBolusVolumes: viewModel.pumpSupportedIncrements!.bolusVolumes,
+                onSave: { limits in
+                    self.viewModel.saveDeliveryLimits(limits: limits)
+                    self.viewModel.didFinishEditing?()
+                },
+                mode: mode
+            )
+        }
+    }
+
+    private var maxBasal: HKQuantity {
+        return HKQuantity(unit: .internationalUnitsPerHour, doubleValue: viewModel.therapySettings.maximumBasalRatePerHour!)
+    }
+    
+    private var maxBolus: HKQuantity {
+        return HKQuantity(unit: .internationalUnit(), doubleValue: viewModel.therapySettings.maximumBolus!)
+    }
+}

--- a/LoopKitUI/Views/Settings Editors/DeliveryLimitsReviewView.swift
+++ b/LoopKitUI/Views/Settings Editors/DeliveryLimitsReviewView.swift
@@ -15,24 +15,23 @@ public struct DeliveryLimitsReviewView: View {
     @ObservedObject var viewModel: TherapySettingsViewModel
     let mode: PresentationMode
     
-    public init(mode: PresentationMode = .acceptanceFlow, viewModel: TherapySettingsViewModel){
+    public init(mode: PresentationMode = .acceptanceFlow, viewModel: TherapySettingsViewModel) {
+        precondition(viewModel.pumpSupportedIncrements != nil)
         self.viewModel = viewModel
         self.mode = mode
     }
     
     @ViewBuilder public var body: some View {
-        if viewModel.pumpSupportedIncrements != nil {
-            DeliveryLimitsEditor(
-                value: DeliveryLimits(maximumBasalRate: maxBasal, maximumBolus: maxBolus),
-                supportedBasalRates: viewModel.pumpSupportedIncrements!.basalRates,
-                scheduledBasalRange: viewModel.therapySettings.basalRateSchedule?.valueRange(),
-                supportedBolusVolumes: viewModel.pumpSupportedIncrements!.bolusVolumes,
-                onSave: { limits in
-                    self.viewModel.saveDeliveryLimits(limits: limits)
-                },
-                mode: mode
-            )
-        }
+        DeliveryLimitsEditor(
+            value: DeliveryLimits(maximumBasalRate: maxBasal, maximumBolus: maxBolus),
+            supportedBasalRates: viewModel.pumpSupportedIncrements!.basalRates,
+            scheduledBasalRange: viewModel.therapySettings.basalRateSchedule?.valueRange(),
+            supportedBolusVolumes: viewModel.pumpSupportedIncrements!.bolusVolumes,
+            onSave: { limits in
+                self.viewModel.saveDeliveryLimits(limits: limits)
+        },
+            mode: mode
+        )
     }
 
     private var maxBasal: HKQuantity {

--- a/LoopKitUI/Views/Settings Editors/DeliveryLimitsReviewView.swift
+++ b/LoopKitUI/Views/Settings Editors/DeliveryLimitsReviewView.swift
@@ -29,7 +29,6 @@ public struct DeliveryLimitsReviewView: View {
                 supportedBolusVolumes: viewModel.pumpSupportedIncrements!.bolusVolumes,
                 onSave: { limits in
                     self.viewModel.saveDeliveryLimits(limits: limits)
-                    self.viewModel.didFinishEditing?()
                 },
                 mode: mode
             )

--- a/LoopKitUI/Views/Settings Editors/InsulinSensitivityScheduleEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/InsulinSensitivityScheduleEditor.swift
@@ -23,9 +23,11 @@ public struct InsulinSensitivityScheduleEditor: View {
     private var schedule: DailyQuantitySchedule<Double>?
     private var glucoseUnit: HKUnit
     private var save: (InsulinSensitivitySchedule) -> Void
+    private var mode: PresentationMode
 
     public init(
         schedule: InsulinSensitivitySchedule?,
+        mode: PresentationMode = .legacySettings,
         glucoseUnit: HKUnit,
         onSave save: @escaping (InsulinSensitivitySchedule) -> Void
     ) {
@@ -39,6 +41,7 @@ public struct InsulinSensitivityScheduleEditor: View {
         }
         self.glucoseUnit = glucoseUnit
         self.save = save
+        self.mode = mode
     }
 
     public var body: some View {
@@ -55,7 +58,9 @@ public struct InsulinSensitivityScheduleEditor: View {
             onSave: {
                 // Convert back to the expected glucose-unit-only schedule.
                 self.save(DailyQuantitySchedule(unit: self.glucoseUnit, dailyItems: $0.items)!)
-            }
+            },
+            mode: mode,
+            settingType: .insulinSensitivity
         )
     }
 

--- a/LoopKitUI/Views/Settings Editors/PresentationMode.swift
+++ b/LoopKitUI/Views/Settings Editors/PresentationMode.swift
@@ -6,6 +6,12 @@
 //  Copyright © 2020 LoopKit Authors. All rights reserved.
 //
 
+/// Represents the different modes that settings screens might be represented in
 public enum PresentationMode {
-    case acceptanceFlow, settings, legacySettings
+    /// Presentation is in the onboarding acceptance flow
+    case acceptanceFlow
+    /// Presentation is under the settings ("gear icon") screen
+    case settings
+    /// Presentation is under the old UIKit (legacy) settings screen
+    case legacySettings
 }

--- a/LoopKitUI/Views/Settings Editors/PresentationMode.swift
+++ b/LoopKitUI/Views/Settings Editors/PresentationMode.swift
@@ -1,0 +1,11 @@
+//
+//  PresentationMode.swift
+//  LoopKitUI
+//
+//  Created by Anna Quinlan on 7/21/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+public enum PresentationMode {
+    case acceptanceFlow, settings, legacySettings
+}

--- a/LoopKitUI/Views/Settings Editors/PumpSupportedIncrements.swift
+++ b/LoopKitUI/Views/Settings Editors/PumpSupportedIncrements.swift
@@ -9,8 +9,10 @@
 public struct PumpSupportedIncrements {
     let basalRates: [Double]
     let bolusVolumes: [Double]
-    public init(basalRates: [Double], bolusVolumes: [Double]) {
+    let maximumBasalScheduleEntryCount: Int
+    public init(basalRates: [Double], bolusVolumes: [Double], maximumBasalScheduleEntryCount: Int) {
         self.basalRates = basalRates
         self.bolusVolumes = bolusVolumes
+        self.maximumBasalScheduleEntryCount = maximumBasalScheduleEntryCount
     }
 }

--- a/LoopKitUI/Views/Settings Editors/SuspendThresholdEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/SuspendThresholdEditor.swift
@@ -47,7 +47,7 @@ public struct SuspendThresholdEditor: View {
         unit: HKUnit,
         maxValue: HKQuantity?,
         onSave save: @escaping (_ suspendThreshold: HKQuantity) -> Void,
-        mode: PresentationMode = .modal
+        mode: PresentationMode = .legacySettings
     ) {
         self._value = State(initialValue: value ?? Self.defaultValue(for: unit))
         self.initialValue = value
@@ -108,7 +108,7 @@ public struct SuspendThresholdEditor: View {
             },
             actionAreaContent: {
                 instructionalContentIfNecessary
-                if warningThreshold != nil && (userDidTap || mode == .modal) {
+                if warningThreshold != nil && (userDidTap || mode != .acceptanceFlow) {
                     SuspendThresholdGuardrailWarning(safetyClassificationThreshold: warningThreshold!)
                 }
             },
@@ -121,6 +121,7 @@ public struct SuspendThresholdEditor: View {
             }
         )
         .alert(isPresented: $showingConfirmationAlert, content: confirmationAlert)
+        .navigationBarTitle("", displayMode: .inline)
         .onTapGesture {
             self.userDidTap = true
         }
@@ -132,7 +133,7 @@ public struct SuspendThresholdEditor: View {
     
     private var instructionalContentIfNecessary: some View {
         return Group {
-            if mode == .flow && !userDidTap {
+            if mode == .acceptanceFlow && !userDidTap {
                 instructionalContent
             }
         }
@@ -148,14 +149,14 @@ public struct SuspendThresholdEditor: View {
     }
 
     private var saveButtonState: ConfigurationPageActionButtonState {
-        initialValue == nil || value != initialValue! || mode == .flow ? .enabled : .disabled
+        initialValue == nil || value != initialValue! || mode == .acceptanceFlow ? .enabled : .disabled
     }
     
     private var buttonText: Text {
         switch mode {
-        case .flow:
+        case .acceptanceFlow:
             return self.initialValue == self.value ? Text(LocalizedString("Accept Setting", comment: "The button text for accepting the prescribed setting")) : Text(LocalizedString("Save Setting", comment: "The button text for saving the edited setting"))
-        case .modal:
+        case .settings, .legacySettings:
             return Text("Save", comment: "The button text for saving on a configuration page")
         }
     }
@@ -183,7 +184,7 @@ public struct SuspendThresholdEditor: View {
 
     private func saveAndDismiss() {
         save(value)
-        if mode == .modal {
+        if mode == .legacySettings {
             dismiss()
         }
     }

--- a/LoopKitUI/Views/Settings Editors/SuspendThresholdReview.swift
+++ b/LoopKitUI/Views/Settings Editors/SuspendThresholdReview.swift
@@ -17,7 +17,7 @@ public struct SuspendThresholdReview: View {
         return viewModel.therapySettings.glucoseUnit!
     }
     
-    public init(mode: PresentationMode = .flow, viewModel: TherapySettingsViewModel) {
+    public init(mode: PresentationMode = .acceptanceFlow, viewModel: TherapySettingsViewModel) {
         precondition(viewModel.therapySettings.glucoseUnit != nil)
         self.viewModel = viewModel
         self.mode = mode

--- a/LoopKitUI/Views/Settings Editors/SuspendThresholdReview.swift
+++ b/LoopKitUI/Views/Settings Editors/SuspendThresholdReview.swift
@@ -35,7 +35,6 @@ public struct SuspendThresholdReview: View {
             ),
             onSave: { newValue in
                 self.viewModel.saveSuspendThreshold(value: GlucoseThreshold(unit: self.unit, value: newValue.doubleValue(for: self.unit)))
-                self.viewModel.didFinishEditing?()
             },
             mode: mode
         )

--- a/LoopKitUI/Views/Settings Editors/SuspendThresholdReview.swift
+++ b/LoopKitUI/Views/Settings Editors/SuspendThresholdReview.swift
@@ -1,6 +1,6 @@
 //
 //  SuspendThresholdReview.swift
-//  TidepoolServiceKitUI
+//  LoopKitUI
 //
 //  Created by Anna Quinlan on 7/3/20.
 //  Copyright © 2020 LoopKit Authors. All rights reserved.

--- a/LoopKitUI/Views/Settings Editors/SuspendThresholdReview.swift
+++ b/LoopKitUI/Views/Settings Editors/SuspendThresholdReview.swift
@@ -1,0 +1,43 @@
+//
+//  SuspendThresholdReview.swift
+//  TidepoolServiceKitUI
+//
+//  Created by Anna Quinlan on 7/3/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+import LoopKit
+import HealthKit
+
+public struct SuspendThresholdReview: View {
+    @ObservedObject var viewModel: TherapySettingsViewModel
+    private let mode: PresentationMode
+    private var unit: HKUnit {
+        return viewModel.therapySettings.glucoseUnit!
+    }
+    
+    public init(mode: PresentationMode = .flow, viewModel: TherapySettingsViewModel) {
+        precondition(viewModel.therapySettings.glucoseUnit != nil)
+        self.viewModel = viewModel
+        self.mode = mode
+    }
+    
+    public var body: some View {
+        SuspendThresholdEditor(
+            value: viewModel.therapySettings.suspendThreshold?.quantity,
+            unit: unit,
+            maxValue: Guardrail.maxSuspendThresholdValue(
+                correctionRangeSchedule: viewModel.therapySettings.glucoseTargetRangeSchedule,
+                preMealTargetRange: viewModel.therapySettings.preMealTargetRange,
+                workoutTargetRange: viewModel.therapySettings.workoutTargetRange,
+                unit: unit
+            ),
+            onSave: { newValue in
+                self.viewModel.saveSuspendThreshold(value: GlucoseThreshold(unit: self.unit, value: newValue.doubleValue(for: self.unit)))
+                self.viewModel.didFinishEditing?()
+            },
+            mode: mode
+        )
+    }
+}

--- a/LoopKitUI/Views/Settings Editors/TherapySetting+Settings.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySetting+Settings.swift
@@ -14,15 +14,15 @@ extension TherapySetting {
     public func helpScreen() -> some View {
         switch self {
         case .glucoseTargetRange:
-            return AnyView(CorrectionRangeInformationView(onExit: nil, mode: .modal))
+            return AnyView(CorrectionRangeInformationView(onExit: nil, mode: .settings))
         case .correctionRangeOverrides:
-            return AnyView(CorrectionRangeOverrideInformationView(onExit: nil, mode: .modal))
+            return AnyView(CorrectionRangeOverrideInformationView(onExit: nil, mode: .settings))
         case .suspendThreshold:
-            return AnyView(SuspendThresholdInformationView(onExit: nil, mode: .modal))
+            return AnyView(SuspendThresholdInformationView(onExit: nil, mode: .settings))
         case .basalRate:
-            return AnyView(BasalRatesInformationView(onExit: nil, mode: .modal))
+            return AnyView(BasalRatesInformationView(onExit: nil, mode: .settings))
         case .deliveryLimits:
-            return AnyView(DeliveryLimitsInformationView(onExit: nil, mode: .modal))
+            return AnyView(DeliveryLimitsInformationView(onExit: nil, mode: .settings))
         // ANNA TODO: add more once other instructional screens are created
         default:
             return AnyView(Text("To be implemented"))

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -426,7 +426,7 @@ private extension TherapySettingsView {
     func screen(for setting: TherapySetting) -> some View {
         switch setting {
         case .glucoseTargetRange:
-            return AnyView(CorrectionRangeReviewView(mode: mode, viewModel: viewModel))
+            return AnyView(CorrectionRangeReview(mode: mode, viewModel: viewModel))
         case .correctionRangeOverrides:
             return AnyView(CorrectionRangeOverrideReview(mode: mode, viewModel: viewModel))
         case .suspendThreshold:
@@ -434,7 +434,7 @@ private extension TherapySettingsView {
         case .basalRate:
             return AnyView(BasalRatesReview(mode: mode, viewModel: viewModel))
         case .deliveryLimits:
-            return AnyView(DeliveryLimitsReviewView(mode: mode, viewModel: viewModel))
+            return AnyView(DeliveryLimitsReview(mode: mode, viewModel: viewModel))
         case .insulinModel:
             // TODO insulin model
             break

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -438,7 +438,13 @@ private extension TherapySettingsView {
         case .insulinModel:
             break
         case .carbRatio:
-            break
+            return AnyView(CarbRatioScheduleEditor(
+                schedule: viewModel.therapySettings.carbRatioSchedule,
+                mode: mode,
+                onSave: {
+                    self.viewModel.saveCarbRatioSchedule(carbRatioSchedule: $0)
+                }
+            ))
         case .insulinSensitivity:
             break
         case .none:

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -30,7 +30,7 @@ public struct TherapySettingsView: View, HorizontalSizeClassOverride {
     
     private let mode: PresentationMode
     
-    public init(mode: PresentationMode = .flow, viewModel: TherapySettingsViewModel) {
+    public init(mode: PresentationMode = .settings, viewModel: TherapySettingsViewModel) {
         self.mode = mode
         self.viewModel = viewModel
     }
@@ -38,8 +38,8 @@ public struct TherapySettingsView: View, HorizontalSizeClassOverride {
     public var body: some View {
         switch mode {
         // TODO: Different versions for onboarding vs. in settings
-        case .flow: return AnyView(content)
-        case .modal: return AnyView(navigationContent)
+        case .acceptanceFlow, .settings: return AnyView(content)
+        case .legacySettings: return AnyView(navigationContent)
         }
     }
     
@@ -85,8 +85,8 @@ extension TherapySettingsView {
     private var backButton: some View {
         return Button<AnyView>( action: { self.dismiss() }) {
             switch mode {
-            case .flow: return AnyView(EmptyView())
-            case .modal: return AnyView(Text(LocalizedString("Back", comment: "Back button text")))
+            case .settings, .acceptanceFlow: return AnyView(EmptyView())
+            case .legacySettings: return AnyView(Text(LocalizedString("Back", comment: "Back button text")))
             }
         }
     }
@@ -495,19 +495,19 @@ public struct TherapySettingsView_Previews: PreviewProvider {
 
     public static var previews: some View {
         Group {
-            TherapySettingsView(mode: .modal, viewModel: preview_viewModel)
+            TherapySettingsView(mode: .acceptanceFlow, viewModel: preview_viewModel)
                 .colorScheme(.light)
                 .previewDevice(PreviewDevice(rawValue: "iPhone SE 2"))
                 .previewDisplayName("SE light (onboarding)")
-            TherapySettingsView(mode: .flow, viewModel: preview_viewModel)
+            TherapySettingsView(mode: .settings, viewModel: preview_viewModel)
                 .colorScheme(.light)
                 .previewDevice(PreviewDevice(rawValue: "iPhone SE 2"))
                 .previewDisplayName("SE light (settings)")
-            TherapySettingsView(mode: .modal, viewModel: preview_viewModel)
+            TherapySettingsView(mode: .settings, viewModel: preview_viewModel)
                 .colorScheme(.dark)
                 .previewDevice(PreviewDevice(rawValue: "iPhone XS Max"))
                 .previewDisplayName("XS Max dark (settings)")
-            TherapySettingsView(mode: .modal, viewModel: TherapySettingsViewModel(therapySettings: TherapySettings()))
+            TherapySettingsView(mode: .legacySettings, viewModel: TherapySettingsViewModel(therapySettings: TherapySettings()))
                 .colorScheme(.light)
                 .previewDevice(PreviewDevice(rawValue: "iPhone SE 2"))
                 .previewDisplayName("SE light (Empty TherapySettings)")

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -436,16 +436,23 @@ private extension TherapySettingsView {
         case .deliveryLimits:
             return AnyView(DeliveryLimitsReviewView(mode: mode, viewModel: viewModel))
         case .insulinModel:
+            // TODO insulin model
             break
         case .carbRatio:
             return AnyView(CarbRatioScheduleEditor(
                 schedule: viewModel.therapySettings.carbRatioSchedule,
                 mode: mode,
-                onSave: {
-                    self.viewModel.saveCarbRatioSchedule(carbRatioSchedule: $0)
-                }
+                onSave: { self.viewModel.saveCarbRatioSchedule(carbRatioSchedule: $0) }
             ))
         case .insulinSensitivity:
+            if self.viewModel.therapySettings.glucoseUnit != nil {
+                return AnyView(InsulinSensitivityScheduleEditor(
+                    schedule: self.viewModel.therapySettings.insulinSensitivitySchedule,
+                    mode: mode,
+                    glucoseUnit: self.viewModel.therapySettings.glucoseUnit!,
+                    onSave: { self.viewModel.saveInsulinSensitivitySchedule(insulinSensitivitySchedule: $0) }
+                ))
+            }
             break
         case .none:
             break

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -441,15 +441,15 @@ private extension TherapySettingsView {
     func screen(for setting: TherapySetting) -> some View {
         switch setting {
         case .glucoseTargetRange:
-            return AnyView(CorrectionRangeReviewView(mode: .modal/*mode*/, viewModel: viewModel))
+            return AnyView(CorrectionRangeReviewView(mode: mode, viewModel: viewModel))
         case .correctionRangeOverrides:
-            return AnyView(CorrectionRangeOverrideReview(mode: .modal/*mode*/, viewModel: viewModel))
+            return AnyView(CorrectionRangeOverrideReview(mode: mode, viewModel: viewModel))
         case .suspendThreshold:
-            return AnyView(SuspendThresholdReview(mode: .modal/*mode*/, viewModel: viewModel))
+            return AnyView(SuspendThresholdReview(mode: mode, viewModel: viewModel))
         case .basalRate:
             return AnyView(BasalRatesReview(mode: mode, viewModel: viewModel))
         case .deliveryLimits:
-            return AnyView(DeliveryLimitsReviewView(mode: .modal/*mode*/, viewModel: viewModel))
+            return AnyView(DeliveryLimitsReviewView(mode: mode, viewModel: viewModel))
         case .insulinModel:
             break
         case .carbRatio:

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsViewModel.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsViewModel.swift
@@ -11,20 +11,24 @@ import HealthKit
 
 public class TherapySettingsViewModel: ObservableObject {
 
-    private let initialTherapySettings: TherapySettings
     @Published public var therapySettings: TherapySettings
     public var supportedInsulinModelSettings: SupportedInsulinModelSettings
-    public var didFinishStep: (() -> Void)?
+    public var didFinishEditing: (() -> Void)?
+
+    private let initialTherapySettings: TherapySettings
     let pumpSupportedIncrements: PumpSupportedIncrements?
+    let pumpSyncSchedule: PumpManager.SyncSchedule?
     let includeSupportSection: Bool
 
     public init(therapySettings: TherapySettings,
                 supportedInsulinModelSettings: SupportedInsulinModelSettings = SupportedInsulinModelSettings(fiaspModelEnabled: true, walshModelEnabled: true),
                 pumpSupportedIncrements: PumpSupportedIncrements? = nil,
+                pumpSyncSchedule: PumpManager.SyncSchedule? = nil,
                 includeSupportSection: Bool = true) {
         self.therapySettings = therapySettings
         self.initialTherapySettings = therapySettings
         self.pumpSupportedIncrements = pumpSupportedIncrements
+        self.pumpSyncSchedule = pumpSyncSchedule
         self.supportedInsulinModelSettings = supportedInsulinModelSettings
         self.includeSupportSection = includeSupportSection
     }

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsViewModel.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsViewModel.swift
@@ -18,19 +18,22 @@ public class TherapySettingsViewModel: ObservableObject {
 
     private let initialTherapySettings: TherapySettings
     let pumpSupportedIncrements: PumpSupportedIncrements?
-    let pumpSyncSchedule: PumpManager.SyncSchedule?
+    let syncPumpSchedule: PumpManager.SyncSchedule?
+    let sensitivityOverridesEnabled: Bool
     let includeSupportSection: Bool
 
     public init(therapySettings: TherapySettings,
                 supportedInsulinModelSettings: SupportedInsulinModelSettings = SupportedInsulinModelSettings(fiaspModelEnabled: true, walshModelEnabled: true),
                 pumpSupportedIncrements: PumpSupportedIncrements? = nil,
-                pumpSyncSchedule: PumpManager.SyncSchedule? = nil,
+                syncPumpSchedule: PumpManager.SyncSchedule? = nil,
+                sensitivityOverridesEnabled: Bool = false,
                 includeSupportSection: Bool = true,
                 didSave: SaveCompletion? = nil) {
         self.therapySettings = therapySettings
         self.initialTherapySettings = therapySettings
         self.pumpSupportedIncrements = pumpSupportedIncrements
-        self.pumpSyncSchedule = pumpSyncSchedule
+        self.syncPumpSchedule = syncPumpSchedule
+        self.sensitivityOverridesEnabled = sensitivityOverridesEnabled
         self.supportedInsulinModelSettings = supportedInsulinModelSettings
         self.includeSupportSection = includeSupportSection
         self.didSave = didSave

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsViewModel.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsViewModel.swift
@@ -10,10 +10,11 @@ import LoopKit
 import HealthKit
 
 public class TherapySettingsViewModel: ObservableObject {
-
+    public typealias SaveCompletion = (TherapySetting, TherapySettings) -> Void
+    
     @Published public var therapySettings: TherapySettings
     public var supportedInsulinModelSettings: SupportedInsulinModelSettings
-    public var didFinishEditing: (() -> Void)?
+    private let didSave: SaveCompletion?
 
     private let initialTherapySettings: TherapySettings
     let pumpSupportedIncrements: PumpSupportedIncrements?
@@ -24,13 +25,15 @@ public class TherapySettingsViewModel: ObservableObject {
                 supportedInsulinModelSettings: SupportedInsulinModelSettings = SupportedInsulinModelSettings(fiaspModelEnabled: true, walshModelEnabled: true),
                 pumpSupportedIncrements: PumpSupportedIncrements? = nil,
                 pumpSyncSchedule: PumpManager.SyncSchedule? = nil,
-                includeSupportSection: Bool = true) {
+                includeSupportSection: Bool = true,
+                didSave: SaveCompletion? = nil) {
         self.therapySettings = therapySettings
         self.initialTherapySettings = therapySettings
         self.pumpSupportedIncrements = pumpSupportedIncrements
         self.pumpSyncSchedule = pumpSyncSchedule
         self.supportedInsulinModelSettings = supportedInsulinModelSettings
         self.includeSupportSection = includeSupportSection
+        self.didSave = didSave
     }
     
     /// Reset to initial
@@ -40,23 +43,28 @@ public class TherapySettingsViewModel: ObservableObject {
     
     public func saveCorrectionRange(range: GlucoseRangeSchedule) {
         therapySettings.glucoseTargetRangeSchedule = range
+        didSave?(TherapySetting.glucoseTargetRange, therapySettings)
     }
     
     public func saveCorrectionRangeOverrides(overrides: CorrectionRangeOverrides, unit: HKUnit) {
         therapySettings.preMealTargetRange = overrides.preMeal?.doubleRange(for: unit)
         therapySettings.workoutTargetRange = overrides.workout?.doubleRange(for: unit)
+        didSave?(TherapySetting.correctionRangeOverrides, therapySettings)
     }
     
     public func saveSuspendThreshold(value: GlucoseThreshold) {
         therapySettings.suspendThreshold = value
+        didSave?(TherapySetting.suspendThreshold, therapySettings)
     }
     
     public func saveBasalRates(basalRates: BasalRateSchedule) {
         therapySettings.basalRateSchedule = basalRates
+        didSave?(TherapySetting.basalRate, therapySettings)
     }
     
     public func saveDeliveryLimits(limits: DeliveryLimits) {
         therapySettings.maximumBasalRatePerHour = limits.maximumBasalRate?.doubleValue(for: .internationalUnitsPerHour)
         therapySettings.maximumBolus = limits.maximumBolus?.doubleValue(for: .internationalUnit())
+        didSave?(TherapySetting.deliveryLimits, therapySettings)
     }
 }

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsViewModel.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsViewModel.swift
@@ -67,4 +67,9 @@ public class TherapySettingsViewModel: ObservableObject {
         therapySettings.maximumBolus = limits.maximumBolus?.doubleValue(for: .internationalUnit())
         didSave?(TherapySetting.deliveryLimits, therapySettings)
     }
+    
+    public func saveCarbRatioSchedule(carbRatioSchedule: CarbRatioSchedule) {
+        therapySettings.carbRatioSchedule = carbRatioSchedule
+        didSave?(TherapySetting.carbRatio, therapySettings)
+    }
 }

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsViewModel.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsViewModel.swift
@@ -72,4 +72,9 @@ public class TherapySettingsViewModel: ObservableObject {
         therapySettings.carbRatioSchedule = carbRatioSchedule
         didSave?(TherapySetting.carbRatio, therapySettings)
     }
+    
+    public func saveInsulinSensitivitySchedule(insulinSensitivitySchedule: InsulinSensitivitySchedule) {
+        therapySettings.insulinSensitivitySchedule = insulinSensitivitySchedule
+        didSave?(TherapySetting.insulinSensitivity, therapySettings)
+    }
 }


### PR DESCRIPTION
- Moves a bunch of the therapy settings editors (or their "helpers" in the form of review views -- may want to revisit whether both need to exist) into LoopKitUI
- Now there are 3 `PresentationMode`s : `.acceptanceFlow`, `.settings`, and `.legacySettings`. (thanks and shout-out to @novalegra for helping refactor for these!)
- Wired up navigation to all editors (except, as of this writing, Insulin Model).  [Note: it doesn't navigate "back" on save yet, because (a) I'm not sure that's the designed behavior, although it intuitively feels right to me and (b) I'm not quite sure how to accomplish that]
- Wired up saving the data through the view model (`TherapySettingsViewModel`) and got rid of the delegate (I was 50/50 on whether to have a delegate, but it may resurface later...)


[LOOP-1492](https://tidepool.atlassian.net/browse/LOOP-1492)