### PR TITLE
LOOP-XXXX: Changes pumpSupportedIncrements and syncPumpSchedule to getters

### DIFF
--- a/LoopKitUI/Views/Settings Editors/BasalRateScheduleEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/BasalRateScheduleEditor.swift
@@ -57,10 +57,10 @@ public struct BasalRateScheduleEditor: View {
     ) {
         self.init(
             schedule: viewModel.therapySettings.basalRateSchedule,
-            supportedBasalRates: viewModel.pumpSupportedIncrements!.basalRates ,
+            supportedBasalRates: viewModel.pumpSupportedIncrements!()!.basalRates ,
             maximumBasalRate: viewModel.therapySettings.maximumBasalRatePerHour,
-            maximumScheduleEntryCount: viewModel.pumpSupportedIncrements!.maximumBasalScheduleEntryCount,
-            syncSchedule: viewModel.syncPumpSchedule,
+            maximumScheduleEntryCount: viewModel.pumpSupportedIncrements!()!.maximumBasalScheduleEntryCount,
+            syncSchedule: viewModel.syncPumpSchedule?(),
             onSave: { [weak viewModel] newBasalRates in
                 viewModel?.saveBasalRates(basalRates: newBasalRates)
                 didSave?()

--- a/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
@@ -60,9 +60,9 @@ public struct DeliveryLimitsEditor: View {
         
         self.init(
             value: DeliveryLimits(maximumBasalRate: maxBasal, maximumBolus: maxBolus),
-            supportedBasalRates: viewModel.pumpSupportedIncrements!.basalRates,
+            supportedBasalRates: viewModel.pumpSupportedIncrements!()!.basalRates,
             scheduledBasalRange: viewModel.therapySettings.basalRateSchedule?.valueRange(),
-            supportedBolusVolumes: viewModel.pumpSupportedIncrements!.bolusVolumes,
+            supportedBolusVolumes: viewModel.pumpSupportedIncrements!()!.bolusVolumes,
             onSave: { [weak viewModel] newLimits in
                 viewModel?.saveDeliveryLimits(limits: newLimits)
                 didSave?()

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -211,12 +211,12 @@ extension TherapySettingsView {
 
     private var basalRatesSection: some View {
         section(for: .basalRate) {
-            if self.viewModel.therapySettings.basalRateSchedule != nil && self.viewModel.pumpSupportedIncrements != nil {
+            if self.viewModel.therapySettings.basalRateSchedule != nil && self.viewModel.pumpSupportedIncrements?() != nil {
                 ForEach(self.viewModel.therapySettings.basalRateSchedule!.items, id: \.self) { value in
                     ScheduleValueItem(time: value.startTime,
                                       value: value.value,
                                       unit: .internationalUnitsPerHour,
-                                      guardrail: Guardrail.basalRate(supportedBasalRates: self.viewModel.pumpSupportedIncrements!.basalRates))
+                                      guardrail: Guardrail.basalRate(supportedBasalRates: self.viewModel.pumpSupportedIncrements!()!.basalRates))
                 }
             }
         }
@@ -233,11 +233,11 @@ extension TherapySettingsView {
         HStack {
             Text(DeliveryLimits.Setting.maximumBasalRate.title)
             Spacer()
-            if self.viewModel.pumpSupportedIncrements != nil {
+            if self.viewModel.pumpSupportedIncrements?() != nil {
                 GuardrailConstrainedQuantityView(
                     value: self.viewModel.therapySettings.maximumBasalRatePerHour.map { HKQuantity(unit: .internationalUnitsPerHour, doubleValue: $0) },
                     unit: .internationalUnitsPerHour,
-                    guardrail: Guardrail.maximumBasalRate(supportedBasalRates: self.viewModel.pumpSupportedIncrements!.basalRates, scheduledBasalRange: self.viewModel.therapySettings.basalRateSchedule?.valueRange()),
+                    guardrail: Guardrail.maximumBasalRate(supportedBasalRates: self.viewModel.pumpSupportedIncrements!()!.basalRates, scheduledBasalRange: self.viewModel.therapySettings.basalRateSchedule?.valueRange()),
                     isEditing: false,
                     // Workaround for strange animation behavior on appearance
                     forceDisableAnimations: true
@@ -250,11 +250,11 @@ extension TherapySettingsView {
         HStack {
             Text(DeliveryLimits.Setting.maximumBolus.title)
             Spacer()
-            if self.viewModel.pumpSupportedIncrements != nil {
+            if self.viewModel.pumpSupportedIncrements?() != nil {
                 GuardrailConstrainedQuantityView(
                     value: self.viewModel.therapySettings.maximumBolus.map { HKQuantity(unit: .internationalUnit(), doubleValue: $0) },
                     unit: .internationalUnit(),
-                    guardrail: Guardrail.maximumBolus(supportedBolusVolumes: self.viewModel.pumpSupportedIncrements!.bolusVolumes),
+                    guardrail: Guardrail.maximumBolus(supportedBolusVolumes: self.viewModel.pumpSupportedIncrements!()!.bolusVolumes),
                     isEditing: false,
                     // Workaround for strange animation behavior on appearance
                     forceDisableAnimations: true
@@ -473,13 +473,13 @@ private extension TherapySettingsView {
                 }
             }
         case .basalRate:
-            if self.viewModel.pumpSupportedIncrements != nil {
+            if self.viewModel.pumpSupportedIncrements?() != nil {
                 return { goBack in
                     AnyView(BasalRateScheduleEditor(viewModel: self.viewModel, didSave: goBack).environment(\.dismiss, goBack))
                 }
             }
         case .deliveryLimits:
-            if self.viewModel.pumpSupportedIncrements != nil {
+            if self.viewModel.pumpSupportedIncrements?() != nil {
                 return { goBack in
                     AnyView(DeliveryLimitsEditor(viewModel: self.viewModel, didSave: goBack).environment(\.dismiss, goBack))
                 }
@@ -535,9 +535,9 @@ public struct TherapySettingsView_Previews: PreviewProvider {
         TherapySettingsViewModel(mode: mode,
                                  therapySettings: preview_therapySettings,
                                  supportedInsulinModelSettings: SupportedInsulinModelSettings(fiaspModelEnabled: true, walshModelEnabled: true),
-                                 pumpSupportedIncrements: PumpSupportedIncrements(basalRates: preview_supportedBasalRates,
+                                 pumpSupportedIncrements: { PumpSupportedIncrements(basalRates: preview_supportedBasalRates,
                                                                                   bolusVolumes: preview_supportedBolusVolumes,
-                                                                                  maximumBasalScheduleEntryCount: 24),
+                                                                                  maximumBasalScheduleEntryCount: 24) } ,
                                  chartColors: ChartColorPalette(axisLine: .clear, axisLabel: .secondaryLabel, grid: .systemGray3, glucoseTint: .systemTeal, insulinTint: .systemOrange))
     }
 

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsViewModel.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsViewModel.swift
@@ -21,8 +21,8 @@ public class TherapySettingsViewModel: ObservableObject {
     private let didSave: SaveCompletion?
 
     private let initialTherapySettings: TherapySettings
-    let pumpSupportedIncrements: PumpSupportedIncrements?
-    let syncPumpSchedule: PumpManager.SyncSchedule?
+    let pumpSupportedIncrements: (() -> PumpSupportedIncrements?)?
+    let syncPumpSchedule: (() -> PumpManager.SyncSchedule?)?
     let sensitivityOverridesEnabled: Bool
     public var prescription: Prescription?
 
@@ -33,8 +33,8 @@ public class TherapySettingsViewModel: ObservableObject {
     public init(mode: PresentationMode,
                 therapySettings: TherapySettings,
                 supportedInsulinModelSettings: SupportedInsulinModelSettings = SupportedInsulinModelSettings(fiaspModelEnabled: true, walshModelEnabled: true),
-                pumpSupportedIncrements: PumpSupportedIncrements? = nil,
-                syncPumpSchedule: PumpManager.SyncSchedule? = nil,
+                pumpSupportedIncrements: (() -> PumpSupportedIncrements?)? = nil,
+                syncPumpSchedule: (() -> PumpManager.SyncSchedule?)? = nil,
                 sensitivityOverridesEnabled: Bool = false,
                 prescription: Prescription? = nil,
                 chartColors: ChartColorPalette,


### PR DESCRIPTION
Instead of passing in `pumpSupportedIncrements` and `syncPumpSchedule` once upon creation of a `TherapySettingsViewModel`, pass in "getters" instead.

(Side note: this has been a common refrain for solving "refresh" problems...)

See also https://github.com/tidepool-org/Loop/pull/253