### PR TITLE
Capture last user modification of new or updated carb data as user created or updated date

### DIFF
--- a/LoopKitTests/Extensions/HKHealthStoreMock.swift
+++ b/LoopKitTests/Extensions/HKHealthStoreMock.swift
@@ -23,15 +23,15 @@ class HKHealthStoreMock: HKHealthStore {
 
     override func save(_ object: HKObject, withCompletion completion: @escaping (Bool, Error?) -> Void) {
         queue.async {
-            completion(self.saveError == nil, self.saveError)
             self.saveHandler?([object], self.saveError == nil, self.saveError)
+            completion(self.saveError == nil, self.saveError)
         }
     }
 
     override func save(_ objects: [HKObject], withCompletion completion: @escaping (Bool, Error?) -> Void) {
         queue.async {
-            completion(self.saveError == nil, self.saveError)
             self.saveHandler?(objects, self.saveError == nil, self.saveError)
+            completion(self.saveError == nil, self.saveError)
         }
     }
 
@@ -43,8 +43,8 @@ class HKHealthStoreMock: HKHealthStore {
 
     override func deleteObjects(of objectType: HKObjectType, predicate: NSPredicate, withCompletion completion: @escaping (Bool, Int, Error?) -> Void) {
         queue.async {
-            completion(self.deleteError == nil, 0, self.deleteError)
             self.deleteObjectsHandler?(objectType, predicate, self.deleteError == nil, 0, self.deleteError)
+            completion(self.deleteError == nil, 0, self.deleteError)
         }
     }
 

--- a/LoopKitUI/CarbKit/CarbEntryEditViewController.swift
+++ b/LoopKitUI/CarbKit/CarbEntryEditViewController.swift
@@ -52,13 +52,41 @@ public final class CarbEntryEditViewController: UITableViewController {
         }
     }
 
-    fileprivate var quantity: HKQuantity?
+    fileprivate var lastEntryDate: Date?
 
-    fileprivate var date = Date()
+    fileprivate func updateLastEntryDate() { lastEntryDate = Date() }
 
-    fileprivate var foodType: String?
+    fileprivate var quantity: HKQuantity? {
+        didSet {
+            if quantity != oldValue {
+                updateLastEntryDate()
+            }
+        }
+    }
 
-    fileprivate var absorptionTime: TimeInterval?
+    fileprivate var date = Date() {
+        didSet {
+            if date != oldValue {
+                updateLastEntryDate()
+            }
+        }
+    }
+
+    fileprivate var foodType: String? {
+        didSet {
+            if foodType != oldValue {
+                updateLastEntryDate()
+            }
+        }
+    }
+
+    fileprivate var absorptionTime: TimeInterval? {
+        didSet {
+            if absorptionTime != oldValue {
+                updateLastEntryDate()
+            }
+        }
+    }
 
     fileprivate var absorptionTimeWasEdited = false
 
@@ -69,7 +97,8 @@ public final class CarbEntryEditViewController: UITableViewController {
     private var shouldBeginEditingFoodType = false
 
     public var updatedCarbEntry: NewCarbEntry? {
-        if  let quantity = quantity,
+        if  let lastEntryDate = lastEntryDate,
+            let quantity = quantity,
             let absorptionTime = absorptionTime ?? defaultAbsorptionTimes?.medium
         {
             if let o = originalCarbEntry, o.quantity == quantity && o.startDate == date && o.foodType == foodType && o.absorptionTime == absorptionTime {
@@ -77,6 +106,7 @@ public final class CarbEntryEditViewController: UITableViewController {
             }
             
             return NewCarbEntry(
+                date: lastEntryDate,
                 quantity: quantity,
                 startDate: date,
                 foodType: foodType,
@@ -254,6 +284,7 @@ public final class CarbEntryEditViewController: UITableViewController {
 
     public override func restoreUserActivityState(_ activity: NSUserActivity) {
         if let entry = activity.newCarbEntry {
+            lastEntryDate = entry.date
             quantity = entry.quantity
             date = entry.startDate
 
@@ -304,7 +335,7 @@ extension CarbEntryEditViewController: TextFieldTableViewCellDelegate {
         tableView.endUpdates()
     }
 
-    public func textFieldTableViewCellDidEndEditing(_ cell: TextFieldTableViewCell) {
+    public func textFieldTableViewCellDidChangeEditing(_ cell: TextFieldTableViewCell) {
         guard let row = tableView.indexPath(for: cell)?.row else { return }
 
         switch Row(rawValue: row) {
@@ -319,6 +350,10 @@ extension CarbEntryEditViewController: TextFieldTableViewCellDelegate {
         default:
             break
         }
+    }
+
+    public func textFieldTableViewCellDidEndEditing(_ cell: TextFieldTableViewCell) {
+        textFieldTableViewCellDidChangeEditing(cell)
     }
 }
 


### PR DESCRIPTION
- Capture lastEntryDate in various views
- Add lastEntryDate to NewCarbEntry

Note: The next few PRs will be against the primary feature branch darinkrauss/LOOP-1417-capture-carbohydrate-entries.v2.ALL, not dev. My intention is to break the large overall feature into smaller, more easily reviewable PRs, and then merge the primary feature branch into dev after a final "summary" PR. (Several of the smaller PRs cannot be merged directly into dev because they would partially break existing functionality without a full replacement.)