### PR TITLE
LOOP-1708: Split correction range override into premeal and workout 

### DIFF
--- a/Extensions/Guardrail+Settings.swift
+++ b/Extensions/Guardrail+Settings.swift
@@ -87,7 +87,7 @@ public extension Guardrail where Value == HKQuantity {
         )
     }
 
-    static func correctionRangeOverridePreset(_ preset: CorrectionRangeOverrides.Preset, correctionRangeScheduleRange: ClosedRange<HKQuantity>) -> Guardrail {
+    static func correctionRangeOverride(for preset: CorrectionRangeOverrides.Preset, correctionRangeScheduleRange: ClosedRange<HKQuantity>) -> Guardrail {
         switch preset {
         case .preMeal:
             return Guardrail(

--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -29,7 +29,6 @@
 		1D841AAD24577EE10069DBFF /* AlertSoundPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D841AAC24577EE10069DBFF /* AlertSoundPlayer.swift */; };
 		1DA649AB2445174400F61E75 /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649AA2445174400F61E75 /* Alert.swift */; };
 		1DABAD3A2453615200ACF708 /* IssueAlertTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DABAD392453615200ACF708 /* IssueAlertTableViewController.swift */; };
-		1DBA06CA24E4966000045CDB /* CorrectionRangeOverrideInformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DBA06C924E4966000045CDB /* CorrectionRangeOverrideInformationView.swift */; };
 		1DC64C7C24BF6BFD004A63A1 /* CorrectionRangeOverridesExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC64C7B24BF6BFD004A63A1 /* CorrectionRangeOverridesExtension.swift */; };
 		1DC64C7E24BF6EBC004A63A1 /* DeliveryLimits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC64C7D24BF6EBC004A63A1 /* DeliveryLimits.swift */; };
 		1DD1964E248AE88000420876 /* HorizontalSizeClassOverride.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD1964D248AE88000420876 /* HorizontalSizeClassOverride.swift */; };
@@ -737,6 +736,7 @@
 		E9086B4824B5405E0062F5C8 /* ChartAxisValueDoubleUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9086B4724B5405E0062F5C8 /* ChartAxisValueDoubleUnit.swift */; };
 		E9086B4A24B540B70062F5C8 /* DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9086B4924B540B70062F5C8 /* DateFormatter.swift */; };
 		E916F56924AD32F000BE3547 /* CorrectionRangeOverridesEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E916F56824AD32F000BE3547 /* CorrectionRangeOverridesEditor.swift */; };
+		E916F56F24AE2FFE00BE3547 /* CorrectionRangeOverrideInformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E916F56E24AE2FFE00BE3547 /* CorrectionRangeOverrideInformationView.swift */; };
 		E93BA06624A39DBC00C5D7E6 /* DismissibleHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E93BA06524A39DBC00C5D7E6 /* DismissibleHostingController.swift */; };
 		E93C86A024C8F6E00073089B /* InsulinModelSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E93C869F24C8F6E00073089B /* InsulinModelSelection.swift */; };
 		E93C86A224C8F7550073089B /* InsulinModelChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = E93C86A124C8F7550073089B /* InsulinModelChart.swift */; };
