### PR TITLE
Refactor authentication challenge description

### DIFF
--- a/LoopKitUI/Views/ScheduleEditor.swift
+++ b/LoopKitUI/Views/ScheduleEditor.swift
@@ -39,7 +39,6 @@ struct ScheduleEditor<Value: Equatable, ValueContent: View, ValuePicker: View, A
 
     var title: Text
     var description: Text
-    let authenticationChallengeDescription: String
     var initialScheduleItems: [RepeatingScheduleValue<Value>]
     @Binding var scheduleItems: [RepeatingScheduleValue<Value>]
     var defaultFirstScheduleItemValue: Value
@@ -80,7 +79,6 @@ struct ScheduleEditor<Value: Equatable, ValueContent: View, ValuePicker: View, A
     init(
         title: Text,
         description: Text,
-        authenticationChallengeDescription: String = LocalizedString("Authenticate to change setting", comment: "Authentication hint string"),
         scheduleItems: Binding<[RepeatingScheduleValue<Value>]>,
         initialScheduleItems: [RepeatingScheduleValue<Value>],
         defaultFirstScheduleItemValue: Value,
@@ -106,7 +104,6 @@ struct ScheduleEditor<Value: Equatable, ValueContent: View, ValuePicker: View, A
         self.savingMechanism = savingMechanism
         self.mode = mode
         self.therapySettingType = therapySettingType
-        self.authenticationChallengeDescription = authenticationChallengeDescription
     }
 
     var body: some View {
@@ -374,7 +371,7 @@ struct ScheduleEditor<Value: Equatable, ValueContent: View, ValuePicker: View, A
             return
         }
         
-        authenticate(authenticationChallengeDescription) {
+        authenticate(therapySettingType.authenticationChallengeDescription) {
             switch $0 {
             case .success: self.continueSaving()
             case .failure: break

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
@@ -261,7 +261,7 @@ public struct CorrectionRangeOverridesEditor: View {
             self.continueSaving()
             return
         }
-        authenticate(LocalizedString("Authenticate to change setting", comment: "Authentication hint string")) {
+        authenticate(TherapySetting.correctionRangeOverrides.authenticationChallengeDescription) {
             switch $0 {
             case .success: self.continueSaving()
             case .failure: break

--- a/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
@@ -299,7 +299,7 @@ public struct DeliveryLimitsEditor: View {
             self.continueSaving()
             return
         }
-        authenticate(LocalizedString("Authenticate to change setting", comment: "Authentication hint string")) {
+        authenticate(TherapySetting.deliveryLimits.authenticationChallengeDescription) {
             switch $0 {
             case .success: self.continueSaving()
             case .failure: break

--- a/LoopKitUI/Views/Settings Editors/InsulinModelSelection.swift
+++ b/LoopKitUI/Views/Settings Editors/InsulinModelSelection.swift
@@ -298,7 +298,7 @@ public struct InsulinModelSelection: View, HorizontalSizeClassOverride {
             self.continueSaving()
             return
         }
-        authenticate(LocalizedString("Authenticate to change setting", comment: "Authentication hint string")) {
+        authenticate(TherapySetting.insulinModel.authenticationChallengeDescription) {
             switch $0 {
             case .success: self.continueSaving()
             case .failure: break

--- a/LoopKitUI/Views/Settings Editors/SuspendThresholdEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/SuspendThresholdEditor.swift
@@ -213,7 +213,7 @@ public struct SuspendThresholdEditor: View {
             self.continueSaving()
             return
         }
-        authenticate(LocalizedString("Authenticate to change setting", comment: "Authentication hint string")) {
+        authenticate(TherapySetting.suspendThreshold.authenticationChallengeDescription) {
             switch $0 {
             case .success: self.continueSaving()
             case .failure: break

--- a/LoopKitUI/Views/Settings Editors/TherapySetting+Settings.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySetting+Settings.swift
@@ -11,6 +11,14 @@ import SwiftUI
 
 extension TherapySetting {
     
+    public var authenticationChallengeDescription: String {
+        switch self {
+        default:
+            // Currently, this is the same no matter what the setting is.
+            return LocalizedString("Authenticate to save therapy setting", comment: "Authentication hint string for therapy settings")
+        }
+    }
+    
     public func helpScreen() -> some View {
         switch self {
         case .glucoseTargetRange:


### PR DESCRIPTION
Paul suggested changing the text of the authentication challenge description.  The discussion reminded me that I'd been wanting to refactor this to a common place, possibly one where the text could be different depending on the setting.  While they're still pondering the final copy, I thought I'd clean this up at least.