### PR TITLE
Remove unnecessary properties from carb structures

### DIFF
--- a/LoopKit/CarbKit/CachedCarbObject+CoreDataClass.swift
+++ b/LoopKit/CarbKit/CachedCarbObject+CoreDataClass.swift
@@ -38,19 +38,6 @@ class CachedCarbObject: NSManagedObject {
         }
     }
 
-    var uploadState: UploadState {
-        get {
-            willAccessValue(forKey: "uploadState")
-            defer { didAccessValue(forKey: "uploadState") }
-            return UploadState(rawValue: primitiveUploadState!.intValue)!
-        }
-        set {
-            willChangeValue(forKey: "uploadState")
-            defer { didChangeValue(forKey: "uploadState") }
-            primitiveUploadState = NSNumber(value: newValue.rawValue)
-        }
-    }
-
     override func willSave() {
         if isInserted || isUpdated {
             setPrimitiveValue(managedObjectContext!.modificationCounter ?? 0, forKey: "modificationCounter")

--- a/LoopKit/CarbKit/CachedCarbObject+CoreDataProperties.swift
+++ b/LoopKit/CarbKit/CachedCarbObject+CoreDataProperties.swift
@@ -22,7 +22,6 @@ extension CachedCarbObject {
     @NSManaged public var foodType: String?
     @NSManaged public var grams: Double
     @NSManaged public var primitiveStartDate: NSDate?
-    @NSManaged public var primitiveUploadState: NSNumber?
     @NSManaged public var uuid: UUID?
     @NSManaged public var syncIdentifier: String?
     @NSManaged public var syncVersion: Int32

--- a/LoopKit/CarbKit/CarbStore.swift
+++ b/LoopKit/CarbKit/CarbStore.swift
@@ -243,8 +243,6 @@ public final class CarbStore: HealthKitSampleStore {
             case .adaptiveRateNonlinear:
                 self.settings = CarbModelSettings(absorptionModel: PiecewiseLinearAbsorption(), initialAbsorptionTimeOverrun: 1.0, adaptiveAbsorptionRateEnabled: true, adaptiveRateStandbyIntervalFraction: 0.2)
             }
-
-            // TODO: Consider resetting uploadState.uploading
         }
     }
 
@@ -535,7 +533,6 @@ extension CarbStore {
         cacheStore.managedObjectContext.performAndWait {
             for object in self.cacheStore.managedObjectContext.cachedCarbObjectsWithUUID(oldEntry.sampleUUID) {
                 object.update(from: newEntry)
-                object.uploadState = .notUploaded
             }
 
             self.cacheStore.save()
@@ -955,7 +952,7 @@ extension CarbStore {
                 super.debugDescription,
                 "",
                 "cachedCarbEntries: [",
-                "\tStoredCarbEntry(sampleUUID, syncIdentifier, syncVersion, startDate, quantity, foodType, absorptionTime, createdByCurrentApp, externalID, isUploaded)"
+                "\tStoredCarbEntry(sampleUUID, syncIdentifier, syncVersion, startDate, quantity, foodType, absorptionTime, createdByCurrentApp, externalID)"
             ]
 
             let carbEntries = self.getCachedCarbEntries()
@@ -972,16 +969,15 @@ extension CarbStore {
                     String(describing: entry.absorptionTime ?? self.defaultAbsorptionTimes.medium),
                     String(describing: entry.createdByCurrentApp),
                     entry.externalID ?? "",
-                    String(describing: entry.isUploaded),
                 ].joined(separator: ", ")
             }).joined(separator: "\n"))
             report.append("]")
             report.append("")
 
             report.append("deletedCarbEntries: [")
-            report.append("\tDeletedCarbEntry(externalID, isUploaded)")
+            report.append("\tDeletedCarbEntry(externalID)")
             for entry in self.cachedDeletedCarbEntries {
-                report.append("\t\(String(describing: entry.externalID)), \(entry.isUploaded)")
+                report.append("\t\(String(describing: entry.externalID))")
             }
             report.append("]")
             report.append("")

