### PR TITLE
Final cleanup of carb updates

### DIFF
--- a/LoopKit/CarbKit/CachedCarbObject+CoreDataClass.swift
+++ b/LoopKit/CarbKit/CachedCarbObject+CoreDataClass.swift
@@ -51,13 +51,9 @@ class CachedCarbObject: NSManagedObject {
         }
     }
 
-    override func willSave() {
-        if isInserted {
-            if !changedValues().keys.contains("anchorKey") {
-                setPrimitiveValue(managedObjectContext!.anchorKey ?? 0, forKey: "anchorKey")
-            }
-        }
-        super.willSave()
+    override func awakeFromInsert() {
+        super.awakeFromInsert()
+        setPrimitiveValue(managedObjectContext!.anchorKey!, forKey: "anchorKey")
     }
 }
 

--- a/LoopKit/CarbKit/CarbStore.swift
+++ b/LoopKit/CarbKit/CarbStore.swift
@@ -730,7 +730,7 @@ extension CarbStore {
     /// Store carb objects in Watch extension
     public func setSyncCarbObjects(_ objects: [SyncCarbObject], completion: @escaping (CarbStoreError?) -> Void) {
         queue.async {
-            if let error = self.purgeAllCarbObjectsUnconditionally() {
+            if let error = self.purgeCarbObjectsUnconditionally() {
                 completion(error)
                 return
             }
@@ -770,18 +770,6 @@ extension CarbStore {
 
     private func purgeExpiredCarbObjects() {
         purgeCarbObjects(before: earliestCacheDate)
-    }
-
-    public func purgeCarbObjects(before date: Date, completion: @escaping (CarbStoreError?) -> Void) {
-        queue.async {
-            if let error = self.purgeCarbObjects(before: date) {
-                completion(error)
-                return
-            }
-
-            self.delegate?.carbStoreHasUpdatedCarbData(self)
-            completion(nil)
-        }
     }
 
     @discardableResult
@@ -858,22 +846,6 @@ extension CarbStore {
         }
 
         return error
-    }
-
-    public func purgeAllCarbObjectsUnconditionally(completion: @escaping (CarbStoreError?) -> Void) {
-        queue.async {
-            if let error = self.purgeAllCarbObjectsUnconditionally() {
-                completion(error)
-                return
-            }
-
-            self.delegate?.carbStoreHasUpdatedCarbData(self)
-            completion(nil)
-        }
-    }
-
-    private func purgeAllCarbObjectsUnconditionally() -> CarbStoreError? {
-        return purgeCarbObjectsUnconditionally()
     }
 
     private func notifyUpdatedCarbData(updateSource: UpdateSource) {

--- a/LoopKit/CarbKit/SyncCarbObject.swift
+++ b/LoopKit/CarbKit/SyncCarbObject.swift
@@ -15,7 +15,7 @@ public enum Operation: Int, CaseIterable, Codable {
     case delete
 }
 
-public struct SyncCarbObject: Codable {
+public struct SyncCarbObject: Codable, Equatable {
     public let absorptionTime: TimeInterval?
     public let createdByCurrentApp: Bool
     public let foodType: String?

--- a/LoopKit/DosingDecisionObject+CoreDataClass.swift
+++ b/LoopKit/DosingDecisionObject+CoreDataClass.swift
@@ -9,9 +9,18 @@
 import CoreData
 
 class DosingDecisionObject: NSManagedObject {
+    var hasUpdatedModificationCounter: Bool { changedValues().keys.contains("modificationCounter") }
+
+    func updateModificationCounter() { setPrimitiveValue(managedObjectContext!.modificationCounter!, forKey: "modificationCounter") }
+
+    override func awakeFromInsert() {
+        super.awakeFromInsert()
+        updateModificationCounter()
+    }
+
     override func willSave() {
-        if isInserted || isUpdated {
-            setPrimitiveValue(managedObjectContext!.modificationCounter ?? 0, forKey: "modificationCounter")
+        if isUpdated && !hasUpdatedModificationCounter {
+            updateModificationCounter()
         }
         super.willSave()
     }

--- a/LoopKit/DosingDecisionStore.swift
+++ b/LoopKit/DosingDecisionStore.swift
@@ -283,7 +283,7 @@ extension DosingDecisionStore {
                     object.date = dosingDecisionData.date
                     object.data = dosingDecisionData.data
                 }
-                self.store.save { error = $0 }
+                error = self.store.save()
             }
 
             guard error == nil else {

--- a/LoopKit/GlucoseKit/CachedGlucoseObject+CoreDataClass.swift
+++ b/LoopKit/GlucoseKit/CachedGlucoseObject+CoreDataClass.swift
@@ -38,9 +38,18 @@ class CachedGlucoseObject: NSManagedObject {
         }
     }
 
+    var hasUpdatedModificationCounter: Bool { changedValues().keys.contains("modificationCounter") }
+
+    func updateModificationCounter() { setPrimitiveValue(managedObjectContext!.modificationCounter!, forKey: "modificationCounter") }
+
+    override func awakeFromInsert() {
+        super.awakeFromInsert()
+        updateModificationCounter()
+    }
+
     override func willSave() {
-        if isInserted || isUpdated {
-            setPrimitiveValue(managedObjectContext!.modificationCounter ?? 0, forKey: "modificationCounter")
+        if isUpdated && !hasUpdatedModificationCounter {
+            updateModificationCounter()
         }
         super.willSave()
     }

--- a/LoopKit/GlucoseKit/GlucoseStore.swift
+++ b/LoopKit/GlucoseKit/GlucoseStore.swift
@@ -722,7 +722,7 @@ extension GlucoseStore {
                     let object = CachedGlucoseObject(context: self.cacheStore.managedObjectContext)
                     object.update(from: sample)
                 }
-                self.cacheStore.save { error = $0 }
+                error = self.cacheStore.save()
             }
 
             guard error == nil else {

--- a/LoopKit/GlucoseKit/StoredGlucoseSample.swift
+++ b/LoopKit/GlucoseKit/StoredGlucoseSample.swift
@@ -30,8 +30,8 @@ public struct StoredGlucoseSample: GlucoseSampleValue {
     public init(sample: HKQuantitySample) {
         self.init(
             sampleUUID: sample.uuid,
-            syncIdentifier: sample.metadata?[HKMetadataKeySyncIdentifier] as? String,
-            syncVersion: sample.metadata?[HKMetadataKeySyncVersion] as? Int ?? 1,
+            syncIdentifier: sample.syncIdentifier,
+            syncVersion: sample.syncVersion ?? 1,
             startDate: sample.startDate,
             quantity: sample.quantity,
             isDisplayOnly: sample.isDisplayOnly,

--- a/LoopKit/InsulinKit/CachedInsulinDeliveryObject+CoreDataClass.swift
+++ b/LoopKit/InsulinKit/CachedInsulinDeliveryObject+CoreDataClass.swift
@@ -147,7 +147,7 @@ extension CachedInsulinDeliveryObject {
         endDate = sample.endDate
         reason = sample.insulinDeliveryReason
         // External doses might not have a syncIdentifier, so use the UUID
-        syncIdentifier = sample.metadata?[HKMetadataKeySyncIdentifier] as? String ?? sample.uuid.uuidString
+        syncIdentifier = sample.syncIdentifier ?? sample.uuid.uuidString
         scheduledBasalRate = sample.scheduledBasalRate
         programmedTempBasalRate = sample.programmedTempBasalRate
         hasLoopKitOrigin = sample.hasLoopKitOrigin

--- a/LoopKit/InsulinKit/HKQuantitySample+InsulinKit.swift
+++ b/LoopKit/InsulinKit/HKQuantitySample+InsulinKit.swift
@@ -142,7 +142,7 @@ extension HKQuantitySample {
             unit: unit,
             deliveredUnits: deliveredUnits,
             description: nil,
-            syncIdentifier: metadata?[HKMetadataKeySyncIdentifier] as? String,
+            syncIdentifier: syncIdentifier,
             scheduledBasalRate: scheduledBasalRate
         )
     }

--- a/LoopKit/InsulinKit/PumpEvent+CoreDataClass.swift
+++ b/LoopKit/InsulinKit/PumpEvent+CoreDataClass.swift
@@ -103,15 +103,19 @@ class PumpEvent: NSManagedObject {
         }
     }
 
-    override func awakeFromInsert() {
-        super.awakeFromInsert()
+    var hasUpdatedModificationCounter: Bool { changedValues().keys.contains("modificationCounter") }
 
+    func updateModificationCounter() { setPrimitiveValue(managedObjectContext!.modificationCounter!, forKey: "modificationCounter") }
+
+    public override func awakeFromInsert() {
+        super.awakeFromInsert()
+        updateModificationCounter()
         createdAt = Date()
     }
 
-    override func willSave() {
-        if isInserted || isUpdated {
-            setPrimitiveValue(managedObjectContext!.modificationCounter ?? 0, forKey: "modificationCounter")
+    public override func willSave() {
+        if isUpdated && !hasUpdatedModificationCounter {
+            updateModificationCounter()
         }
         super.willSave()
     }

--- a/LoopKit/SettingsObject+CoreDataClass.swift
+++ b/LoopKit/SettingsObject+CoreDataClass.swift
@@ -9,9 +9,18 @@
 import CoreData
 
 class SettingsObject: NSManagedObject {
+    var hasUpdatedModificationCounter: Bool { changedValues().keys.contains("modificationCounter") }
+
+    func updateModificationCounter() { setPrimitiveValue(managedObjectContext!.modificationCounter!, forKey: "modificationCounter") }
+
+    override func awakeFromInsert() {
+        super.awakeFromInsert()
+        updateModificationCounter()
+    }
+
     override func willSave() {
-        if isInserted || isUpdated {
-            setPrimitiveValue(managedObjectContext!.modificationCounter ?? 0, forKey: "modificationCounter")
+        if isUpdated && !hasUpdatedModificationCounter {
+            updateModificationCounter()
         }
         super.willSave()
     }

--- a/LoopKit/SettingsStore.swift
+++ b/LoopKit/SettingsStore.swift
@@ -344,7 +344,7 @@ extension SettingsStore {
                     object.data = data
                     object.date = setting.date
                 }
-                self.store.save { error = $0 }
+                error = self.store.save()
             }
 
             guard error == nil else {


### PR DESCRIPTION
- Fix modification counter and anchor key based upon insert and update order
- Update HKHealthStoreMock
- Directly use store save error return value (rather than capturing in completion, it is a synchronous function)
- Use syncIdentifier and syncVersion helper functions on HKObject
- Directly use error returned from PersistenceController.save
- Use shortcuts on HKObject for sync identifier and version
- Remove unused CarbStore code
- Add tests for new carb related code

Note: The next few PRs will be against the primary feature branch darinkrauss/LOOP-1417-capture-carbohydrate-entries.v2.ALL, not dev. My intention is to break the large overall feature into smaller, more easily reviewable PRs, and then merge the primary feature branch into dev after a final "summary" PR. (Several of the smaller PRs cannot be merged directly into dev because they would partially break existing functionality without a full replacement.)