@@ -899,7 +899,6 @@
 		1D841AAC24577EE10069DBFF /* AlertSoundPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertSoundPlayer.swift; sourceTree = "<group>"; };
 		1DA649AA2445174400F61E75 /* Alert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Alert.swift; sourceTree = "<group>"; };
 		1DABAD392453615200ACF708 /* IssueAlertTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueAlertTableViewController.swift; sourceTree = "<group>"; };
-		1DBA06C924E4966000045CDB /* CorrectionRangeOverrideInformationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CorrectionRangeOverrideInformationView.swift; sourceTree = "<group>"; };
 		1DC64C7B24BF6BFD004A63A1 /* CorrectionRangeOverridesExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectionRangeOverridesExtension.swift; sourceTree = "<group>"; };
 		1DC64C7D24BF6EBC004A63A1 /* DeliveryLimits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryLimits.swift; sourceTree = "<group>"; };
 		1DD1964D248AE88000420876 /* HorizontalSizeClassOverride.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalSizeClassOverride.swift; sourceTree = "<group>"; };
@@ -1535,6 +1534,7 @@
 		E9086B4724B5405E0062F5C8 /* ChartAxisValueDoubleUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartAxisValueDoubleUnit.swift; sourceTree = "<group>"; };
 		E9086B4924B540B70062F5C8 /* DateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatter.swift; sourceTree = "<group>"; };
 		E916F56824AD32F000BE3547 /* CorrectionRangeOverridesEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectionRangeOverridesEditor.swift; sourceTree = "<group>"; };
+		E916F56E24AE2FFE00BE3547 /* CorrectionRangeOverrideInformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectionRangeOverrideInformationView.swift; sourceTree = "<group>"; };
 		E93BA06524A39DBC00C5D7E6 /* DismissibleHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissibleHostingController.swift; sourceTree = "<group>"; };
 		E93C869F24C8F6E00073089B /* InsulinModelSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsulinModelSelection.swift; sourceTree = "<group>"; };
 		E93C86A124C8F7550073089B /* InsulinModelChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsulinModelChart.swift; sourceTree = "<group>"; };
@@ -2535,15 +2535,15 @@
 		E9077D2824ACD5AA0066A88D /* Information Screens */ = {
 			isa = PBXGroup;
 			children = (
-				E96DCB5D24AF7DC7007117BC /* BasalRatesInformationView.swift */,
-				E93C86B124D080E00073089B /* CarbRatioInformationView.swift */,
-				E9077D2924ACDE2C0066A88D /* CorrectionRangeInformationView.swift */,
-				1DBA06C924E4966000045CDB /* CorrectionRangeOverrideInformationView.swift */,
-				E949E38824AFC82F00024DA0 /* DeliveryLimitsInformationView.swift */,
 				E9077D2624ACD59F0066A88D /* InformationView.swift */,
+				E9077D2924ACDE2C0066A88D /* CorrectionRangeInformationView.swift */,
+				E916F56E24AE2FFE00BE3547 /* CorrectionRangeOverrideInformationView.swift */,
 				E949E38E24B3711E00024DA0 /* InsulinModelInformationView.swift */,
-				E93C86B524D08CAD0073089B /* InsulinSensitivityInformationView.swift */,
 				E96DCB5724AEF50F007117BC /* SuspendThresholdInformationView.swift */,
+				E96DCB5D24AF7DC7007117BC /* BasalRatesInformationView.swift */,
+				E949E38824AFC82F00024DA0 /* DeliveryLimitsInformationView.swift */,
+				E93C86B124D080E00073089B /* CarbRatioInformationView.swift */,
+				E93C86B524D08CAD0073089B /* InsulinSensitivityInformationView.swift */,
 			);
 			path = "Information Screens";
 			sourceTree = "<group>";
@@ -3210,7 +3210,6 @@
 				43BA7163201E490D0058961E /* InsulinDeliveryTableViewController.swift in Sources */,
 				C1E4B30A242E99A800E70CCB /* Image.swift in Sources */,
 				43BA718A201EE8CF0058961E /* NSTimeInterval.swift in Sources */,
-				1DBA06CA24E4966000045CDB /* CorrectionRangeOverrideInformationView.swift in Sources */,
 				B4A2AAB1240830A30066563F /* LabeledTextField.swift in Sources */,
 				B429D66E24BF7255003E1B4A /* UIImage.swift in Sources */,
 				B46B62A923FF05F8001E69BA /* LabeledNumberInput.swift in Sources */,
@@ -3318,6 +3317,7 @@
 				89FC6892245A2D680075CF59 /* ScheduleEditor.swift in Sources */,
 				89CAB37124CB4DEC009EE3CE /* WarningView.swift in Sources */,
 				43BA717B201EE6A40058961E /* NibLoadable.swift in Sources */,
+				E916F56F24AE2FFE00BE3547 /* CorrectionRangeOverrideInformationView.swift in Sources */,
 				89BE75C124649C2E00B145D9 /* ModalHeaderButtonBar.swift in Sources */,
 				E9D95F6524C7BC400079F47D /* PresentationMode.swift in Sources */,
 				89186C0524BEC9CA0003D0F3 /* SegmentedControlTableViewCell.swift in Sources */,

--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		1D841AAD24577EE10069DBFF /* AlertSoundPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D841AAC24577EE10069DBFF /* AlertSoundPlayer.swift */; };
 		1DA649AB2445174400F61E75 /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649AA2445174400F61E75 /* Alert.swift */; };
 		1DABAD3A2453615200ACF708 /* IssueAlertTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DABAD392453615200ACF708 /* IssueAlertTableViewController.swift */; };
