### PR TITLE
Synchronize carb data into HealthKit

### DIFF
--- a/LoopKit Example/Managers/DeviceDataManager.swift
+++ b/LoopKit Example/Managers/DeviceDataManager.swift
@@ -24,7 +24,8 @@ class DeviceDataManager : CarbStoreDelegate {
             defaultAbsorptionTimes: (fast: .minutes(30), medium: .hours(3), slow: .hours(5)),
             observationInterval: .hours(24),
             carbRatioSchedule: carbRatioSchedule,
-            insulinSensitivitySchedule: insulinSensitivitySchedule
+            insulinSensitivitySchedule: insulinSensitivitySchedule,
+            provenanceIdentifier: HKSource.default().bundleIdentifier
         )
         let insulinModel: WalshInsulinModel?
         if let actionDuration = insulinActionDuration {

--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -558,6 +558,7 @@
 		A971C8A023C69E0F0099BEFC /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434FB64B1D712449007B9C70 /* NSData.swift */; };
 		A971C8A223C6B17D0099BEFC /* SettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A971C8A123C6B17D0099BEFC /* SettingsStoreTests.swift */; };
 		A971C8A423C6B1890099BEFC /* DosingDecisionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A971C8A323C6B1890099BEFC /* DosingDecisionStoreTests.swift */; };
+		A975BE8E24FEEE5700FE7B35 /* CarbStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 437AFF192039F149008C4892 /* CarbStoreTests.swift */; };
 		A991161423426A0A00A4B2E9 /* ServiceSetupNotifying.swift in Sources */ = {isa = PBXBuildFile; fileRef = A991161323426A0A00A4B2E9 /* ServiceSetupNotifying.swift */; };
 		A99C7373233990D400C80963 /* TempBasalRecommendationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A99C7372233990D400C80963 /* TempBasalRecommendationTests.swift */; };
 		A99C7375233993FE00C80963 /* DiagnosticLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A99C7374233993FE00C80963 /* DiagnosticLogTests.swift */; };
@@ -671,7 +672,6 @@
 		A9E675F5227140DD00E25293 /* HealthKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9E675F4227140DD00E25293 /* HealthKit.framework */; };
 		A9FD046F24E310D00040F203 /* HKObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9FD046E24E310D00040F203 /* HKObject.swift */; };
 		A9FD047024E310DD0040F203 /* HKObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9FD046E24E310D00040F203 /* HKObject.swift */; };
-		A9FD047424E319EA0040F203 /* CarbStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 437AFF192039F149008C4892 /* CarbStoreTests.swift */; };
 		B4102D3224ABB068005D460B /* DeviceLifecycleProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4102D3124ABB068005D460B /* DeviceLifecycleProgress.swift */; };
 		B4102D3324ABB0D8005D460B /* DeviceLifecycleProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4102D3124ABB068005D460B /* DeviceLifecycleProgress.swift */; };
 		B41A60AF23D1DB5B00636320 /* TableViewTitleLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41A60AE23D1DB5B00636320 /* TableViewTitleLabel.swift */; };
@@ -3174,7 +3174,6 @@
 				C1A3F5BE24AA6EE200329152 /* NSTimeInterval.swift in Sources */,
 				A9E1E6AE24E1D8860073CA39 /* NSManagedObjectContext.swift in Sources */,
 				1DEE229724A676A300693C32 /* DoseStoreHKFilterTests.swift in Sources */,
-				A9FD047424E319EA0040F203 /* CarbStoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3593,6 +3592,7 @@
 				43D8FDDB1C728FDF0073BE78 /* LoopKitTests.swift in Sources */,
 				8974AFC022120D7A0043F01B /* TemporaryScheduleOverrideTests.swift in Sources */,
 				437AFF1D203A45DB008C4892 /* CacheStore.swift in Sources */,
+				A975BE8E24FEEE5700FE7B35 /* CarbStoreTests.swift in Sources */,
 				891A3FD12249948A00378B27 /* TemporaryScheduleOverrideHistoryTests.swift in Sources */,
 				A9BFA03E245CCCB9001E4AE3 /* DailyQuantityScheduleTests.swift in Sources */,
 				A99C73772339A67A00C80963 /* GlucoseThresholdTests.swift in Sources */,

