### PR TITLE
Use localized description

### DIFF
--- a/LoopKitUI/UIAlertController.swift
+++ b/LoopKitUI/UIAlertController.swift
@@ -29,7 +29,7 @@ extension UIAlertController {
             }).joined(separator: "\n")
 
             if messageWithRecovery.isEmpty {
-                message = String(describing: error)
+                message = error.localizedDescription
             } else {
                 message = messageWithRecovery
             }


### PR DESCRIPTION
Use localized description instead of debug string for errors without failureReason or recoverySuggestion.  The debug string just shows class names and does not attempt to use errorDescription.