+		1DBA06CA24E4966000045CDB /* CorrectionRangeOverrideInformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DBA06C924E4966000045CDB /* CorrectionRangeOverrideInformationView.swift */; };
 		1DC64C7C24BF6BFD004A63A1 /* CorrectionRangeOverridesExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC64C7B24BF6BFD004A63A1 /* CorrectionRangeOverridesExtension.swift */; };
 		1DC64C7E24BF6EBC004A63A1 /* DeliveryLimits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC64C7D24BF6EBC004A63A1 /* DeliveryLimits.swift */; };
 		1DD1964E248AE88000420876 /* HorizontalSizeClassOverride.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD1964D248AE88000420876 /* HorizontalSizeClassOverride.swift */; };
@@ -736,7 +737,6 @@
 		E9086B4824B5405E0062F5C8 /* ChartAxisValueDoubleUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9086B4724B5405E0062F5C8 /* ChartAxisValueDoubleUnit.swift */; };
 		E9086B4A24B540B70062F5C8 /* DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9086B4924B540B70062F5C8 /* DateFormatter.swift */; };
 		E916F56924AD32F000BE3547 /* CorrectionRangeOverridesEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E916F56824AD32F000BE3547 /* CorrectionRangeOverridesEditor.swift */; };
-		E916F56F24AE2FFE00BE3547 /* CorrectionRangeOverrideInformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E916F56E24AE2FFE00BE3547 /* CorrectionRangeOverrideInformationView.swift */; };
 		E93BA06624A39DBC00C5D7E6 /* DismissibleHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E93BA06524A39DBC00C5D7E6 /* DismissibleHostingController.swift */; };
 		E93C86A024C8F6E00073089B /* InsulinModelSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E93C869F24C8F6E00073089B /* InsulinModelSelection.swift */; };
 		E93C86A224C8F7550073089B /* InsulinModelChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = E93C86A124C8F7550073089B /* InsulinModelChart.swift */; };