--- a/LoopKit/CarbKit/CachedCarbObject+CoreDataClass.swift
+++ b/LoopKit/CarbKit/CachedCarbObject+CoreDataClass.swift
@@ -222,7 +222,7 @@ extension CachedCarbObject {
 // MARK: - HealthKit Synchronization
 
 extension CachedCarbObject {
-    func createSample() -> HKQuantitySample? {
+    func createSample() -> HKQuantitySample {
         var metadata = [String: Any]()
 
         metadata[HKMetadataKeyFoodType] = foodType

--- a/LoopKit/CarbKit/CarbStore.swift
+++ b/LoopKit/CarbKit/CarbStore.swift
@@ -179,6 +179,7 @@ public final class CarbStore: HealthKitSampleStore {
     
     var settings = CarbModelSettings(absorptionModel: PiecewiseLinearAbsorption(), initialAbsorptionTimeOverrun: 1.5, adaptiveAbsorptionRateEnabled: false)
 
+    private let provenanceIdentifier: String
 
     /**
      Initializes a new instance of the store.
@@ -199,7 +200,8 @@ public final class CarbStore: HealthKitSampleStore {
         absorptionTimeOverrun: Double = 1.5,
         calculationDelta: TimeInterval = 5 /* minutes */ * 60,
         effectDelay: TimeInterval = 10 /* minutes */ * 60,
-        carbAbsorptionModel: CarbAbsorptionModel = .nonlinear
+        carbAbsorptionModel: CarbAbsorptionModel = .nonlinear,
+        provenanceIdentifier: String
     ) {
         self.cacheStore = cacheStore
         self.defaultAbsorptionTimes = defaultAbsorptionTimes
@@ -213,6 +215,7 @@ public final class CarbStore: HealthKitSampleStore {
         self.cacheLength = cacheLength
         self.observationInterval = observationInterval
         self.carbAbsorptionModel = carbAbsorptionModel
+        self.provenanceIdentifier = provenanceIdentifier
         
         let observationEnabled = observationInterval > 0
 
@@ -438,7 +441,7 @@ extension CarbStore {
 
                     let newObject = CachedCarbObject(context: self.cacheStore.managedObjectContext)
                     newObject.create(from: newEntry,
-                                     provenanceIdentifier: HKSource.default().bundleIdentifier,
+                                     provenanceIdentifier: self.provenanceIdentifier,
                                      syncIdentifier: syncIdentifier,
                                      syncVersion: self.syncVersion)
 
@@ -1264,7 +1267,7 @@ extension CarbStore {
                         let object = CachedCarbObject(context: self.cacheStore.managedObjectContext)
                         object.create(from: entry,
                                       on: date,
-                                      provenanceIdentifier: HKSource.default().bundleIdentifier,
+                                      provenanceIdentifier: self.provenanceIdentifier,
                                       syncIdentifier: syncIdentifier)
                     }
                     error = self.cacheStore.save()

--- a/LoopKitTests/CarbStoreTests.swift
+++ b/LoopKitTests/CarbStoreTests.swift
@@ -24,7 +24,8 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
             cacheStore: cacheStore,
             cacheLength: .hours(24),
             defaultAbsorptionTimes: (fast: .minutes(30), medium: .hours(3), slow: .hours(5)),
-            observationInterval: 0)
+            observationInterval: 0,
+            provenanceIdentifier: Bundle.main.bundleIdentifier!)
         carbStore.testQueryStore = healthStore
         carbStore.delegate = self
     }
@@ -100,7 +101,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                     XCTAssertEqual(objects[0].grams, addCarbEntry.quantity.doubleValue(for: .gram()))
                     XCTAssertEqual(objects[0].startDate, addCarbEntry.startDate)
                     XCTAssertEqual(objects[0].uuid, addUUID)
-                    XCTAssertEqual(objects[0].provenanceIdentifier, HKSource.default().bundleIdentifier)
+                    XCTAssertEqual(objects[0].provenanceIdentifier, Bundle.main.bundleIdentifier!)
                     XCTAssertEqual(objects[0].syncIdentifier, addSyncIdentifier)
                     XCTAssertEqual(objects[0].syncVersion, 1)
                     XCTAssertEqual(objects[0].userCreatedDate, addCarbEntry.date)
@@ -122,7 +123,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
 
                                 // Added sample
                                 XCTAssertEqual(entries[0].uuid, addUUID)
-                                XCTAssertEqual(entries[0].provenanceIdentifier, HKSource.default().bundleIdentifier)
+                                XCTAssertEqual(entries[0].provenanceIdentifier, Bundle.main.bundleIdentifier!)
                                 XCTAssertEqual(entries[0].syncIdentifier, addSyncIdentifier)
                                 XCTAssertEqual(entries[0].syncVersion, 1)
                                 XCTAssertEqual(entries[0].startDate, addCarbEntry.startDate)
@@ -203,7 +204,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                     XCTAssertEqual(objects[0].grams, addCarbEntry.quantity.doubleValue(for: .gram()))
                     XCTAssertEqual(objects[0].startDate, addCarbEntry.startDate)
                     XCTAssertEqual(objects[0].uuid, addUUID)
-                    XCTAssertEqual(objects[0].provenanceIdentifier, HKSource.default().bundleIdentifier)
+                    XCTAssertEqual(objects[0].provenanceIdentifier, Bundle.main.bundleIdentifier!)
                     XCTAssertEqual(objects[0].syncIdentifier, addSyncIdentifier)
                     XCTAssertEqual(objects[0].syncVersion, 1)
                     XCTAssertEqual(objects[0].userCreatedDate, addCarbEntry.date)
@@ -251,7 +252,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                     XCTAssertEqual(objects[0].grams, addCarbEntry.quantity.doubleValue(for: .gram()))
                     XCTAssertEqual(objects[0].startDate, addCarbEntry.startDate)
                     XCTAssertEqual(objects[0].uuid, addUUID)
-                    XCTAssertEqual(objects[0].provenanceIdentifier, HKSource.default().bundleIdentifier)
+                    XCTAssertEqual(objects[0].provenanceIdentifier, Bundle.main.bundleIdentifier!)
                     XCTAssertEqual(objects[0].syncIdentifier, addSyncIdentifier)
                     XCTAssertEqual(objects[0].syncVersion, 1)
                     XCTAssertEqual(objects[0].userCreatedDate, addCarbEntry.date)
@@ -269,7 +270,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                     XCTAssertEqual(objects[1].grams, replaceCarbEntry.quantity.doubleValue(for: .gram()))
                     XCTAssertEqual(objects[1].startDate, replaceCarbEntry.startDate)
                     XCTAssertEqual(objects[1].uuid, updateUUID)
-                    XCTAssertEqual(objects[1].provenanceIdentifier, HKSource.default().bundleIdentifier)
+                    XCTAssertEqual(objects[1].provenanceIdentifier, Bundle.main.bundleIdentifier!)
                     XCTAssertEqual(objects[1].syncIdentifier, addSyncIdentifier)
                     XCTAssertEqual(objects[1].syncVersion, 2)
                     XCTAssertEqual(objects[1].userCreatedDate, addCarbEntry.date)
@@ -291,7 +292,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
 
                                 // Updated sample
                                 XCTAssertEqual(entries[0].uuid, updateUUID)
-                                XCTAssertEqual(entries[0].provenanceIdentifier, HKSource.default().bundleIdentifier)
+                                XCTAssertEqual(entries[0].provenanceIdentifier, Bundle.main.bundleIdentifier!)
                                 XCTAssertEqual(entries[0].syncIdentifier, addSyncIdentifier)
                                 XCTAssertEqual(entries[0].syncVersion, 2)
                                 XCTAssertEqual(entries[0].startDate, replaceCarbEntry.startDate)
@@ -370,7 +371,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                     XCTAssertEqual(objects[0].grams, addCarbEntry.quantity.doubleValue(for: .gram()))
                     XCTAssertEqual(objects[0].startDate, addCarbEntry.startDate)
                     XCTAssertEqual(objects[0].uuid, addUUID)
-                    XCTAssertEqual(objects[0].provenanceIdentifier, HKSource.default().bundleIdentifier)
+                    XCTAssertEqual(objects[0].provenanceIdentifier, Bundle.main.bundleIdentifier!)
                     XCTAssertEqual(objects[0].syncIdentifier, addSyncIdentifier)
                     XCTAssertEqual(objects[0].syncVersion, 1)
                     XCTAssertEqual(objects[0].userCreatedDate, addCarbEntry.date)
@@ -407,7 +408,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                     XCTAssertEqual(objects[0].grams, addCarbEntry.quantity.doubleValue(for: .gram()))
                     XCTAssertEqual(objects[0].startDate, addCarbEntry.startDate)
                     XCTAssertEqual(objects[0].uuid, addUUID)
-                    XCTAssertEqual(objects[0].provenanceIdentifier, HKSource.default().bundleIdentifier)
+                    XCTAssertEqual(objects[0].provenanceIdentifier, Bundle.main.bundleIdentifier!)
                     XCTAssertEqual(objects[0].syncIdentifier, addSyncIdentifier)
                     XCTAssertEqual(objects[0].syncVersion, 1)
                     XCTAssertEqual(objects[0].userCreatedDate, addCarbEntry.date)
@@ -425,7 +426,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                     XCTAssertEqual(objects[1].grams, addCarbEntry.quantity.doubleValue(for: .gram()))
                     XCTAssertEqual(objects[1].startDate, addCarbEntry.startDate)
                     XCTAssertNil(objects[1].uuid)
-                    XCTAssertEqual(objects[1].provenanceIdentifier, HKSource.default().bundleIdentifier)
+                    XCTAssertEqual(objects[1].provenanceIdentifier, Bundle.main.bundleIdentifier!)
                     XCTAssertEqual(objects[1].syncIdentifier, addSyncIdentifier)
                     XCTAssertEqual(objects[1].syncVersion, 1)
                     XCTAssertEqual(objects[1].userCreatedDate, addCarbEntry.date)
@@ -520,7 +521,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                     XCTAssertEqual(objects[0].grams, addCarbEntry.quantity.doubleValue(for: .gram()))
                     XCTAssertEqual(objects[0].startDate, addCarbEntry.startDate)
                     XCTAssertEqual(objects[0].uuid, addUUID)
-                    XCTAssertEqual(objects[0].provenanceIdentifier, HKSource.default().bundleIdentifier)
+                    XCTAssertEqual(objects[0].provenanceIdentifier, Bundle.main.bundleIdentifier!)
                     XCTAssertEqual(objects[0].syncIdentifier, addSyncIdentifier)
                     XCTAssertEqual(objects[0].syncVersion, 1)
                     XCTAssertEqual(objects[0].userCreatedDate, addCarbEntry.date)
@@ -568,7 +569,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                     XCTAssertEqual(objects[0].grams, addCarbEntry.quantity.doubleValue(for: .gram()))
                     XCTAssertEqual(objects[0].startDate, addCarbEntry.startDate)
                     XCTAssertEqual(objects[0].uuid, addUUID)
-                    XCTAssertEqual(objects[0].provenanceIdentifier, HKSource.default().bundleIdentifier)
+                    XCTAssertEqual(objects[0].provenanceIdentifier, Bundle.main.bundleIdentifier!)
                     XCTAssertEqual(objects[0].syncIdentifier, addSyncIdentifier)
                     XCTAssertEqual(objects[0].syncVersion, 1)
                     XCTAssertEqual(objects[0].userCreatedDate, addCarbEntry.date)
@@ -586,7 +587,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                     XCTAssertEqual(objects[1].grams, replaceCarbEntry.quantity.doubleValue(for: .gram()))
                     XCTAssertEqual(objects[1].startDate, replaceCarbEntry.startDate)
                     XCTAssertEqual(objects[1].uuid, updateUUID)
-                    XCTAssertEqual(objects[1].provenanceIdentifier, HKSource.default().bundleIdentifier)
+                    XCTAssertEqual(objects[1].provenanceIdentifier, Bundle.main.bundleIdentifier!)
                     XCTAssertEqual(objects[1].syncIdentifier, addSyncIdentifier)
                     XCTAssertEqual(objects[1].syncVersion, 2)
                     XCTAssertEqual(objects[1].userCreatedDate, addCarbEntry.date)
@@ -621,7 +622,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                     XCTAssertEqual(objects[0].grams, addCarbEntry.quantity.doubleValue(for: .gram()))
                     XCTAssertEqual(objects[0].startDate, addCarbEntry.startDate)
                     XCTAssertEqual(objects[0].uuid, addUUID)
-                    XCTAssertEqual(objects[0].provenanceIdentifier, HKSource.default().bundleIdentifier)
+                    XCTAssertEqual(objects[0].provenanceIdentifier, Bundle.main.bundleIdentifier!)
                     XCTAssertEqual(objects[0].syncIdentifier, addSyncIdentifier)
                     XCTAssertEqual(objects[0].syncVersion, 1)
                     XCTAssertEqual(objects[0].userCreatedDate, addCarbEntry.date)
@@ -639,7 +640,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                     XCTAssertEqual(objects[1].grams, replaceCarbEntry.quantity.doubleValue(for: .gram()))
                     XCTAssertEqual(objects[1].startDate, replaceCarbEntry.startDate)
                     XCTAssertEqual(objects[1].uuid, updateUUID)
-                    XCTAssertEqual(objects[1].provenanceIdentifier, HKSource.default().bundleIdentifier)
+                    XCTAssertEqual(objects[1].provenanceIdentifier, Bundle.main.bundleIdentifier!)
                     XCTAssertEqual(objects[1].syncIdentifier, addSyncIdentifier)
                     XCTAssertEqual(objects[1].syncVersion, 2)
                     XCTAssertEqual(objects[1].userCreatedDate, addCarbEntry.date)
@@ -657,7 +658,7 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                     XCTAssertEqual(objects[2].grams, replaceCarbEntry.quantity.doubleValue(for: .gram()))
                     XCTAssertEqual(objects[2].startDate, replaceCarbEntry.startDate)
                     XCTAssertNil(objects[2].uuid)
-                    XCTAssertEqual(objects[2].provenanceIdentifier, HKSource.default().bundleIdentifier)
+                    XCTAssertEqual(objects[2].provenanceIdentifier, Bundle.main.bundleIdentifier!)
                     XCTAssertEqual(objects[2].syncIdentifier, addSyncIdentifier)
                     XCTAssertEqual(objects[2].syncVersion, 2)
                     XCTAssertEqual(objects[2].userCreatedDate, addCarbEntry.date)
@@ -772,7 +773,8 @@ class CarbStoreQueryTests: PersistenceControllerTestCase {
             cacheStore: cacheStore,
             cacheLength: .hours(24),
             defaultAbsorptionTimes: (fast: .minutes(30), medium: .hours(3), slow: .hours(5)),
-            observationInterval: 0)
+            observationInterval: 0,
+            provenanceIdentifier: Bundle.main.bundleIdentifier!)
         completion = expectation(description: "Completion")
         queryAnchor = CarbStore.QueryAnchor()
         limit = Int.max

--- a/LoopKitTests/Extensions/HKHealthStoreMock.swift
+++ b/LoopKitTests/Extensions/HKHealthStoreMock.swift
@@ -17,8 +17,16 @@ class HKHealthStoreMock: HKHealthStore {
     var lastQuery: HKQuery?
 
     private var saveHandler: ((_ objects: [HKObject], _ success: Bool, _ error: Error?) -> Void)?
+    private var deleteObjectsHandler: ((_ objectType: HKObjectType, _ predicate: NSPredicate, _ success: Bool, _ count: Int, _ error: Error?) -> Void)?
 
     let queue = DispatchQueue(label: "HKHealthStoreMock")
+
+    override func save(_ object: HKObject, withCompletion completion: @escaping (Bool, Error?) -> Void) {
+        queue.async {
+            completion(self.saveError == nil, self.saveError)
+            self.saveHandler?([object], self.saveError == nil, self.saveError)
+        }
+    }
 
     override func save(_ objects: [HKObject], withCompletion completion: @escaping (Bool, Error?) -> Void) {
         queue.async {
@@ -36,12 +44,19 @@ class HKHealthStoreMock: HKHealthStore {
     override func deleteObjects(of objectType: HKObjectType, predicate: NSPredicate, withCompletion completion: @escaping (Bool, Int, Error?) -> Void) {
         queue.async {
             completion(self.deleteError == nil, 0, self.deleteError)
+            self.deleteObjectsHandler?(objectType, predicate, self.deleteError == nil, 0, self.deleteError)
         }
     }
 
     func setSaveHandler(_ saveHandler: ((_ objects: [HKObject], _ success: Bool, _ error: Error?) -> Void)?) {
         queue.sync {
             self.saveHandler = saveHandler
+        }
+    }
+
+    func setDeletedObjectsHandler(_ deleteObjectsHandler: ((_ objectType: HKObjectType, _ predicate: NSPredicate, _ success: Bool, _ count: Int, _ error: Error?) -> Void)?) {
+        queue.sync {
+            self.deleteObjectsHandler = deleteObjectsHandler
         }
     }
 }


### PR DESCRIPTION
Note: The next few PRs will be against the primary feature branch darinkrauss/LOOP-1417-capture-carbohydrate-entries.v2.ALL, not dev. My intention is to break the large overall feature into smaller, more easily reviewable PRs, and then merge the primary feature branch into dev after a final "summary" PR. (Several of the smaller PRs cannot be merged directly into dev because they would partially break existing functionality without a full replacement.)