### PR TITLE
Fix Therapy Settings in acceptance flow

### DIFF
--- a/LoopKitUI/Views/Settings Editors/InsulinModelSelection.swift
+++ b/LoopKitUI/Views/Settings Editors/InsulinModelSelection.swift
@@ -120,7 +120,7 @@ public struct InsulinModelSelection: View, HorizontalSizeClassOverride {
             content
             Button(action: { self.onSave?(self.viewModel.insulinModelSettings) }) {
                 Text(mode.buttonText)
-                    .buttonStyle(ActionButtonStyle(.primary))
+                    .actionButtonStyle(.primary)
                     .padding()
             }
             .disabled(viewModel.insulinModelSettings == initialInsulinModelSettings)

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -273,10 +273,11 @@ extension TherapySettingsView {
     private func section<Content>(for therapySetting: TherapySetting,
                                   addExtraSpaceAboveSection: Bool = false,
                                   @ViewBuilder content: @escaping () -> Content) -> some View where Content: View {
-        SectionWithTapToEdit(addExtraSpaceAboveSection: addExtraSpaceAboveSection,
+        SectionWithTapToEdit(isEnabled: viewModel.mode != .acceptanceFlow,
+                             header: addExtraSpaceAboveSection ? AnyView(Spacer()) : AnyView(EmptyView()),
                              title: therapySetting.title,
                              descriptiveText: therapySetting.descriptiveText,
-                             destination: self.screen(for: therapySetting),
+                             destination: screen(for: therapySetting),
                              content: content)
     }
 }
@@ -337,8 +338,9 @@ struct CorrectionRangeOverridesRangeItem: View {
     }
 }
 
-struct SectionWithTapToEdit<Content, NavigationDestination>: View where Content: View, NavigationDestination: View  {
-    let addExtraSpaceAboveSection: Bool
+struct SectionWithTapToEdit<Header, Content, NavigationDestination>: View where Header: View, Content: View, NavigationDestination: View  {
+    let isEnabled: Bool
+    let header: Header
     let title: String
     let descriptiveText: String
     let destination: (_ goBack: @escaping () -> Void) -> NavigationDestination
@@ -355,8 +357,10 @@ struct SectionWithTapToEdit<Content, NavigationDestination>: View where Content:
                 Spacer()
                 ZStack(alignment: .leading) {
                     DescriptiveText(label: descriptiveText)
-                    NavigationLink(destination: destination({ self.isActive = false }), isActive: $isActive) {
-                        EmptyView()
+                    if isEnabled {
+                        NavigationLink(destination: destination({ self.isActive = false }), isActive: $isActive) {
+                            EmptyView()
+                        }
                     }
                 }
                 Spacer()
@@ -368,10 +372,6 @@ struct SectionWithTapToEdit<Content, NavigationDestination>: View where Content:
                 .onEnded { _ in
                     self.isActive = true
         })
-    }
-    
-    private var header: some View {
-        addExtraSpaceAboveSection ? AnyView(Spacer()) : AnyView(EmptyView())
     }
 }
 


### PR DESCRIPTION
Follow-up from my last change:
Fix two bugs found after-the-fact:
1. Therapy Settings cards are no longer "tappable" in the acceptance flow
2. The "save" button now looks correct in Insulin Model