--- a/LoopKit/CarbKit/DeletedCarbEntry.swift
+++ b/LoopKit/CarbKit/DeletedCarbEntry.swift
@@ -10,15 +10,13 @@ import Foundation
 
 public struct DeletedCarbEntry {
     public let externalID: String?
-    public var isUploaded: Bool
     public let startDate: Date?
     public let uuid: UUID?
     public let syncIdentifier: String?
     public let syncVersion: Int
 
-    public init(externalID: String?, isUploaded: Bool, startDate: Date?, uuid: UUID?, syncIdentifier: String?, syncVersion: Int) {
+    public init(externalID: String?, startDate: Date?, uuid: UUID?, syncIdentifier: String?, syncVersion: Int) {
         self.externalID = externalID
-        self.isUploaded = isUploaded
         self.startDate = startDate
         self.uuid = uuid
         self.syncIdentifier = syncIdentifier
@@ -30,7 +28,6 @@ extension DeletedCarbEntry {
     init(managedObject: DeletedCarbObject) {
         self.init(
             externalID: managedObject.externalID,
-            isUploaded: managedObject.uploadState == .uploaded,
             startDate: managedObject.startDate,
             uuid: managedObject.uuid,
             syncIdentifier: managedObject.syncIdentifier,

--- a/LoopKit/CarbKit/DeletedCarbObject+CoreDataClass.swift
+++ b/LoopKit/CarbKit/DeletedCarbObject+CoreDataClass.swift
@@ -11,19 +11,6 @@ import CoreData
 
 
 class DeletedCarbObject: NSManagedObject {
-    var uploadState: UploadState {
-        get {
-            willAccessValue(forKey: "uploadState")
-            defer { didAccessValue(forKey: "uploadState") }
-            return UploadState(rawValue: primitiveUploadState!.intValue)!
-        }
-        set {
-            willChangeValue(forKey: "uploadState")
-            defer { didChangeValue(forKey: "uploadState") }
-            primitiveUploadState = NSNumber(value: newValue.rawValue)
-        }
-    }
-
     override func willSave() {
         if isInserted || isUpdated {
             setPrimitiveValue(managedObjectContext!.modificationCounter ?? 0, forKey: "modificationCounter")
@@ -36,7 +23,6 @@ extension DeletedCarbObject {
 
     func update(from cachedCarbObject: CachedCarbObject) {
         externalID = cachedCarbObject.externalID
-        uploadState = cachedCarbObject.uploadState
         startDate = cachedCarbObject.startDate
         uuid = cachedCarbObject.uuid
         syncIdentifier = cachedCarbObject.syncIdentifier
@@ -45,7 +31,6 @@ extension DeletedCarbObject {
 
     func update(from entry: DeletedCarbEntry) {
         externalID = entry.externalID
-        uploadState = entry.isUploaded ? .uploaded : .notUploaded
         startDate = entry.startDate
         uuid = entry.uuid
         syncIdentifier = entry.syncIdentifier

--- a/LoopKit/CarbKit/DeletedCarbObject+CoreDataProperties.swift
+++ b/LoopKit/CarbKit/DeletedCarbObject+CoreDataProperties.swift
@@ -17,7 +17,6 @@ extension DeletedCarbObject {
     }
 
     @NSManaged public var externalID: String?
-    @NSManaged public var primitiveUploadState: NSNumber?
     @NSManaged public var startDate: Date?
     @NSManaged public var uuid: UUID?
     @NSManaged public var syncIdentifier: String?

--- a/LoopKit/CarbKit/StoredCarbEntry.swift
+++ b/LoopKit/CarbKit/StoredCarbEntry.swift
@@ -34,8 +34,7 @@ public struct StoredCarbEntry: CarbEntry {
 
     // MARK: - Sync state
 
-    public var externalID: String?
-    public var isUploaded: Bool
+    public let externalID: String?
 
     init(sample: HKQuantitySample, createdByCurrentApp: Bool? = nil) {
         self.init(
@@ -48,8 +47,7 @@ public struct StoredCarbEntry: CarbEntry {
             foodType: sample.foodType,
             absorptionTime: sample.absorptionTime,
             createdByCurrentApp: createdByCurrentApp ?? sample.createdByCurrentApp,
-            externalID: sample.externalID,
-            isUploaded: sample.externalID != nil
+            externalID: sample.externalID
         )
     }
 
@@ -63,8 +61,7 @@ public struct StoredCarbEntry: CarbEntry {
         foodType: String?,
         absorptionTime: TimeInterval?,
         createdByCurrentApp: Bool,
-        externalID: String?,
-        isUploaded: Bool
+        externalID: String?
     ) {
         self.sampleUUID = sampleUUID
         self.syncIdentifier = syncIdentifier
@@ -75,7 +72,6 @@ public struct StoredCarbEntry: CarbEntry {
         self.absorptionTime = absorptionTime
         self.createdByCurrentApp = createdByCurrentApp
         self.externalID = externalID
-        self.isUploaded = isUploaded
     }
 }
 
@@ -126,8 +122,7 @@ extension StoredCarbEntry {
             foodType: rawValue["foodType"] as? String,
             absorptionTime: rawValue["absorptionTime"] as? TimeInterval,
             createdByCurrentApp: createdByCurrentApp,
-            externalID: externalID,
-            isUploaded: externalID != nil
+            externalID: externalID
         )
     }
 }
@@ -145,8 +140,7 @@ extension StoredCarbEntry {
             foodType: managedObject.foodType,
             absorptionTime: managedObject.absorptionTime,
             createdByCurrentApp: managedObject.createdByCurrentApp,
-            externalID: managedObject.externalID,
-            isUploaded: (managedObject.uploadState == .uploaded)
+            externalID: managedObject.externalID
         )
     }
 }

--- a/LoopKit/Persistence/Model.xcdatamodeld/Modelv2.xcdatamodel/contents
+++ b/LoopKit/Persistence/Model.xcdatamodeld/Modelv2.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="16119" systemVersion="19F101" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="16119" systemVersion="19G73" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="CachedCarbObject" representedClassName=".CachedCarbObject" syncable="YES">
         <attribute name="absorptionTime" optional="YES" attributeType="Double" usesScalarValueType="NO"/>
         <attribute name="createdByCurrentApp" attributeType="Boolean" usesScalarValueType="YES"/>
@@ -10,7 +10,6 @@
         <attribute name="startDate" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="syncIdentifier" optional="YES" attributeType="String"/>
         <attribute name="syncVersion" attributeType="Integer 32" defaultValueString="1" usesScalarValueType="YES"/>
-        <attribute name="uploadState" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
         <attribute name="uuid" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <uniquenessConstraints>
             <uniquenessConstraint>
@@ -91,7 +90,6 @@
         <attribute name="startDate" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="syncIdentifier" optional="YES" attributeType="String"/>
         <attribute name="syncVersion" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="uploadState" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
         <attribute name="uuid" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <uniquenessConstraints>
             <uniquenessConstraint>
@@ -151,10 +149,10 @@
         <attribute name="modificationCounter" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>
     <elements>
-        <element name="CachedCarbObject" positionX="-63" positionY="72" width="128" height="208"/>
+        <element name="CachedCarbObject" positionX="-63" positionY="72" width="128" height="193"/>
         <element name="CachedGlucoseObject" positionX="-63" positionY="99" width="128" height="208"/>
         <element name="CachedInsulinDeliveryObject" positionX="-63" positionY="108" width="128" height="208"/>
-        <element name="DeletedCarbObject" positionX="-63" positionY="90" width="128" height="148"/>
+        <element name="DeletedCarbObject" positionX="-63" positionY="90" width="128" height="133"/>
         <element name="DosingDecisionObject" positionX="-63" positionY="126" width="128" height="88"/>
         <element name="PumpEvent" positionX="-63" positionY="18" width="128" height="238"/>
         <element name="Reservoir" positionX="-63" positionY="-18" width="128" height="105"/>

--- a/LoopKitTests/CarbStoreTests.swift
+++ b/LoopKitTests/CarbStoreTests.swift
@@ -52,8 +52,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
     // MARK: -
     
     func testAddCarbEntry() {
-        let syncIdentifier = generateSyncIdentifier()
-        let addCarbEntry = NewCarbEntry(quantity: HKQuantity(unit: .gram(), doubleValue: 10), startDate: Date(), foodType: "Add", absorptionTime: .hours(3), syncIdentifier: syncIdentifier)
+        let addCarbEntry = NewCarbEntry(quantity: HKQuantity(unit: .gram(), doubleValue: 10), startDate: Date(), foodType: "Add", absorptionTime: .hours(3))
         let addCarbEntryCompletion = expectation(description: "Add carb entry completion")
         let addCarbEntryHandler = expectation(description: "Add carb entry handler")
         
@@ -74,9 +73,8 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                     XCTAssertEqual(objects[0].foodType, addCarbEntry.foodType)
                     XCTAssertEqual(objects[0].grams, addCarbEntry.quantity.doubleValue(for: .gram()))
                     XCTAssertEqual(objects[0].startDate, addCarbEntry.startDate)
-                    XCTAssertEqual(objects[0].uploadState, .notUploaded)
                     XCTAssertNotNil(objects[0].uuid)
-                    XCTAssertEqual(objects[0].syncIdentifier, syncIdentifier)
+                    XCTAssertNotNil(objects[0].syncIdentifier)
                     XCTAssertEqual(objects[0].syncVersion, 1)
                     XCTAssertGreaterThan(objects[0].modificationCounter, 0)
                 default:
@@ -93,8 +91,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
     }
     
     func testAddAndReplaceCarbEntry() {
-        let syncIdentifier = generateSyncIdentifier()
-        let addCarbEntry = NewCarbEntry(quantity: HKQuantity(unit: .gram(), doubleValue: 10), startDate: Date(), foodType: "Add", absorptionTime: .hours(3), syncIdentifier: syncIdentifier)
+        let addCarbEntry = NewCarbEntry(quantity: HKQuantity(unit: .gram(), doubleValue: 10), startDate: Date(), foodType: "Add", absorptionTime: .hours(3))
         let replaceCarbEntry = NewCarbEntry(quantity: HKQuantity(unit: .gram(), doubleValue: 15), startDate: Date(), foodType: "Replace", absorptionTime: .hours(4))
         let addCarbEntryCompletion = expectation(description: "Add carb entry completion")
         let addCarbEntryHandler = expectation(description: "Add carb entry handler")
@@ -104,6 +101,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
         var handlerInvocation = 0
         
         var lastUUID: UUID?
+        var lastSyncIdentifier: String?
         var lastModificationCounter: Int64?
         
         carbStoreHasUpdatedCarbDataHandler = { (carbStore) in
@@ -121,12 +119,12 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                     XCTAssertEqual(objects[0].foodType, addCarbEntry.foodType)
                     XCTAssertEqual(objects[0].grams, addCarbEntry.quantity.doubleValue(for: .gram()))
                     XCTAssertEqual(objects[0].startDate, addCarbEntry.startDate)
-                    XCTAssertEqual(objects[0].uploadState, .notUploaded)
                     XCTAssertNotNil(objects[0].uuid)
-                    XCTAssertEqual(objects[0].syncIdentifier, syncIdentifier)
+                    XCTAssertNotNil(objects[0].syncIdentifier)
                     XCTAssertEqual(objects[0].syncVersion, 1)
                     XCTAssertGreaterThan(objects[0].modificationCounter, 0)
                     lastUUID = objects[0].uuid
+                    lastSyncIdentifier = objects[0].syncIdentifier
                     lastModificationCounter = objects[0].modificationCounter
                     self.carbStore.replaceCarbEntry(StoredCarbEntry(managedObject: objects[0]), withEntry: replaceCarbEntry) { (result) in
                         replaceCarbEntryCompletion.fulfill()
@@ -141,10 +139,9 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                     XCTAssertEqual(objects[0].foodType, replaceCarbEntry.foodType)
                     XCTAssertEqual(objects[0].grams, replaceCarbEntry.quantity.doubleValue(for: .gram()))
                     XCTAssertEqual(objects[0].startDate, replaceCarbEntry.startDate)
-                    XCTAssertEqual(objects[0].uploadState, .notUploaded)
                     XCTAssertNotNil(objects[0].uuid)
                     XCTAssertNotEqual(objects[0].uuid!, lastUUID!)
-                    XCTAssertEqual(objects[0].syncIdentifier, syncIdentifier)
+                    XCTAssertEqual(objects[0].syncIdentifier, lastSyncIdentifier)
                     XCTAssertEqual(objects[0].syncVersion, 2)
                     XCTAssertGreaterThan(objects[0].modificationCounter, lastModificationCounter!)
                 default:
@@ -162,8 +159,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
     }
     
     func testAddAndDeleteCarbEntry() {
-        let syncIdentifier = generateSyncIdentifier()
-        let addCarbEntry = NewCarbEntry(quantity: HKQuantity(unit: .gram(), doubleValue: 10), startDate: Date(), foodType: "Add", absorptionTime: .hours(3), syncIdentifier: syncIdentifier)
+        let addCarbEntry = NewCarbEntry(quantity: HKQuantity(unit: .gram(), doubleValue: 10), startDate: Date(), foodType: "Add", absorptionTime: .hours(3))
         let addCarbEntryCompletion = expectation(description: "Add carb entry completion")
         let addCarbEntryHandler = expectation(description: "Add carb entry handler")
         let deleteCarbEntryCompletion = expectation(description: "Delete carb entry completion")
@@ -172,6 +168,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
         var handlerInvocation = 0
         
         var lastUUID: UUID?
+        var lastSyncIdentifier: String?
         var lastModificationCounter: Int64?
         
         carbStoreHasUpdatedCarbDataHandler = { (carbStore) in
@@ -189,12 +186,12 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                     XCTAssertEqual(objects[0].foodType, addCarbEntry.foodType)
                     XCTAssertEqual(objects[0].grams, addCarbEntry.quantity.doubleValue(for: .gram()))
                     XCTAssertEqual(objects[0].startDate, addCarbEntry.startDate)
-                    XCTAssertEqual(objects[0].uploadState, .notUploaded)
                     XCTAssertNotNil(objects[0].uuid)
-                    XCTAssertEqual(objects[0].syncIdentifier, syncIdentifier)
+                    XCTAssertNotNil(objects[0].syncIdentifier)
                     XCTAssertEqual(objects[0].syncVersion, 1)
                     XCTAssertGreaterThan(objects[0].modificationCounter, 0)
                     lastUUID = objects[0].uuid
+                    lastSyncIdentifier = objects[0].syncIdentifier
                     lastModificationCounter = objects[0].modificationCounter
                     self.carbStore.deleteCarbEntry(StoredCarbEntry(managedObject: objects[0])) { (result) in
                         deleteCarbEntryCompletion.fulfill()
@@ -204,11 +201,10 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                     let objects: [DeletedCarbObject] = self.cacheStore.managedObjectContext.all()
                     XCTAssertEqual(objects.count, 1)
                     XCTAssertNil(objects[0].externalID)
-                    XCTAssertEqual(objects[0].uploadState, .notUploaded)
                     XCTAssertEqual(objects[0].startDate, addCarbEntry.startDate)
                     XCTAssertNotNil(objects[0].uuid)
                     XCTAssertEqual(objects[0].uuid!, lastUUID!)
-                    XCTAssertEqual(objects[0].syncIdentifier, syncIdentifier)
+                    XCTAssertEqual(objects[0].syncIdentifier, lastSyncIdentifier)
                     XCTAssertEqual(objects[0].syncVersion, 1)
                     XCTAssertGreaterThan(objects[0].modificationCounter, lastModificationCounter!)
                 default:
@@ -226,8 +222,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
     }
     
     func testAddAndReplaceAndDeleteCarbEntry() {
-        let syncIdentifier = generateSyncIdentifier()
-        let addCarbEntry = NewCarbEntry(quantity: HKQuantity(unit: .gram(), doubleValue: 10), startDate: Date(), foodType: "Add", absorptionTime: .hours(3), syncIdentifier: syncIdentifier)
+        let addCarbEntry = NewCarbEntry(quantity: HKQuantity(unit: .gram(), doubleValue: 10), startDate: Date(), foodType: "Add", absorptionTime: .hours(3))
         let replaceCarbEntry = NewCarbEntry(quantity: HKQuantity(unit: .gram(), doubleValue: 15), startDate: Date(), foodType: "Replace", absorptionTime: .hours(4))
         let addCarbEntryCompletion = expectation(description: "Add carb entry completion")
         let addCarbEntryHandler = expectation(description: "Add carb entry handler")
@@ -239,6 +234,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
         var handlerInvocation = 0
         
         var lastUUID: UUID?
+        var lastSyncIdentifier: String?
         var lastModificationCounter: Int64?
         
         carbStoreHasUpdatedCarbDataHandler = { (carbStore) in
@@ -256,12 +252,12 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                     XCTAssertEqual(objects[0].foodType, addCarbEntry.foodType)
                     XCTAssertEqual(objects[0].grams, addCarbEntry.quantity.doubleValue(for: .gram()))
                     XCTAssertEqual(objects[0].startDate, addCarbEntry.startDate)
-                    XCTAssertEqual(objects[0].uploadState, .notUploaded)
                     XCTAssertNotNil(objects[0].uuid)
-                    XCTAssertEqual(objects[0].syncIdentifier, syncIdentifier)
+                    XCTAssertNotNil(objects[0].syncIdentifier)
                     XCTAssertEqual(objects[0].syncVersion, 1)
                     XCTAssertGreaterThan(objects[0].modificationCounter, 0)
                     lastUUID = objects[0].uuid
+                    lastSyncIdentifier = objects[0].syncIdentifier
                     lastModificationCounter = objects[0].modificationCounter
                     self.carbStore.replaceCarbEntry(StoredCarbEntry(managedObject: objects[0]), withEntry: replaceCarbEntry) { (result) in
                         replaceCarbEntryCompletion.fulfill()
@@ -276,10 +272,9 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                     XCTAssertEqual(objects[0].foodType, replaceCarbEntry.foodType)
                     XCTAssertEqual(objects[0].grams, replaceCarbEntry.quantity.doubleValue(for: .gram()))
                     XCTAssertEqual(objects[0].startDate, replaceCarbEntry.startDate)
-                    XCTAssertEqual(objects[0].uploadState, .notUploaded)
                     XCTAssertNotNil(objects[0].uuid)
                     XCTAssertNotEqual(objects[0].uuid!, lastUUID!)
-                    XCTAssertEqual(objects[0].syncIdentifier, syncIdentifier)
+                    XCTAssertEqual(objects[0].syncIdentifier, lastSyncIdentifier)
                     XCTAssertEqual(objects[0].syncVersion, 2)
                     XCTAssertGreaterThan(objects[0].modificationCounter, lastModificationCounter!)
                     lastUUID = objects[0].uuid
@@ -292,11 +287,10 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                     let objects: [DeletedCarbObject] = self.cacheStore.managedObjectContext.all()
                     XCTAssertEqual(objects.count, 1)
                     XCTAssertNil(objects[0].externalID)
-                    XCTAssertEqual(objects[0].uploadState, .notUploaded)
                     XCTAssertEqual(objects[0].startDate, replaceCarbEntry.startDate)
                     XCTAssertNotNil(objects[0].uuid)
                     XCTAssertEqual(objects[0].uuid!, lastUUID!)
-                    XCTAssertEqual(objects[0].syncIdentifier, syncIdentifier)
+                    XCTAssertEqual(objects[0].syncIdentifier, lastSyncIdentifier)
                     XCTAssertEqual(objects[0].syncVersion, 2)
                     XCTAssertGreaterThan(objects[0].modificationCounter, lastModificationCounter!)
                 default:

--- a/LoopKitTests/Persistence/DeletedCarbObjectTests.swift
+++ b/LoopKitTests/Persistence/DeletedCarbObjectTests.swift
@@ -53,7 +53,6 @@ class DeletedCarbObjectTests: PersistenceControllerTestCase {
 extension DeletedCarbObject {
     fileprivate func setDefaultValues() {
         externalID = UUID().uuidString
-        uploadState = .notUploaded
         startDate = Date()
     }
 }

--- a/LoopKitUI/CarbKit/CarbEntryEditViewController.swift
+++ b/LoopKitUI/CarbKit/CarbEntryEditViewController.swift
@@ -80,8 +80,7 @@ public final class CarbEntryEditViewController: UITableViewController {
                 quantity: quantity,
                 startDate: date,
                 foodType: foodType,
-                absorptionTime: absorptionTime,
-                externalID: originalCarbEntry?.externalID
+                absorptionTime: absorptionTime
             )
         } else {
             return nil

--- a/LoopKitUI/CarbKit/CarbEntryTableViewController.swift
+++ b/LoopKitUI/CarbKit/CarbEntryTableViewController.swift
@@ -251,8 +251,6 @@ public final class CarbEntryTableViewController: UITableViewController {
             }
 
             cell.detailTextLabel?.text = detailText
-
-            cell.accessoryType = entry.isUploaded ? .checkmark : .none
         }
         return cell
     }


### PR DESCRIPTION
- https://tidepool.atlassian.net/browse/LOOP-1417
- Remove unused uploadState from CachedCarbObject and DeletedCarbObject
- Remove unused isUploaded from StoredCarbEntry and DeletedCarbEntry
- Remove unused createdByCurrentApp, externalID, syncIdentifier, and isUploaded from NewCarbEntry