### PR TITLE
LOOP-1650: fix crash with two pickers scrolling in opposite directions at the same time

### DIFF
--- a/LoopKitUI/Views/GlucoseRangePicker.swift
+++ b/LoopKitUI/Views/GlucoseRangePicker.swift
@@ -39,11 +39,26 @@ public struct GlucoseRangePicker: View {
     ) {
         self._lowerBound = Binding(
             get: { range.wrappedValue.lowerBound },
-            set: { range.wrappedValue = $0...range.wrappedValue.upperBound }
+            set: {
+                if $0 > range.wrappedValue.upperBound {
+                    // Prevent crash if picker gets into state where "lower bound" > "upper bound"
+                    range.wrappedValue = $0...$0
+                }
+                range.wrappedValue = $0...range.wrappedValue.upperBound
+                
+        }
         )
         self._upperBound = Binding(
             get: { range.wrappedValue.upperBound },
-            set: { range.wrappedValue = range.wrappedValue.lowerBound...$0 }
+            set: {
+                if range.wrappedValue.lowerBound > $0 {
+                    // Prevent crash if picker gets into state where "lower bound" > "upper bound"
+                    range.wrappedValue = range.wrappedValue.lowerBound...range.wrappedValue.lowerBound
+                } else {
+                    range.wrappedValue = range.wrappedValue.lowerBound...$0
+                }
+                
+        }
         )
         self.unit = unit
         self.minValue = minValue


### PR DESCRIPTION
This error is occurring because the picker gets into a state where the “low” bound of the range is actually greater than the “high” bound of the range. I changed it so that if (and only if) the picker runs into this situation, it picks the higher of the two values (ex: if picker thinks it’s 110-106 mg/dL, it’ll change to be 110-110 mg/dL).

https://tidepool.atlassian.net/browse/LOOP-1650