### PR TITLE
LOOP-1717: Use Navigation Wrapped content in .settings mode 

### DIFF
--- a/LoopKitUI/Views/Information Screens/InformationView.swift
+++ b/LoopKitUI/Views/Information Screens/InformationView.swift
@@ -57,7 +57,7 @@ struct InformationView<InformationalContent: View> : View {
         switch mode {
         case .acceptanceFlow:
             return AnyView(bodyWithBottomButton)
-        case .settings, .legacySettings:
+        case .settings:
             return AnyView(bodyWithCancelButton)
         }
     }

--- a/LoopKitUI/Views/QuantityScheduleEditor.swift
+++ b/LoopKitUI/Views/QuantityScheduleEditor.swift
@@ -131,7 +131,7 @@ struct QuantityScheduleEditor<ActionAreaContent: View>: View {
     private var guardrailWarningIfNecessary: some View {
         let crossedThresholds = self.crossedThresholds
         return Group {
-            if !crossedThresholds.isEmpty && (userDidTap || mode == .settings || mode == .legacySettings) {
+            if !crossedThresholds.isEmpty && (userDidTap || mode == .settings) {
                 guardrailWarning(crossedThresholds)
             }
         }
@@ -167,7 +167,7 @@ extension QuantityScheduleEditor {
         confirmationAlertContent: AlertContent,
         @ViewBuilder guardrailWarning: @escaping (_ thresholds: [SafetyClassification.Threshold]) -> ActionAreaContent,
         onSave savingMechanism: SavingMechanism<DailyQuantitySchedule<Double>>,
-        mode: PresentationMode = .legacySettings,
+        mode: PresentationMode = .settings,
         settingType: TherapySetting = .none
     ) {
         self.title = title
@@ -200,7 +200,7 @@ extension QuantityScheduleEditor {
         confirmationAlertContent: AlertContent,
         @ViewBuilder guardrailWarning: @escaping (_ thresholds: [SafetyClassification.Threshold]) -> ActionAreaContent,
         onSave save: @escaping (DailyQuantitySchedule<Double>) -> Void,
-        mode: PresentationMode = .legacySettings,
+        mode: PresentationMode = .settings,
         settingType: TherapySetting = .none
     ) {
         let selectableValues = guardrail.allValues(stridingBy: selectableValueStride, unit: unit)

--- a/LoopKitUI/Views/ScheduleEditor.swift
+++ b/LoopKitUI/Views/ScheduleEditor.swift
@@ -88,7 +88,7 @@ struct ScheduleEditor<Value: Equatable, ValueContent: View, ValuePicker: View, A
         @ViewBuilder valuePicker: @escaping (_ item: Binding<RepeatingScheduleValue<Value>>, _ availableWidth: CGFloat) -> ValuePicker,
         @ViewBuilder actionAreaContent: () -> ActionAreaContent,
         savingMechanism: SavingMechanism<[RepeatingScheduleValue<Value>]>,
-        mode: PresentationMode = .legacySettings,
+        mode: PresentationMode = .settings,
         therapySettingType: TherapySetting = .none
     ) {
         self.title = title
@@ -140,25 +140,13 @@ struct ScheduleEditor<Value: Equatable, ValueContent: View, ValuePicker: View, A
     
     private var configurationPage: some View {
         switch mode {
-        case .legacySettings:
-            return AnyView(navigationPage)
         case .acceptanceFlow:
             return AnyView(page)
         case .settings:
             return AnyView(pageWithCancel)
         }
     }
-    
-    private var navigationPage: some View {
-        NavigationView {
-            page
-                .navigationBarItems(
-                    leading: cancelButton, // add in cancel button if modal
-                    trailing: trailingNavigationItems
-            )
-        }
-    }
-    
+        
     private var pageWithCancel: some View {
         switch saveButtonState {
         case .disabled, .loading:
@@ -369,7 +357,7 @@ struct ScheduleEditor<Value: Equatable, ValueContent: View, ValuePicker: View, A
     }
 
     private func startSaving() {
-        guard mode == .settings || mode == .legacySettings else {
+        guard mode == .settings else {
             self.continueSaving()
             return
         }
@@ -387,9 +375,6 @@ struct ScheduleEditor<Value: Equatable, ValueContent: View, ValuePicker: View, A
         switch savingMechanism {
         case .synchronous(let save):
             save(scheduleItems)
-            if mode == .legacySettings {
-                dismiss()
-            }
         case .asynchronous(let save):
             withAnimation {
                 self.editingIndex = nil
@@ -403,8 +388,6 @@ struct ScheduleEditor<Value: Equatable, ValueContent: View, ValuePicker: View, A
                             self.isSyncing = false
                         }
                         self.presentedAlert = .saveError(error)
-                    } else if self.mode == .legacySettings {
-                        self.dismiss()
                     }
                 }
             }

--- a/LoopKitUI/Views/Settings Editors/BasalRateScheduleEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/BasalRateScheduleEditor.swift
@@ -28,7 +28,7 @@ public struct BasalRateScheduleEditor: View {
         maximumScheduleEntryCount: Int,
         syncSchedule: PumpManager.SyncSchedule?,
         onSave save: @escaping (BasalRateSchedule) -> Void,
-        mode: PresentationMode = .legacySettings
+        mode: PresentationMode = .settings
     ) {
         self.schedule = schedule.map { schedule in
             DailyQuantitySchedule(
@@ -106,7 +106,7 @@ public struct BasalRateScheduleEditor: View {
     
     private var savingMechanism: SavingMechanism<DailyQuantitySchedule<Double>> {
         switch mode {
-        case .settings, .legacySettings:
+        case .settings:
             return .asynchronous { quantitySchedule, completion in
                 precondition(self.syncSchedule != nil)
                 self.syncSchedule?(quantitySchedule.items) { result in

--- a/LoopKitUI/Views/Settings Editors/CarbRatioScheduleEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CarbRatioScheduleEditor.swift
@@ -24,7 +24,7 @@ public struct CarbRatioScheduleEditor: View {
     public init(
         schedule: CarbRatioSchedule?,
         onSave save: @escaping (CarbRatioSchedule) -> Void,
-        mode: PresentationMode = .legacySettings
+        mode: PresentationMode = .settings
     ) {
         // CarbRatioSchedule stores only the gram unit.
         // For consistency across display & computation, convert to "real" g/U units.

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
@@ -44,7 +44,7 @@ public struct CorrectionRangeOverridesEditor: View {
         minValue: HKQuantity?,
         onSave save: @escaping (_ overrides: CorrectionRangeOverrides) -> Void,
         sensitivityOverridesEnabled: Bool,
-        mode: PresentationMode = .legacySettings
+        mode: PresentationMode = .settings
     ) {
         self._value = State(initialValue: value)
         self.initialValue = value
@@ -91,7 +91,6 @@ public struct CorrectionRangeOverridesEditor: View {
         switch mode {
         case .settings: return AnyView(contentWithCancel)
         case .acceptanceFlow: return AnyView(content)
-        case .legacySettings: return AnyView(content)
         }
     }
     
@@ -230,7 +229,7 @@ public struct CorrectionRangeOverridesEditor: View {
     private var guardrailWarningIfNecessary: some View {
         let crossedThresholds = self.crossedThresholds
         return Group {
-            if !crossedThresholds.isEmpty && (userDidTap || mode == .settings || mode == .legacySettings) {
+            if !crossedThresholds.isEmpty && (userDidTap || mode == .settings) {
                 CorrectionRangeOverridesGuardrailWarning(crossedThresholds: crossedThresholds)
             }
         }
@@ -268,7 +267,7 @@ public struct CorrectionRangeOverridesEditor: View {
     }
     
     private func startSaving() {
-        guard mode == .settings || mode == .legacySettings else {
+        guard mode == .settings else {
             self.continueSaving()
             return
         }
@@ -282,9 +281,6 @@ public struct CorrectionRangeOverridesEditor: View {
     
     private func continueSaving() {
         self.save(self.value)
-        if self.mode == .legacySettings {
-            self.dismiss()
-        }
     }
 
     private func accessibilityIdentifier(for preset: CorrectionRangeOverrides.Preset) -> String {

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeScheduleEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeScheduleEditor.swift
@@ -26,7 +26,7 @@ public struct CorrectionRangeScheduleEditor: View {
         unit: HKUnit,
         minValue: HKQuantity?,
         onSave save: @escaping (GlucoseRangeSchedule) -> Void,
-        mode: PresentationMode = .legacySettings
+        mode: PresentationMode = .settings
     ) {
         self.initialSchedule = schedule
         self._scheduleItems = State(initialValue: schedule?.items ?? [])
@@ -139,7 +139,7 @@ public struct CorrectionRangeScheduleEditor: View {
     var guardrailWarningIfNecessary: some View {
         let crossedThresholds = self.crossedThresholds
         return Group {
-            if !crossedThresholds.isEmpty && (userDidTap || mode == .settings || mode == .legacySettings) {
+            if !crossedThresholds.isEmpty && (userDidTap || mode == .settings) {
                 CorrectionRangeGuardrailWarning(crossedThresholds: crossedThresholds)
             }
         }

--- a/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
@@ -34,7 +34,7 @@ public struct DeliveryLimitsEditor: View {
         scheduledBasalRange: ClosedRange<Double>?,
         supportedBolusVolumes: [Double],
         onSave save: @escaping (_ deliveryLimits: DeliveryLimits) -> Void,
-        mode: PresentationMode = .legacySettings
+        mode: PresentationMode = .settings
     ) {
         self._value = State(initialValue: value)
         self.initialValue = value
@@ -75,7 +75,6 @@ public struct DeliveryLimitsEditor: View {
         switch mode {
         case .settings: return AnyView(contentWithCancel)
         case .acceptanceFlow: return AnyView(content)
-        case .legacySettings: return AnyView(content)
         }
     }
     
@@ -256,7 +255,7 @@ public struct DeliveryLimitsEditor: View {
     private var guardrailWarningIfNecessary: some View {
         let crossedThresholds = self.crossedThresholds
         return Group {
-            if !crossedThresholds.isEmpty && (userDidTap || mode == .settings || mode == .legacySettings) {
+            if !crossedThresholds.isEmpty && (userDidTap || mode == .settings) {
                 DeliveryLimitsGuardrailWarning(crossedThresholds: crossedThresholds)
             }
         }
@@ -295,7 +294,7 @@ public struct DeliveryLimitsEditor: View {
     }
 
     private func startSaving() {
-        guard mode == .settings || mode == .legacySettings else {
+        guard mode == .settings else {
             self.continueSaving()
             return
         }
@@ -309,9 +308,6 @@ public struct DeliveryLimitsEditor: View {
     
     private func continueSaving() {
         self.save(self.value)
-        if self.mode == .legacySettings {
-            self.dismiss()
-        }
     }
 }
 

--- a/LoopKitUI/Views/Settings Editors/InsulinModelSelection.swift
+++ b/LoopKitUI/Views/Settings Editors/InsulinModelSelection.swift
@@ -104,7 +104,6 @@ public struct InsulinModelSelection: View, HorizontalSizeClassOverride {
         switch mode {
         case .acceptanceFlow: return AnyView(content)
         case .settings: return AnyView(contentWithCancel)
-        case .legacySettings: return AnyView(navigationContent)
         }
     }
     
@@ -124,13 +123,6 @@ public struct InsulinModelSelection: View, HorizontalSizeClassOverride {
     
     private var cancelButton: some View {
         Button(action: { self.dismiss() } ) { Text("Cancel", comment: "Cancel editing settings button title") }
-    }
-
-    private var navigationContent: some View {
-        NavigationView {
-            content
-                .navigationBarItems(leading: dismissButton)
-        }
     }
     
     private var content: some View {
@@ -296,7 +288,7 @@ public struct InsulinModelSelection: View, HorizontalSizeClassOverride {
     }
     
     private func startSaving() {
-        guard mode == .settings || mode == .legacySettings else {
+        guard mode == .settings else {
             self.continueSaving()
             return
         }
@@ -310,9 +302,6 @@ public struct InsulinModelSelection: View, HorizontalSizeClassOverride {
     
     private func continueSaving() {
         self.save(self.value)
-        if self.mode == .legacySettings {
-            self.dismiss()
-        }
     }
 
     var dismissButton: some View {

--- a/LoopKitUI/Views/Settings Editors/InsulinSensitivityScheduleEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/InsulinSensitivityScheduleEditor.swift
@@ -19,7 +19,7 @@ public struct InsulinSensitivityScheduleEditor: View {
 
     public init(
         schedule: InsulinSensitivitySchedule?,
-        mode: PresentationMode = .legacySettings,
+        mode: PresentationMode = .settings,
         glucoseUnit: HKUnit,
         onSave save: @escaping (InsulinSensitivitySchedule) -> Void
     ) {

--- a/LoopKitUI/Views/Settings Editors/PresentationMode.swift
+++ b/LoopKitUI/Views/Settings Editors/PresentationMode.swift
@@ -12,8 +12,6 @@ public enum PresentationMode {
     case acceptanceFlow
     /// Presentation is under the settings ("gear icon") screen
     case settings
-    /// Presentation is under the old UIKit (legacy) settings screen
-    case legacySettings
 }
 
 extension PresentationMode {
@@ -22,7 +20,7 @@ extension PresentationMode {
         switch self {
         case .acceptanceFlow:
             return LocalizedString("Confirm Setting", comment: "The button text for confirming the setting")
-        case .settings, .legacySettings:
+        case .settings:
             return LocalizedString("Save", comment: "The button text for saving on a configuration page")
         }
     }

--- a/LoopKitUI/Views/Settings Editors/SuspendThresholdEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/SuspendThresholdEditor.swift
@@ -32,7 +32,7 @@ public struct SuspendThresholdEditor: View {
         unit: HKUnit,
         maxValue: HKQuantity?,
         onSave save: @escaping (_ suspendThreshold: HKQuantity) -> Void,
-        mode: PresentationMode = .legacySettings
+        mode: PresentationMode = .settings
     ) {
         self._value = State(initialValue: value ?? Self.defaultValue(for: unit))
         self.initialValue = value
@@ -81,7 +81,6 @@ public struct SuspendThresholdEditor: View {
         switch mode {
         case .settings: return AnyView(contentWithCancel)
         case .acceptanceFlow: return AnyView(content)
-        case .legacySettings: return AnyView(content)
         }
     }
     
@@ -209,7 +208,7 @@ public struct SuspendThresholdEditor: View {
     }
     
     private func startSaving() {
-        guard mode == .settings || mode == .legacySettings else {
+        guard mode == .settings else {
             self.continueSaving()
             return
         }
@@ -223,9 +222,6 @@ public struct SuspendThresholdEditor: View {
     
     private func continueSaving() {
         self.save(self.value)
-        if self.mode == .legacySettings {
-            self.dismiss()
-        }
     }
 }
 

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -38,7 +38,6 @@ public struct TherapySettingsView: View, HorizontalSizeClassOverride {
         switch viewModel.mode {
         case .acceptanceFlow: return AnyView(content)
         case .settings: return AnyView(navigationViewWrappedContent)
-        case .legacySettings: return AnyView(navigationViewWrappedContent)
         }
     }
     
@@ -557,7 +556,7 @@ public struct TherapySettingsView_Previews: PreviewProvider {
                 .colorScheme(.dark)
                 .previewDevice(PreviewDevice(rawValue: "iPhone XS Max"))
                 .previewDisplayName("XS Max dark (settings)")
-            TherapySettingsView(viewModel: TherapySettingsViewModel(mode: .legacySettings,
+            TherapySettingsView(viewModel: TherapySettingsViewModel(mode: .settings,
                                                                     therapySettings: TherapySettings(),
                                                                     chartColors: ChartColorPalette(axisLine: .clear,
                                                                                                    axisLabel: .secondaryLabel,

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -34,7 +34,6 @@ public struct TherapySettingsView: View, HorizontalSizeClassOverride {
     }
         
     public var body: some View {
-        // TODO: simplify this once 'legacy settings' are factored out
         switch viewModel.mode {
         case .acceptanceFlow: return AnyView(content)
         case .settings: return AnyView(navigationViewWrappedContent)

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -12,6 +12,8 @@ import LoopKit
 import SwiftUI
 
 public struct TherapySettingsView: View, HorizontalSizeClassOverride {
+    @Environment(\.dismiss) var dismiss
+
     public struct ActionButton {
         public init(localizedString: String, action: @escaping () -> Void) {
             self.localizedString = localizedString
@@ -21,8 +23,6 @@ public struct TherapySettingsView: View, HorizontalSizeClassOverride {
         let action: () -> Void
     }
     
-    @Environment(\.dismiss) var dismiss
-   
     @ObservedObject var viewModel: TherapySettingsViewModel
         
     private let actionButton: ActionButton?
@@ -37,7 +37,7 @@ public struct TherapySettingsView: View, HorizontalSizeClassOverride {
         // TODO: simplify this once 'legacy settings' are factored out
         switch viewModel.mode {
         case .acceptanceFlow: return AnyView(content)
-        case .settings: return AnyView(content)
+        case .settings: return AnyView(navigationViewWrappedContent)
         case .legacySettings: return AnyView(navigationViewWrappedContent)
         }
     }
@@ -77,6 +77,15 @@ public struct TherapySettingsView: View, HorizontalSizeClassOverride {
     private var navigationViewWrappedContent: some View {
         NavigationView {
             content
+                .navigationBarItems(trailing: dismissButton)
+        }
+    }
+    
+    private var dismissButton: some View {
+        Button(action: {
+            self.dismiss()
+        }) {
+            Text("Done").bold()
         }
     }
     


### PR DESCRIPTION
Because we needed to be consistent with how the device settings navigate, this makes TherapySettings (in .settings mode) have its own NavigationView

also remove .legacySettings

[LOOP-1717](https://tidepool.atlassian.net/browse/LOOP-1717)
