### PR TITLE
Fix blank screen for basal rates editor

### DIFF
--- a/LoopKitUI/Views/Settings Editors/BasalRatesReview.swift
+++ b/LoopKitUI/Views/Settings Editors/BasalRatesReview.swift
@@ -21,13 +21,13 @@ public struct BasalRatesReview: View {
         self.mode = mode
     }
     
-    @ViewBuilder public var body: some View {
+    public var body: some View {
         return BasalRateScheduleEditor(
             schedule: viewModel.therapySettings.basalRateSchedule,
             supportedBasalRates: viewModel.pumpSupportedIncrements!.basalRates ,
             maximumBasalRate: viewModel.therapySettings.maximumBasalRatePerHour,
             maximumScheduleEntryCount: viewModel.pumpSupportedIncrements!.maximumBasalScheduleEntryCount,
-            syncSchedule: viewModel.pumpSyncSchedule,
+            syncSchedule: viewModel.syncPumpSchedule,
             onSave: { newRates in
                 self.viewModel.saveBasalRates(basalRates: newRates)
         },


### PR DESCRIPTION
Fix a blank screen caused by a mis-named variable