@@ -899,6 +899,7 @@
 		1D841AAC24577EE10069DBFF /* AlertSoundPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertSoundPlayer.swift; sourceTree = "<group>"; };
 		1DA649AA2445174400F61E75 /* Alert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Alert.swift; sourceTree = "<group>"; };
 		1DABAD392453615200ACF708 /* IssueAlertTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueAlertTableViewController.swift; sourceTree = "<group>"; };
+		1DBA06C924E4966000045CDB /* CorrectionRangeOverrideInformationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CorrectionRangeOverrideInformationView.swift; sourceTree = "<group>"; };
 		1DC64C7B24BF6BFD004A63A1 /* CorrectionRangeOverridesExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectionRangeOverridesExtension.swift; sourceTree = "<group>"; };
 		1DC64C7D24BF6EBC004A63A1 /* DeliveryLimits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryLimits.swift; sourceTree = "<group>"; };
 		1DD1964D248AE88000420876 /* HorizontalSizeClassOverride.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalSizeClassOverride.swift; sourceTree = "<group>"; };
@@ -1534,7 +1535,6 @@
 		E9086B4724B5405E0062F5C8 /* ChartAxisValueDoubleUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartAxisValueDoubleUnit.swift; sourceTree = "<group>"; };
 		E9086B4924B540B70062F5C8 /* DateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatter.swift; sourceTree = "<group>"; };
 		E916F56824AD32F000BE3547 /* CorrectionRangeOverridesEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectionRangeOverridesEditor.swift; sourceTree = "<group>"; };
-		E916F56E24AE2FFE00BE3547 /* CorrectionRangeOverrideInformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectionRangeOverrideInformationView.swift; sourceTree = "<group>"; };
 		E93BA06524A39DBC00C5D7E6 /* DismissibleHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissibleHostingController.swift; sourceTree = "<group>"; };
 		E93C869F24C8F6E00073089B /* InsulinModelSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsulinModelSelection.swift; sourceTree = "<group>"; };
 		E93C86A124C8F7550073089B /* InsulinModelChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsulinModelChart.swift; sourceTree = "<group>"; };
@@ -2535,15 +2535,15 @@
 		E9077D2824ACD5AA0066A88D /* Information Screens */ = {
 			isa = PBXGroup;
 			children = (
-				E9077D2624ACD59F0066A88D /* InformationView.swift */,
-				E9077D2924ACDE2C0066A88D /* CorrectionRangeInformationView.swift */,
-				E916F56E24AE2FFE00BE3547 /* CorrectionRangeOverrideInformationView.swift */,
-				E949E38E24B3711E00024DA0 /* InsulinModelInformationView.swift */,
-				E96DCB5724AEF50F007117BC /* SuspendThresholdInformationView.swift */,
 				E96DCB5D24AF7DC7007117BC /* BasalRatesInformationView.swift */,
-				E949E38824AFC82F00024DA0 /* DeliveryLimitsInformationView.swift */,
 				E93C86B124D080E00073089B /* CarbRatioInformationView.swift */,
+				E9077D2924ACDE2C0066A88D /* CorrectionRangeInformationView.swift */,
+				1DBA06C924E4966000045CDB /* CorrectionRangeOverrideInformationView.swift */,
+				E949E38824AFC82F00024DA0 /* DeliveryLimitsInformationView.swift */,
+				E9077D2624ACD59F0066A88D /* InformationView.swift */,
+				E949E38E24B3711E00024DA0 /* InsulinModelInformationView.swift */,
 				E93C86B524D08CAD0073089B /* InsulinSensitivityInformationView.swift */,
+				E96DCB5724AEF50F007117BC /* SuspendThresholdInformationView.swift */,
 			);
 			path = "Information Screens";
 			sourceTree = "<group>";
@@ -3210,6 +3210,7 @@
 				43BA7163201E490D0058961E /* InsulinDeliveryTableViewController.swift in Sources */,
 				C1E4B30A242E99A800E70CCB /* Image.swift in Sources */,
 				43BA718A201EE8CF0058961E /* NSTimeInterval.swift in Sources */,
+				1DBA06CA24E4966000045CDB /* CorrectionRangeOverrideInformationView.swift in Sources */,
 				B4A2AAB1240830A30066563F /* LabeledTextField.swift in Sources */,
 				B429D66E24BF7255003E1B4A /* UIImage.swift in Sources */,
 				B46B62A923FF05F8001E69BA /* LabeledNumberInput.swift in Sources */,
@@ -3317,7 +3318,6 @@
 				89FC6892245A2D680075CF59 /* ScheduleEditor.swift in Sources */,
 				89CAB37124CB4DEC009EE3CE /* WarningView.swift in Sources */,
 				43BA717B201EE6A40058961E /* NibLoadable.swift in Sources */,
-				E916F56F24AE2FFE00BE3547 /* CorrectionRangeOverrideInformationView.swift in Sources */,
 				89BE75C124649C2E00B145D9 /* ModalHeaderButtonBar.swift in Sources */,
 				E9D95F6524C7BC400079F47D /* PresentationMode.swift in Sources */,
 				89186C0524BEC9CA0003D0F3 /* SegmentedControlTableViewCell.swift in Sources */,

--- a/LoopKit/CorrectionRangeOverrides.swift
+++ b/LoopKit/CorrectionRangeOverrides.swift
@@ -9,6 +9,7 @@
 import HealthKit
 import Foundation
 
+// TODO: Now that these are split, can we get rid of this struct?
 public struct CorrectionRangeOverrides: Equatable {
     public enum Preset: Hashable, CaseIterable {
         case preMeal
@@ -43,6 +44,13 @@ public extension CorrectionRangeOverrides.Preset {
             return LocalizedString("Temporarily lower your glucose target before a meal to impact post-meal glucose spikes. This range can be set anywhere from your suspend threshold on the low end to the top of your regular correction range on the high end.", comment: "Description of pre-meal mode")
         case .workout:
             return LocalizedString("Temporarily raise your glucose target before, during, or after physical activity to reduce the risk of low glucose events. This range can be set anywhere from the top of your regular correction range on the low end to 180 mg/dL (10 mmol/L) on the high end.", comment: "Description of workout mode")
+        }
+    }
+    
+    var therapySetting: TherapySetting {
+        switch self {
+        case .preMeal: return .preMealCorrectionRangeOverride
+        case .workout: return .workoutCorrectionRangeOverride
         }
     }
 }

--- a/LoopKit/CorrectionRangeOverrides.swift
+++ b/LoopKit/CorrectionRangeOverrides.swift
@@ -9,7 +9,6 @@
 import HealthKit
 import Foundation
 
-// TODO: Now that these are split, can we get rid of this struct?
 public struct CorrectionRangeOverrides: Equatable {
     public enum Preset: Hashable, CaseIterable {
         case preMeal

--- a/LoopKit/TherapySetting.swift
+++ b/LoopKit/TherapySetting.swift
@@ -9,7 +9,8 @@
 
 public enum TherapySetting: Int {
     case glucoseTargetRange
-    case correctionRangeOverrides
+    case preMealCorrectionRangeOverride
+    case workoutCorrectionRangeOverride
     case suspendThreshold
     case basalRate
     case deliveryLimits
@@ -26,8 +27,10 @@ public extension TherapySetting {
         switch self {
         case .glucoseTargetRange:
             return LocalizedString("Correction Range", comment: "Title text for glucose target range")
-        case .correctionRangeOverrides:
-            return LocalizedString("Temporary Correction Ranges", comment: "Title text for temporary correction ranges")
+        case .preMealCorrectionRangeOverride:
+            return String(format: LocalizedString("%@ Range", comment: "Format for correction range override therapy setting card"), CorrectionRangeOverrides.Preset.preMeal.title)
+        case .workoutCorrectionRangeOverride:
+            return String(format: LocalizedString("%@ Range", comment: "Format for correction range override therapy setting card"), CorrectionRangeOverrides.Preset.workout.title)
         case .suspendThreshold:
             return LocalizedString("Suspend Threshold", comment: "Title text for suspend threshold")
         case .basalRate:
@@ -47,8 +50,6 @@ public extension TherapySetting {
     
     var smallTitle: String {
         switch self {
-        case .correctionRangeOverrides:
-            return LocalizedString("Temporary Ranges", comment: "Title text for temporary correction ranges")
         default:
             return title
         }
@@ -58,8 +59,10 @@ public extension TherapySetting {
         switch self {
         case .glucoseTargetRange:
             return LocalizedString("Correction range is the glucose value (or range of values) that you want Tidepool Loop to aim for in adjusting your basal insulin.", comment: "Descriptive text for glucose target range")
-        case .correctionRangeOverrides:
-            return LocalizedString("Pre-Meal and Workout ranges temporarily adjust your glucose target based on your selected activity.", comment: "Descriptive text for correction range overrides")
+        case .preMealCorrectionRangeOverride:
+            return CorrectionRangeOverrides.Preset.preMeal.descriptiveText
+        case .workoutCorrectionRangeOverride:
+            return CorrectionRangeOverrides.Preset.workout.descriptiveText
         case .suspendThreshold:
             return LocalizedString("When your glucose is predicted to go below this value, the app will recommend a basal rate of 0 U/hr and will not recommend a bolus.", comment: "Descriptive text for suspend threshold")
         case .basalRate:

--- a/LoopKitUI/Views/Information Screens/CorrectionRangeOverrideInformationView.swift
+++ b/LoopKitUI/Views/Information Screens/CorrectionRangeOverrideInformationView.swift
@@ -10,29 +10,30 @@ import LoopKit
 import SwiftUI
 
 public struct CorrectionRangeOverrideInformationView: View {
+    let preset: CorrectionRangeOverrides.Preset
     var onExit: (() -> Void)?
-    var mode: PresentationMode
+    let mode: PresentationMode
     
     @Environment(\.presentationMode) var presentationMode
     @Environment(\.carbTintColor) var carbTintColor
     @Environment(\.glucoseTintColor) var glucoseTintColor
     
     public init(
+        preset: CorrectionRangeOverrides.Preset,
         onExit: (() -> Void)?,
         mode: PresentationMode = .acceptanceFlow
     ) {
+        self.preset = preset
         self.onExit = onExit
         self.mode = mode
     }
     
     public var body: some View {
         InformationView(
-            title: Text(TherapySetting.correctionRangeOverrides.smallTitle),
+            title: Text(preset.therapySetting.title),
             informationalContent: {
                 VStack (alignment: .leading, spacing: 20) {
-                    section(for: CorrectionRangeOverrides.Preset.preMeal)
-                    Divider()
-                    section(for: CorrectionRangeOverrides.Preset.workout)
+                    section(for: preset)
                 }
             },
             onExit: onExit ?? { self.presentationMode.wrappedValue.dismiss() },

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
@@ -76,9 +76,9 @@ public struct CorrectionRangeOverridesEditor: View {
                 let glucoseUnit = viewModel?.therapySettings.glucoseUnit ?? .milligramsPerDeciliter
                 switch preset {
                 case .preMeal:
-                    viewModel?.saveCorrectionRangeOverride(preMeal: overrides.preMeal?.doubleRange(for: glucoseUnit))
+                    viewModel?.saveCorrectionRangeOverride(preMeal: overrides.preMeal, unit: glucoseUnit)
                 case .workout:
-                    viewModel?.saveCorrectionRangeOverride(workout: overrides.workout?.doubleRange(for: glucoseUnit))
+                    viewModel?.saveCorrectionRangeOverride(workout: overrides.workout, unit: glucoseUnit)
                 }
                 didSave?()
             },

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
@@ -186,7 +186,7 @@ public struct CorrectionRangeOverridesEditor: View {
     }
     
     private func guardrail(for preset: CorrectionRangeOverrides.Preset) -> Guardrail<HKQuantity> {
-        return Guardrail.correctionRangeOverridePreset(preset, correctionRangeScheduleRange: correctionRangeScheduleRange)
+        return Guardrail.correctionRangeOverride(for: preset, correctionRangeScheduleRange: correctionRangeScheduleRange)
     }
     
     private var instructionalContentIfNecessary: some View {
@@ -251,6 +251,7 @@ public struct CorrectionRangeOverridesEditor: View {
 
                 return thresholds.isEmpty ? nil : thresholds
             }
+            .filter { $0.key == preset }
     }
 
     private func confirmationAlert() -> SwiftUI.Alert {

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesExpandableSetting.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesExpandableSetting.swift
@@ -44,6 +44,6 @@ public struct CorrectionRangeOverridesExpandableSetting<ExpandedContent: View>: 
     }
 
     private func guardrail(for preset: CorrectionRangeOverrides.Preset) -> Guardrail<HKQuantity> {
-        return Guardrail.correctionRangeOverridePreset(preset, correctionRangeScheduleRange: correctionRangeScheduleRange)
+        return Guardrail.correctionRangeOverride(for: preset, correctionRangeScheduleRange: correctionRangeScheduleRange)
     }
 }

--- a/LoopKitUI/Views/Settings Editors/TherapySetting+Settings.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySetting+Settings.swift
@@ -23,8 +23,10 @@ extension TherapySetting {
         switch self {
         case .glucoseTargetRange:
             return AnyView(CorrectionRangeInformationView(onExit: nil, mode: .settings))
-        case .correctionRangeOverrides:
-            return AnyView(CorrectionRangeOverrideInformationView(onExit: nil, mode: .settings))
+        case .preMealCorrectionRangeOverride:
+            return AnyView(CorrectionRangeOverrideInformationView(preset: .preMeal, onExit: nil, mode: .settings))
+        case .workoutCorrectionRangeOverride:
+            return AnyView(CorrectionRangeOverrideInformationView(preset: .workout, onExit: nil, mode: .settings))
         case .suspendThreshold:
             return AnyView(SuspendThresholdInformationView(onExit: nil, mode: .settings))
         case .basalRate:

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -50,7 +50,9 @@ public struct TherapySettingsView: View, HorizontalSizeClassOverride {
                 suspendThresholdSection
                 correctionRangeSection
                 preMealCorrectionRangeSection
-                workoutCorrectionRangeSection
+                if !viewModel.sensitivityOverridesEnabled {
+                    workoutCorrectionRangeSection
+                }
                 basalRatesSection
                 deliveryLimitsSection
                 insulinModelSection

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -49,7 +49,8 @@ public struct TherapySettingsView: View, HorizontalSizeClassOverride {
                 }
                 suspendThresholdSection
                 correctionRangeSection
-                temporaryCorrectionRangesSection
+                preMealCorrectionRangeSection
+                workoutCorrectionRangeSection
                 basalRatesSection
                 deliveryLimitsSection
                 insulinModelSection
@@ -109,37 +110,8 @@ extension TherapySettingsView {
                DateFormatter.localizedString(from: viewModel.prescription!.datePrescribed, dateStyle: .short, timeStyle: .none))
     }
     
-    private var correctionRangeSection: some View {
-        section(for: .glucoseTargetRange) {
-            if self.glucoseUnit != nil && self.viewModel.therapySettings.glucoseTargetRangeSchedule != nil {
-                ForEach(self.viewModel.therapySettings.glucoseTargetRangeSchedule!.items, id: \.self) { value in
-                    ScheduleRangeItem(time: value.startTime,
-                                      range: value.value,
-                                      unit: self.glucoseUnit!,
-                                      guardrail: .correctionRange)
-                }
-            }
-        }
-    }
-    
-    private var temporaryCorrectionRangesSection: some View {
-        section(for: .correctionRangeOverrides) {
-            if self.glucoseUnit != nil && self.viewModel.therapySettings.glucoseTargetRangeSchedule != nil {
-                ForEach(CorrectionRangeOverrides.Preset.allCases, id: \.self) { preset in
-                    CorrectionRangeOverridesRangeItem(
-                        preMealTargetRange: self.viewModel.therapySettings.preMealTargetRange,
-                        workoutTargetRange: self.viewModel.therapySettings.workoutTargetRange,
-                        unit: self.glucoseUnit!,
-                        preset: preset,
-                        correctionRangeScheduleRange: self.viewModel.therapySettings.glucoseTargetRangeSchedule!.scheduleRange()
-                    )
-                }
-            }
-        }
-    }
-    
     private var suspendThresholdSection: some View {
-        section(for: .suspendThreshold, addExtraSpaceAboveSection: viewModel.prescription == nil) {
+        section(for: .suspendThreshold, header: viewModel.prescription == nil ? AnyView(Spacer()) : AnyView(EmptyView())) {
             if self.glucoseUnit != nil {
                 HStack {
                     Spacer()
@@ -156,6 +128,47 @@ extension TherapySettingsView {
         }
     }
     
+    private var correctionRangeSection: some View {
+        section(for: .glucoseTargetRange) {
+            if self.glucoseUnit != nil && self.viewModel.therapySettings.glucoseTargetRangeSchedule != nil {
+                ForEach(self.viewModel.therapySettings.glucoseTargetRangeSchedule!.items, id: \.self) { value in
+                    ScheduleRangeItem(time: value.startTime,
+                                      range: value.value,
+                                      unit: self.glucoseUnit!,
+                                      guardrail: .correctionRange)
+                }
+            }
+        }
+    }
+    
+    private var preMealCorrectionRangeSection: some View {
+        section(for: .preMealCorrectionRangeOverride) {
+            if self.glucoseUnit != nil && self.viewModel.therapySettings.glucoseTargetRangeSchedule != nil {
+                CorrectionRangeOverridesRangeItem(
+                    preMealTargetRange: self.viewModel.therapySettings.preMealTargetRange,
+                    workoutTargetRange: self.viewModel.therapySettings.workoutTargetRange,
+                    unit: self.glucoseUnit!,
+                    preset: CorrectionRangeOverrides.Preset.preMeal,
+                    correctionRangeScheduleRange: self.viewModel.therapySettings.glucoseTargetRangeSchedule!.scheduleRange()
+                )
+            }
+        }
+    }
+    
+    private var workoutCorrectionRangeSection: some View {
+        section(for: .workoutCorrectionRangeOverride) {
+            if self.glucoseUnit != nil && self.viewModel.therapySettings.glucoseTargetRangeSchedule != nil {
+                CorrectionRangeOverridesRangeItem(
+                    preMealTargetRange: self.viewModel.therapySettings.preMealTargetRange,
+                    workoutTargetRange: self.viewModel.therapySettings.workoutTargetRange,
+                    unit: self.glucoseUnit!,
+                    preset: CorrectionRangeOverrides.Preset.workout,
+                    correctionRangeScheduleRange: self.viewModel.therapySettings.glucoseTargetRangeSchedule!.scheduleRange()
+                )
+            }
+        }
+    }
+
     private var basalRatesSection: some View {
         section(for: .basalRate) {
             if self.viewModel.therapySettings.basalRateSchedule != nil && self.viewModel.pumpSupportedIncrements != nil {
@@ -272,12 +285,22 @@ extension TherapySettingsView {
     private var sensitivityUnit: HKUnit? {
         glucoseUnit?.unitDivided(by: .internationalUnit())
     }
-
+    
     private func section<Content>(for therapySetting: TherapySetting,
-                                  addExtraSpaceAboveSection: Bool = false,
                                   @ViewBuilder content: @escaping () -> Content) -> some View where Content: View {
         SectionWithTapToEdit(isEnabled: viewModel.mode != .acceptanceFlow,
-                             header: addExtraSpaceAboveSection ? AnyView(Spacer()) : AnyView(EmptyView()),
+                             header: EmptyView(),
+                             title: therapySetting.title,
+                             descriptiveText: therapySetting.descriptiveText,
+                             destination: screen(for: therapySetting),
+                             content: content)
+    }
+
+    private func section<Content, Header>(for therapySetting: TherapySetting,
+                                          header: Header,
+                                          @ViewBuilder content: @escaping () -> Content) -> some View where Content: View, Header: View {
+        SectionWithTapToEdit(isEnabled: viewModel.mode != .acceptanceFlow,
+                             header: header,
                              title: therapySetting.title,
                              descriptiveText: therapySetting.descriptiveText,
                              destination: screen(for: therapySetting),
@@ -397,10 +420,16 @@ private extension TherapySettingsView {
                     AnyView(CorrectionRangeScheduleEditor(viewModel: self.viewModel, didSave: goBack).environment(\.dismiss, goBack))
                 }
             }
-        case .correctionRangeOverrides:
+        case .preMealCorrectionRangeOverride:
             if self.viewModel.therapySettings.glucoseUnit != nil {
                 return { goBack in
-                   AnyView(CorrectionRangeOverridesEditor(viewModel: self.viewModel, didSave: goBack).environment(\.dismiss, goBack))
+                    AnyView(CorrectionRangeOverridesEditor(viewModel: self.viewModel, preset: .preMeal, didSave: goBack).environment(\.dismiss, goBack))
+                }
+            }
+        case .workoutCorrectionRangeOverride:
+            if self.viewModel.therapySettings.glucoseUnit != nil {
+                return { goBack in
+                    AnyView(CorrectionRangeOverridesEditor(viewModel: self.viewModel, preset: .workout, didSave: goBack).environment(\.dismiss, goBack))
                 }
             }
         case .basalRate:

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsViewModel.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsViewModel.swift
@@ -65,11 +65,15 @@ public class TherapySettingsViewModel: ObservableObject {
         therapySettings.glucoseTargetRangeSchedule = range
         didSave?(TherapySetting.glucoseTargetRange, therapySettings)
     }
+        
+    public func saveCorrectionRangeOverride(preMeal: DoubleRange?) {
+        therapySettings.preMealTargetRange = preMeal
+        didSave?(TherapySetting.preMealCorrectionRangeOverride, therapySettings)
+    }
     
-    public func saveCorrectionRangeOverrides(overrides: CorrectionRangeOverrides, unit: HKUnit) {
-        therapySettings.preMealTargetRange = overrides.preMeal?.doubleRange(for: unit)
-        therapySettings.workoutTargetRange = overrides.workout?.doubleRange(for: unit)
-        didSave?(TherapySetting.correctionRangeOverrides, therapySettings)
+    public func saveCorrectionRangeOverride(workout: DoubleRange?) {
+        therapySettings.workoutTargetRange = workout
+        didSave?(TherapySetting.workoutCorrectionRangeOverride, therapySettings)
     }
     
     public func saveSuspendThreshold(value: GlucoseThreshold) {

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsViewModel.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsViewModel.swift
@@ -66,13 +66,13 @@ public class TherapySettingsViewModel: ObservableObject {
         didSave?(TherapySetting.glucoseTargetRange, therapySettings)
     }
         
-    public func saveCorrectionRangeOverride(preMeal: DoubleRange?) {
-        therapySettings.preMealTargetRange = preMeal
+    public func saveCorrectionRangeOverride(preMeal: ClosedRange<HKQuantity>?, unit: HKUnit) {
+        therapySettings.preMealTargetRange = preMeal?.doubleRange(for: unit)
         didSave?(TherapySetting.preMealCorrectionRangeOverride, therapySettings)
     }
     
-    public func saveCorrectionRangeOverride(workout: DoubleRange?) {
-        therapySettings.workoutTargetRange = workout
+    public func saveCorrectionRangeOverride(workout: ClosedRange<HKQuantity>?, unit: HKUnit) {
+        therapySettings.workoutTargetRange = workout?.doubleRange(for: unit)
         didSave?(TherapySetting.workoutCorrectionRangeOverride, therapySettings)
     }
     


### PR DESCRIPTION
This splits both the sections in TherapySettingsView _and_ the screens for the editors.

[LOOP-1708](https://tidepool.atlassian.net/browse/LOOP-1708)