### PR TITLE
LOOP-1833: Add a completion block when fetch current pump data

### DIFF
--- a/LoopKit/DeviceManager/PumpManager.swift
+++ b/LoopKit/DeviceManager/PumpManager.swift
@@ -203,11 +203,5 @@ public extension PumpManager {
             completion()
         }
     }
-    
-    /// Convenience wrapper for fetching current pump data without a completion
-    ///
-    func fetchCurrentPumpData() {
-        fetchCurrentPumpData(completion: nil)
-    }
 
 }

--- a/LoopKit/DeviceManager/PumpManager.swift
+++ b/LoopKit/DeviceManager/PumpManager.swift
@@ -112,9 +112,11 @@ public protocol PumpManager: DeviceManager {
     /// - Parameter observer: The observing object
     func removeStatusObserver(_ observer: PumpManagerStatusObserver)
     
-    /// Fetch the pump data (reservoir/events) if it is out of date.
-    /// After a successful fetch, the PumpManager should call the completion block, and trigger a loop by calling the delegate method `pumpManagerRecommendsLoop(_:)`
-    func fetchCurrentPumpData(completion: (() -> Void)?)
+    /// Ensure that the pump's data (reservoir/events) is up to date.  If not, fetch it.
+    /// After a successful fetch, the PumpManager should call the completion block.
+    /// Then, it must call the delegate method `pumpManagerRecommendsLoop(_:)` if it has an accurate and up to date understanding of insulin delivery
+    /// and has reported it via the appropriate status observer and delegate calls.
+    func ensureCurrentPumpData(completion: (() -> Void)?)
     
     /// Loop calls this method when the current environment requires the pump to provide its own periodic
     /// scheduling via BLE.

--- a/LoopKit/DeviceManager/PumpManager.swift
+++ b/LoopKit/DeviceManager/PumpManager.swift
@@ -113,9 +113,9 @@ public protocol PumpManager: DeviceManager {
     func removeStatusObserver(_ observer: PumpManagerStatusObserver)
     
     /// Fetch the pump data (reservoir/events) if it is out of date.
-    /// After a successful fetch, the PumpManager should trigger a loop by calling the delegate method `pumpManagerRecommendsLoop(_:)`
-    func assertCurrentPumpData()
-
+    /// After a successful fetch, the PumpManager should call the completion block, and trigger a loop by calling the delegate method `pumpManagerRecommendsLoop(_:)`
+    func fetchCurrentPumpData(completion: (() -> Void)?)
+    
     /// Loop calls this method when the current environment requires the pump to provide its own periodic
     /// scheduling via BLE.
     /// The manager may choose to still enable its own heartbeat even if `mustProvideBLEHeartbeat` is false
@@ -203,4 +203,11 @@ public extension PumpManager {
             completion()
         }
     }
+    
+    /// Convenience wrapper for fetching current pump data without a completion
+    ///
+    func fetchCurrentPumpData() {
+        fetchCurrentPumpData(completion: nil)
+    }
+
 }

--- a/MockKit/MockPumpManager.swift
+++ b/MockKit/MockPumpManager.swift
@@ -313,7 +313,7 @@ public final class MockPumpManager: TestingPumpManager {
         statusObservers.removeElement(observer)
     }
 
-    public func fetchCurrentPumpData(completion: (() -> Void)? = nil) {
+    public func ensureCurrentPumpData(completion: (() -> Void)? = nil) {
         // Change this to artificially increase the delay fetching the current pump data
         let fetchDelay = 0
         DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(fetchDelay)) {

--- a/MockKit/MockPumpManager.swift
+++ b/MockKit/MockPumpManager.swift
@@ -313,26 +313,34 @@ public final class MockPumpManager: TestingPumpManager {
         statusObservers.removeElement(observer)
     }
 
-    public func assertCurrentPumpData() {
-
-        state.finalizeFinishedDoses()
-
-        storeDoses { (error) in
-            self.delegate.notify { (delegate) in
-                delegate?.pumpManagerRecommendsLoop(self)
-            }
-
-            guard error == nil else {
-                return
-            }
-
-            DispatchQueue.main.async {
-                let totalInsulinUsage = self.state.finalizedDoses.reduce(into: 0 as Double) { total, dose in
-                    total += dose.units
+    public func fetchCurrentPumpData(completion: (() -> Void)? = nil) {
+        // Change this to artificially increase the delay fetching the current pump data
+        let fetchDelay = 0
+        DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(fetchDelay)) {
+            
+            self.state.finalizeFinishedDoses()
+            
+            self.storeDoses { (error) in
+                self.delegate.notify { (delegate) in
+                    delegate?.pumpManagerRecommendsLoop(self)
                 }
-
-                self.state.finalizedDoses = []
-                self.state.reservoirUnitsRemaining -= totalInsulinUsage
+                
+                guard error == nil else {
+                    return
+                }
+                
+                DispatchQueue.main.async {
+                    let totalInsulinUsage = self.state.finalizedDoses.reduce(into: 0 as Double) { total, dose in
+                        total += dose.units
+                    }
+                    
+                    self.state.finalizedDoses = []
+                    self.state.reservoirUnitsRemaining -= totalInsulinUsage
+                    
+                    DispatchQueue.global().async {
+                        completion?()
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
I also renamed the function to reflect what it actually expects of the PumpManager. (Also, the previous name "assert" has other meaning, so I thought it best to change it)