### PR TITLE
LOOP-1201 Export of Critical Event Logs

### DIFF
--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		1D096C0224C24C220078B6B5 /* InsulinModelSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D096BFF24C24C220078B6B5 /* InsulinModelSettings.swift */; };
 		1D096C0324C24C220078B6B5 /* ExponentialInsulinModelPreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D096C0024C24C220078B6B5 /* ExponentialInsulinModelPreset.swift */; };
 		1D096C0524C624F70078B6B5 /* InsulinModelSettings+LoopKitUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D096C0424C624F70078B6B5 /* InsulinModelSettings+LoopKitUI.swift */; };
-		1D096C0624C626F90078B6B5 /* InsulinModelSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D096BFF24C24C220078B6B5 /* InsulinModelSettings.swift */; };
 		1D1A019E24B678BF0077D86E /* TherapySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1A019D24B678BF0077D86E /* TherapySettingsView.swift */; };
 		1D1FCE2324BD13A2000300A8 /* CorrectionRangeOverridesExpandableSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FCE2224BD13A2000300A8 /* CorrectionRangeOverridesExpandableSetting.swift */; };
 		1D1FCE2524BD42EF000300A8 /* TherapySettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1FCE2424BD42EF000300A8 /* TherapySettingsViewModel.swift */; };
@@ -513,28 +512,22 @@
 		9E78434523665B5A0016C583 /* ice_35_min_partial_piecewiselinear_adaptiverate_output.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E78434423665B5A0016C583 /* ice_35_min_partial_piecewiselinear_adaptiverate_output.json */; };
 		A912BE29245B9CD500CBE199 /* SettingsObject+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912BE28245B9CD500CBE199 /* SettingsObject+CoreDataClass.swift */; };
 		A912BE2B245B9E8600CBE199 /* SettingsObject+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912BE2A245B9E8600CBE199 /* SettingsObject+CoreDataProperties.swift */; };
-		A912BE2C245B9E8600CBE199 /* SettingsObject+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912BE2A245B9E8600CBE199 /* SettingsObject+CoreDataProperties.swift */; };
 		A912BE2D245B9F9800CBE199 /* SettingsObject+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912BE28245B9CD500CBE199 /* SettingsObject+CoreDataClass.swift */; };
 		A919889C2354E5EB00B75EEE /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A919889B2354E5EB00B75EEE /* SettingsStore.swift */; };
-		A919889D2354E5EB00B75EEE /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A919889B2354E5EB00B75EEE /* SettingsStore.swift */; };
 		A919889F2355016B00B75EEE /* DosingDecisionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A919889E2355016B00B75EEE /* DosingDecisionStore.swift */; };
-		A91988A02355016B00B75EEE /* DosingDecisionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A919889E2355016B00B75EEE /* DosingDecisionStore.swift */; };
 		A91A601A23CD023800C0E8A1 /* Modelv2.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = A91A601923CD023800C0E8A1 /* Modelv2.xcmappingmodel */; };
 		A91A601B23CD023800C0E8A1 /* Modelv2.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = A91A601923CD023800C0E8A1 /* Modelv2.xcmappingmodel */; };
+		A933DB8824BF956F009B417A /* CriticalEventLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A933DB8724BF956F009B417A /* CriticalEventLog.swift */; };
+		A933DB8924BF97CC009B417A /* CriticalEventLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A933DB8724BF956F009B417A /* CriticalEventLog.swift */; };
 		A9498D6F23386C0B00DAA9B9 /* TempBasalRecommendation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D6E23386C0B00DAA9B9 /* TempBasalRecommendation.swift */; };
 		A9498D7023386C0B00DAA9B9 /* TempBasalRecommendation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D6E23386C0B00DAA9B9 /* TempBasalRecommendation.swift */; };
 		A9498D7823386C3300DAA9B9 /* LoggingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D7123386C3200DAA9B9 /* LoggingService.swift */; };
-		A9498D7923386C3300DAA9B9 /* LoggingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D7123386C3200DAA9B9 /* LoggingService.swift */; };
 		A9498D7C23386C3300DAA9B9 /* AnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D7323386C3200DAA9B9 /* AnalyticsService.swift */; };
-		A9498D7D23386C3300DAA9B9 /* AnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D7323386C3200DAA9B9 /* AnalyticsService.swift */; };
 		A9498D7E23386C3300DAA9B9 /* GlucoseThreshold.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D7423386C3200DAA9B9 /* GlucoseThreshold.swift */; };
 		A9498D7F23386C3300DAA9B9 /* GlucoseThreshold.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D7423386C3200DAA9B9 /* GlucoseThreshold.swift */; };
 		A9498D8023386C3300DAA9B9 /* RemoteDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D7523386C3300DAA9B9 /* RemoteDataService.swift */; };
-		A9498D8123386C3300DAA9B9 /* RemoteDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D7523386C3300DAA9B9 /* RemoteDataService.swift */; };
 		A9498D8223386C3300DAA9B9 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D7623386C3300DAA9B9 /* Service.swift */; };
-		A9498D8323386C3300DAA9B9 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D7623386C3300DAA9B9 /* Service.swift */; };
 		A9498D8423386C3300DAA9B9 /* DiagnosticLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D7723386C3300DAA9B9 /* DiagnosticLog.swift */; };
-		A9498D8523386C3300DAA9B9 /* DiagnosticLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D7723386C3300DAA9B9 /* DiagnosticLog.swift */; };
 		A9498D8823386CAF00DAA9B9 /* ServiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D8623386CAF00DAA9B9 /* ServiceViewController.swift */; };
 		A9498D8B23386CC700DAA9B9 /* ServiceUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D8A23386CC700DAA9B9 /* ServiceUI.swift */; };
 		A9498D8D23386CD800DAA9B9 /* MockService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D8C23386CD700DAA9B9 /* MockService.swift */; };
@@ -549,11 +542,15 @@
 		A95A1D892460F8930079378D /* PumpManagerStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95A1D882460F8930079378D /* PumpManagerStatusTests.swift */; };
 		A95A1D8B2460FD620079378D /* BolusRecommendationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95A1D8A2460FD620079378D /* BolusRecommendationTests.swift */; };
 		A95A1D8D246101760079378D /* DoseEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95A1D8C246101760079378D /* DoseEntryTests.swift */; };
+		A967D94924F99B6A00CDDF8A /* OutputStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = A967D94824F99B6A00CDDF8A /* OutputStream.swift */; };
+		A967D94A24F99B6A00CDDF8A /* OutputStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = A967D94824F99B6A00CDDF8A /* OutputStream.swift */; };
 		A971C89F23C68B030099BEFC /* GlucoseStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A971C89E23C68B030099BEFC /* GlucoseStoreTests.swift */; };
 		A971C8A023C69E0F0099BEFC /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434FB64B1D712449007B9C70 /* NSData.swift */; };
 		A971C8A223C6B17D0099BEFC /* SettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A971C8A123C6B17D0099BEFC /* SettingsStoreTests.swift */; };
 		A971C8A423C6B1890099BEFC /* DosingDecisionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A971C8A323C6B1890099BEFC /* DosingDecisionStoreTests.swift */; };
 		A975BE8E24FEEE5700FE7B35 /* CarbStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 437AFF192039F149008C4892 /* CarbStoreTests.swift */; };
+		A987CD4624A5893500439ADC /* JSONStreamEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A987CD4524A5893500439ADC /* JSONStreamEncoder.swift */; };
+		A987CD4724A5893500439ADC /* JSONStreamEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A987CD4524A5893500439ADC /* JSONStreamEncoder.swift */; };
 		A991161423426A0A00A4B2E9 /* ServiceSetupNotifying.swift in Sources */ = {isa = PBXBuildFile; fileRef = A991161323426A0A00A4B2E9 /* ServiceSetupNotifying.swift */; };
 		A99C7373233990D400C80963 /* TempBasalRecommendationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A99C7372233990D400C80963 /* TempBasalRecommendationTests.swift */; };
 		A99C7375233993FE00C80963 /* DiagnosticLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A99C7374233993FE00C80963 /* DiagnosticLogTests.swift */; };
@@ -564,8 +561,19 @@
 		A9BD318824F45C0100994B83 /* Modelv3.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = A9BD318724F45C0100994B83 /* Modelv3.xcmappingmodel */; };
 		A9BD318924F45C0100994B83 /* Modelv3.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = A9BD318724F45C0100994B83 /* Modelv3.xcmappingmodel */; };
 		A9BFA03E245CCCB9001E4AE3 /* DailyQuantityScheduleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9BFA03D245CCCB9001E4AE3 /* DailyQuantityScheduleTests.swift */; };
+		A9CE912324CA033A00302A40 /* InsulinModelSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D096BFF24C24C220078B6B5 /* InsulinModelSettings.swift */; };
+		A9CE912524CA051A00302A40 /* StoredInsulinModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9CE912424CA051A00302A40 /* StoredInsulinModel.swift */; };
+		A9CE912624CA051A00302A40 /* StoredInsulinModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9CE912424CA051A00302A40 /* StoredInsulinModel.swift */; };
 		A9D77A2F242E8BDE0009F62C /* BolusRecommendation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D77A2E242E8BDE0009F62C /* BolusRecommendation.swift */; };
 		A9D77A30242E8BDE0009F62C /* BolusRecommendation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D77A2E242E8BDE0009F62C /* BolusRecommendation.swift */; };
+		A9DF02C324F6EEE400B7C988 /* DeviceLogEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DF02C224F6EEE400B7C988 /* DeviceLogEntryTests.swift */; };
+		A9DF02C524F6FA5100B7C988 /* PumpEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DF02C424F6FA5100B7C988 /* PumpEventTests.swift */; };
+		A9DF02C724F6FD1700B7C988 /* StoredInsulinModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DF02C624F6FD1700B7C988 /* StoredInsulinModelTests.swift */; };
+		A9DF02C924F724D900B7C988 /* CriticalEventLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DF02C824F724D900B7C988 /* CriticalEventLogTests.swift */; };
+		A9DF02CF24F732FC00B7C988 /* JSONStreamEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DF02CE24F732FC00B7C988 /* JSONStreamEncoderTests.swift */; };
+		A9DF02D124F7449E00B7C988 /* PersistentDeviceLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DF02D024F7449E00B7C988 /* PersistentDeviceLogTests.swift */; };
+		A9DF02D224F748BF00B7C988 /* CriticalEventLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DF02C824F724D900B7C988 /* CriticalEventLogTests.swift */; };
+		A9DF02D324F762DC00B7C988 /* CarbStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 437AFF192039F149008C4892 /* CarbStoreTests.swift */; };
 		A9E1E6A924E1B6700073CA39 /* SyncCarbObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E1E6A824E1B6700073CA39 /* SyncCarbObject.swift */; };
 		A9E1E6AA24E1B7C10073CA39 /* SyncCarbObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E1E6A824E1B6700073CA39 /* SyncCarbObject.swift */; };
 		A9E1E6AC24E1D7EC0073CA39 /* PersistenceControllerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434113B720F2BDE800D05747 /* PersistenceControllerTestCase.swift */; };
@@ -730,7 +738,6 @@
 		E9086B3124B3A7270062F5C8 /* ChartTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9086B3024B3A7270062F5C8 /* ChartTableViewCell.swift */; };
 		E9086B3524B3A8820062F5C8 /* ChartContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9086B3424B3A8820062F5C8 /* ChartContainerView.swift */; };
 		E9086B3924B3CB4B0062F5C8 /* TherapySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9086B3824B3CB4B0062F5C8 /* TherapySettings.swift */; };
-		E9086B3B24B3CFFD0062F5C8 /* TherapySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9086B3824B3CB4B0062F5C8 /* TherapySettings.swift */; };
 		E9086B4524B53CC50062F5C8 /* GlucoseChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9086B4424B53CC50062F5C8 /* GlucoseChart.swift */; };
 		E9086B4824B5405E0062F5C8 /* ChartAxisValueDoubleUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9086B4724B5405E0062F5C8 /* ChartAxisValueDoubleUnit.swift */; };
 		E9086B4A24B540B70062F5C8 /* DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9086B4924B540B70062F5C8 /* DateFormatter.swift */; };
@@ -1383,6 +1390,7 @@
 		A919889E2355016B00B75EEE /* DosingDecisionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DosingDecisionStore.swift; sourceTree = "<group>"; };
 		A91A601823CD01B000C0E8A1 /* Modelv2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Modelv2.xcdatamodel; sourceTree = "<group>"; };
 		A91A601923CD023800C0E8A1 /* Modelv2.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = Modelv2.xcmappingmodel; sourceTree = "<group>"; };
+		A933DB8724BF956F009B417A /* CriticalEventLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CriticalEventLog.swift; sourceTree = "<group>"; };
 		A9498D6E23386C0B00DAA9B9 /* TempBasalRecommendation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TempBasalRecommendation.swift; sourceTree = "<group>"; };
 		A9498D7123386C3200DAA9B9 /* LoggingService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggingService.swift; sourceTree = "<group>"; };
 		A9498D7323386C3200DAA9B9 /* AnalyticsService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsService.swift; sourceTree = "<group>"; };
@@ -1402,9 +1410,11 @@
 		A95A1D882460F8930079378D /* PumpManagerStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PumpManagerStatusTests.swift; sourceTree = "<group>"; };
 		A95A1D8A2460FD620079378D /* BolusRecommendationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BolusRecommendationTests.swift; sourceTree = "<group>"; };
 		A95A1D8C246101760079378D /* DoseEntryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoseEntryTests.swift; sourceTree = "<group>"; };
+		A967D94824F99B6A00CDDF8A /* OutputStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputStream.swift; sourceTree = "<group>"; };
 		A971C89E23C68B030099BEFC /* GlucoseStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseStoreTests.swift; sourceTree = "<group>"; };
 		A971C8A123C6B17D0099BEFC /* SettingsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStoreTests.swift; sourceTree = "<group>"; };
 		A971C8A323C6B1890099BEFC /* DosingDecisionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DosingDecisionStoreTests.swift; sourceTree = "<group>"; };
+		A987CD4524A5893500439ADC /* JSONStreamEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONStreamEncoder.swift; sourceTree = "<group>"; };
 		A991161323426A0A00A4B2E9 /* ServiceSetupNotifying.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceSetupNotifying.swift; sourceTree = "<group>"; };
 		A996FB6924F089F900864646 /* Modelv3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Modelv3.xcdatamodel; sourceTree = "<group>"; };
 		A99C7372233990D400C80963 /* TempBasalRecommendationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempBasalRecommendationTests.swift; sourceTree = "<group>"; };
@@ -1414,7 +1424,14 @@
 		A9BD318124F4548900994B83 /* Modelv3EntityMigrationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Modelv3EntityMigrationPolicy.swift; sourceTree = "<group>"; };
 		A9BD318724F45C0100994B83 /* Modelv3.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = Modelv3.xcmappingmodel; sourceTree = "<group>"; };
 		A9BFA03D245CCCB9001E4AE3 /* DailyQuantityScheduleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyQuantityScheduleTests.swift; sourceTree = "<group>"; };
+		A9CE912424CA051A00302A40 /* StoredInsulinModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredInsulinModel.swift; sourceTree = "<group>"; };
 		A9D77A2E242E8BDE0009F62C /* BolusRecommendation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BolusRecommendation.swift; sourceTree = "<group>"; };
+		A9DF02C224F6EEE400B7C988 /* DeviceLogEntryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceLogEntryTests.swift; sourceTree = "<group>"; };
+		A9DF02C424F6FA5100B7C988 /* PumpEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PumpEventTests.swift; sourceTree = "<group>"; };
+		A9DF02C624F6FD1700B7C988 /* StoredInsulinModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredInsulinModelTests.swift; sourceTree = "<group>"; };
+		A9DF02C824F724D900B7C988 /* CriticalEventLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CriticalEventLogTests.swift; sourceTree = "<group>"; };
+		A9DF02CE24F732FC00B7C988 /* JSONStreamEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONStreamEncoderTests.swift; sourceTree = "<group>"; };
+		A9DF02D024F7449E00B7C988 /* PersistentDeviceLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentDeviceLogTests.swift; sourceTree = "<group>"; };
 		A9E1E6A824E1B6700073CA39 /* SyncCarbObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncCarbObject.swift; sourceTree = "<group>"; };
 		A9E675F022713F4700E25293 /* LoopKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LoopKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9E675F2227140D800E25293 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
@@ -1727,8 +1744,10 @@
 				434113BD20F2C72000D05747 /* CachedCarbObjectTests.swift */,
 				434113BB20F2C56100D05747 /* CachedGlucoseObjectTests.swift */,
 				434113B420F2BDB500D05747 /* CachedInsulinDeliveryObjectTests.swift */,
+				A9DF02C224F6EEE400B7C988 /* DeviceLogEntryTests.swift */,
 				434113B220F2890800D05747 /* PersistenceControllerTests.swift */,
 				434113B720F2BDE800D05747 /* PersistenceControllerTestCase.swift */,
+				A9DF02C424F6FA5100B7C988 /* PumpEventTests.swift */,
 			);
 			path = Persistence;
 			sourceTree = "<group>";
@@ -1889,6 +1908,7 @@
 				A9FD046E24E310D00040F203 /* HKObject.swift */,
 				43AF1FB11C926CDD00EA2F3D /* HKQuantity.swift */,
 				432762731D60505F0083215A /* HKQuantitySample.swift */,
+				A967D94824F99B6A00CDDF8A /* OutputStream.swift */,
 				43CB51B0211EB16C00DB9B4A /* NSUserActivity+CarbKit.swift */,
 			);
 			path = Extensions;
@@ -2030,6 +2050,7 @@
 				891A3FD4224B047200378B27 /* DailyQuantitySchedule+Override.swift */,
 				43D8FDE81C7290350073BE78 /* DailyValueSchedule.swift */,
 				1DA649AA2445174400F61E75 /* Alert.swift */,
+				A933DB8724BF956F009B417A /* CriticalEventLog.swift */,
 				A9498D7723386C3300DAA9B9 /* DiagnosticLog.swift */,
 				A95A1D7E2460BBC70079378D /* DosingDecisionObject+CoreDataClass.swift */,
 				A95A1D812460BBDC0079378D /* DosingDecisionObject+CoreDataProperties.swift */,
@@ -2044,6 +2065,7 @@
 				43D9888A1C87E47800DA4467 /* GlucoseValue.swift */,
 				43D8FDED1C7290350073BE78 /* HealthKitSampleStore.swift */,
 				43B17C88208EEC0B00AC27E9 /* HealthStoreUnitCache.swift */,
+				A987CD4524A5893500439ADC /* JSONStreamEncoder.swift */,
 				43F5034A21051FCD009FA89A /* KeychainManager.swift */,
 				89AC792E224C781200B8E9BA /* Locked.swift */,
 				A9498D7123386C3200DAA9B9 /* LoggingService.swift */,
@@ -2056,6 +2078,7 @@
 				A912BE28245B9CD500CBE199 /* SettingsObject+CoreDataClass.swift */,
 				A912BE2A245B9E8600CBE199 /* SettingsObject+CoreDataProperties.swift */,
 				A919889B2354E5EB00B75EEE /* SettingsStore.swift */,
+				A9CE912424CA051A00302A40 /* StoredInsulinModel.swift */,
 				89AE2223228BC54C00BDFD85 /* TemporaryScheduleOverride.swift */,
 				89AE2225228BC54C00BDFD85 /* TemporaryScheduleOverrideHistory.swift */,
 				89AE221F228BC54C00BDFD85 /* TemporaryScheduleOverridePreset.swift */,
@@ -2094,6 +2117,7 @@
 				43D8FE411C7291900073BE78 /* CarbMathTests.swift */,
 				437AFF192039F149008C4892 /* CarbStoreTests.swift */,
 				A95A1D842460CAD50079378D /* CarbValueTests.swift */,
+				A9DF02C824F724D900B7C988 /* CriticalEventLogTests.swift */,
 				A9BFA03D245CCCB9001E4AE3 /* DailyQuantityScheduleTests.swift */,
 				891A3FD6224BE62100378B27 /* DailyValueScheduleTests.swift */,
 				A99C7374233993FE00C80963 /* DiagnosticLogTests.swift */,
@@ -2108,14 +2132,17 @@
 				C1E703612500390B00DAB534 /* HKAnchoredObjectQueryMock.swift */,
 				C1E7035E25001EA500DAB534 /* HKObserverQueryMock.swift */,
 				43D8FEC81C7294640073BE78 /* InsulinMathTests.swift */,
+				A9DF02CE24F732FC00B7C988 /* JSONStreamEncoderTests.swift */,
 				43D8FDDA1C728FDF0073BE78 /* LoopKitTests.swift */,
 				43D9888C1C87EBE400DA4467 /* LoopMathTests.swift */,
 				43D8FE1B1C72906E0073BE78 /* NSDateTests.swift */,
+				A9DF02D024F7449E00B7C988 /* PersistentDeviceLogTests.swift */,
 				A95A1D882460F8930079378D /* PumpManagerStatusTests.swift */,
 				434C5F9F209ABD4700B2FD1A /* QuantityFormatterTests.swift */,
 				43D8FE1C1C72906E0073BE78 /* QuantityScheduleTests.swift */,
 				A99C73782339ACDC00C80963 /* ServiceTests.swift */,
 				A971C8A123C6B17D0099BEFC /* SettingsStoreTests.swift */,
+				A9DF02C624F6FD1700B7C988 /* StoredInsulinModelTests.swift */,
 				A99C7372233990D400C80963 /* TempBasalRecommendationTests.swift */,
 				891A3FD02249948A00378B27 /* TemporaryScheduleOverrideHistoryTests.swift */,
 				8974AFBF22120D7A0043F01B /* TemporaryScheduleOverrideTests.swift */,
@@ -3109,6 +3136,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A9E1E6AC24E1D7EC0073CA39 /* PersistenceControllerTestCase.swift in Sources */,
+				A9DF02D224F748BF00B7C988 /* CriticalEventLogTests.swift in Sources */,
 				1DEE226F24A676A300693C32 /* GlucoseStoreHKFilterTests.swift in Sources */,
 				1DEE227724A676A300693C32 /* HKHealthStoreMock.swift in Sources */,
 				A9E1E6AD24E1D8590073CA39 /* CacheStore.swift in Sources */,
@@ -3395,6 +3423,7 @@
 				432CF87320D774220066B889 /* PumpManager.swift in Sources */,
 				43D8FE021C7290350073BE78 /* SampleValue.swift in Sources */,
 				43D9888B1C87E47800DA4467 /* GlucoseValue.swift in Sources */,
+				A967D94924F99B6A00CDDF8A /* OutputStream.swift in Sources */,
 				43D8FDF41C7290350073BE78 /* BasalRateSchedule.swift in Sources */,
 				4322B788202FA2B30002837D /* DoseStore.swift in Sources */,
 				4303C4921E2D665000ADEDC8 /* TimeZone.swift in Sources */,
@@ -3444,6 +3473,7 @@
 				434113AB20F171CB00D05747 /* CachedInsulinDeliveryObject+CoreDataProperties.swift in Sources */,
 				A9E1E6A924E1B6700073CA39 /* SyncCarbObject.swift in Sources */,
 				43CF0B3F2030FD0D002A66DE /* UploadState.swift in Sources */,
+				A933DB8824BF956F009B417A /* CriticalEventLog.swift in Sources */,
 				C16DA83F22E8D88F008624C2 /* LoopPlugin.swift in Sources */,
 				C1F8403923DB84B700673141 /* DeviceLogEntry+CoreDataClass.swift in Sources */,
 				433BC7AD20538FCA000B1200 /* StoredGlucoseSample.swift in Sources */,
@@ -3461,6 +3491,7 @@
 				4322B77A202FA2790002837D /* NSUserDefaults.swift in Sources */,
 				4322B776202FA2790002837D /* CarbStore.swift in Sources */,
 				C1F8403A23DB84B700673141 /* DeviceLogEntry+CoreDataProperties.swift in Sources */,
+				A987CD4624A5893500439ADC /* JSONStreamEncoder.swift in Sources */,
 				A9498D7823386C3300DAA9B9 /* LoggingService.swift in Sources */,
 				1D096C0224C24C220078B6B5 /* InsulinModelSettings.swift in Sources */,
 				433BC7AA20538D4C000B1200 /* CachedGlucoseObject+CoreDataClass.swift in Sources */,
@@ -3470,6 +3501,7 @@
 				4322B780202FA2AF0002837D /* PumpEvent+CoreDataClass.swift in Sources */,
 				89AE2227228BC54C00BDFD85 /* TemporaryScheduleOverride.swift in Sources */,
 				433BC7B120562705000B1200 /* UpdateSource.swift in Sources */,
+				A9CE912524CA051A00302A40 /* StoredInsulinModel.swift in Sources */,
 				4322B784202FA2AF0002837D /* Reservoir+CoreDataProperties.swift in Sources */,
 				4322B778202FA2790002837D /* HKQuantitySample+CarbKit.swift in Sources */,
 				4322B771202FA26F0002837D /* HKQuantitySample+GlucoseKit.swift in Sources */,
@@ -3512,9 +3544,11 @@
 				891A3FD32249990900378B27 /* DailyValueSchedule.swift in Sources */,
 				434C5FA0209ABD4700B2FD1A /* QuantityFormatterTests.swift in Sources */,
 				A95A1D892460F8930079378D /* PumpManagerStatusTests.swift in Sources */,
+				A9DF02C724F6FD1700B7C988 /* StoredInsulinModelTests.swift in Sources */,
 				A95A1D8D246101760079378D /* DoseEntryTests.swift in Sources */,
 				43D8FE1E1C72906E0073BE78 /* NSDateTests.swift in Sources */,
 				43D9888D1C87EBE400DA4467 /* LoopMathTests.swift in Sources */,
+				A9DF02D324F762DC00B7C988 /* CarbStoreTests.swift in Sources */,
 				437874B5202FDD1200A3D8B9 /* DoseStoreTests.swift in Sources */,
 				A99C7375233993FE00C80963 /* DiagnosticLogTests.swift in Sources */,
 				4322B76C202F9ECD0002837D /* CarbMathTests.swift in Sources */,
@@ -3524,15 +3558,19 @@
 				434113B320F2890800D05747 /* PersistenceControllerTests.swift in Sources */,
 				A971C8A023C69E0F0099BEFC /* NSData.swift in Sources */,
 				434113BE20F2C72000D05747 /* CachedCarbObjectTests.swift in Sources */,
+				A9DF02D124F7449E00B7C988 /* PersistentDeviceLogTests.swift in Sources */,
 				43260F6E21C4BF7A00DD6837 /* UUID.swift in Sources */,
+				A9DF02C524F6FA5100B7C988 /* PumpEventTests.swift in Sources */,
 				A971C8A223C6B17D0099BEFC /* SettingsStoreTests.swift in Sources */,
 				C1E7035D24FFFA5C00DAB534 /* CollectionTests.swift in Sources */,
 				1DFB99D6245CB2E900DCC8C9 /* AlertTests.swift in Sources */,
 				4303C4941E2D665F00ADEDC8 /* TimeZone.swift in Sources */,
 				898C897124D4C0E4002FA994 /* GuardrailTests.swift in Sources */,
+				A9DF02CF24F732FC00B7C988 /* JSONStreamEncoderTests.swift in Sources */,
 				4322B76D202F9EF20002837D /* GlucoseMathTests.swift in Sources */,
 				43025DAF1D5AB2E300106C28 /* NSTimeInterval.swift in Sources */,
 				43D8FDDB1C728FDF0073BE78 /* LoopKitTests.swift in Sources */,
+				A9DF02C924F724D900B7C988 /* CriticalEventLogTests.swift in Sources */,
 				8974AFC022120D7A0043F01B /* TemporaryScheduleOverrideTests.swift in Sources */,
 				437AFF1D203A45DB008C4892 /* CacheStore.swift in Sources */,
 				A975BE8E24FEEE5700FE7B35 /* CarbStoreTests.swift in Sources */,
@@ -3542,6 +3580,7 @@
 				434113BC20F2C56100D05747 /* CachedGlucoseObjectTests.swift in Sources */,
 				E93C86B024CF7C470073089B /* TherapySettingsTests.swift in Sources */,
 				A95A1D872460F1250079378D /* GlucoseValueTests.swift in Sources */,
+				A9DF02C324F6EEE400B7C988 /* DeviceLogEntryTests.swift in Sources */,
 				891A3FD7224BE62100378B27 /* DailyValueScheduleTests.swift in Sources */,
 				430059241CCDD08C00C861EA /* NSDateFormatter.swift in Sources */,
 			);
@@ -3628,10 +3667,12 @@
 				89AE2235228BCAAB00BDFD85 /* CarbSensitivitySchedule.swift in Sources */,
 				89AE2236228BCAAB00BDFD85 /* DailyQuantitySchedule+Override.swift in Sources */,
 				89AE2237228BCAAB00BDFD85 /* EGPSchedule.swift in Sources */,
+				A933DB8924BF97CC009B417A /* CriticalEventLog.swift in Sources */,
 				89AE2238228BCAAB00BDFD85 /* TemporaryScheduleOverride.swift in Sources */,
 				89AE2239228BCAAB00BDFD85 /* TemporaryScheduleOverrideHistory.swift in Sources */,
 				89AE223A228BCAAB00BDFD85 /* TemporaryScheduleOverridePreset.swift in Sources */,
 				89AE223B228BCAAB00BDFD85 /* TemporaryScheduleOverrideSettings.swift in Sources */,
+				A987CD4724A5893500439ADC /* JSONStreamEncoder.swift in Sources */,
 				89AE223C228BCAAB00BDFD85 /* WeakSet.swift in Sources */,
 				A9E6758222713F4700E25293 /* LoopNotificationCategory.swift in Sources */,
 				A9E1E6AA24E1B7C10073CA39 /* SyncCarbObject.swift in Sources */,
@@ -3645,19 +3686,17 @@
 				A9E6758B22713F4700E25293 /* OSLog.swift in Sources */,
 				C17F39CC23CD2D3E00FA1113 /* DeviceLog.xcdatamodeld in Sources */,
 				A9E6758C22713F4700E25293 /* DoseType.swift in Sources */,
-				A9498D7923386C3300DAA9B9 /* LoggingService.swift in Sources */,
 				A9E6758D22713F4700E25293 /* CachedCarbObject+CoreDataClass.swift in Sources */,
 				A9E6758E22713F4700E25293 /* DailyValueSchedule.swift in Sources */,
 				A9E6758F22713F4700E25293 /* NewPumpEvent.swift in Sources */,
+				A9CE912324CA033A00302A40 /* InsulinModelSettings.swift in Sources */,
 				A9E6759022713F4700E25293 /* CachedInsulinDeliveryObject+CoreDataClass.swift in Sources */,
 				A9E6759122713F4700E25293 /* GlucoseTrend.swift in Sources */,
-				A912BE2C245B9E8600CBE199 /* SettingsObject+CoreDataProperties.swift in Sources */,
 				A9E6759222713F4700E25293 /* PumpManagerStatus.swift in Sources */,
 				A9E6759322713F4700E25293 /* CarbMath.swift in Sources */,
 				A9E6759522713F4700E25293 /* ExponentialInsulinModel.swift in Sources */,
 				A91A601B23CD023800C0E8A1 /* Modelv2.xcmappingmodel in Sources */,
 				B4102D3324ABB0D8005D460B /* DeviceLifecycleProgress.swift in Sources */,
-				A9498D8323386C3300DAA9B9 /* Service.swift in Sources */,
 				A9E6759622713F4700E25293 /* NSTimeInterval.swift in Sources */,
 				A9E6759722713F4700E25293 /* DailyQuantitySchedule.swift in Sources */,
 				89ED164124A29BA300C9A105 /* Sequence.swift in Sources */,
@@ -3672,12 +3711,10 @@
 				A9E6759E22713F4700E25293 /* DoseUnit.swift in Sources */,
 				C17F39D123CE34FD00FA1113 /* StoredDeviceLogEntry.swift in Sources */,
 				A9E675A022713F4700E25293 /* HKQuantitySample.swift in Sources */,
-				A9498D8523386C3300DAA9B9 /* DiagnosticLog.swift in Sources */,
 				A9E675A122713F4700E25293 /* Double.swift in Sources */,
 				A9E675A222713F4700E25293 /* KeychainManager.swift in Sources */,
 				A9E675A322713F4700E25293 /* PumpManager.swift in Sources */,
 				A9FD047024E310DD0040F203 /* HKObject.swift in Sources */,
-				A91988A02355016B00B75EEE /* DosingDecisionStore.swift in Sources */,
 				A9E675A422713F4700E25293 /* SampleValue.swift in Sources */,
 				A9E675A522713F4700E25293 /* GlucoseValue.swift in Sources */,
 				A9E675A622713F4700E25293 /* BasalRateSchedule.swift in Sources */,
@@ -3690,7 +3727,6 @@
 				A9E675AC22713F4700E25293 /* Reservoir.swift in Sources */,
 				A9E675AE22713F4700E25293 /* CarbValue.swift in Sources */,
 				C17F39CB23CD2D2F00FA1113 /* DeviceLogEntryType.swift in Sources */,
-				A9498D8123386C3300DAA9B9 /* RemoteDataService.swift in Sources */,
 				A9E675AF22713F4700E25293 /* PumpEventType.swift in Sources */,
 				A9E675B122713F4700E25293 /* NSData.swift in Sources */,
 				C1A174ED23DEAD6A0034DF11 /* DeviceLogEntry+CoreDataProperties.swift in Sources */,
@@ -3701,10 +3737,8 @@
 				A9E675B522713F4700E25293 /* AbsorbedCarbValue.swift in Sources */,
 				A9BD318924F45C0100994B83 /* Modelv3.xcmappingmodel in Sources */,
 				A9E675B622713F4700E25293 /* LocalizedString.swift in Sources */,
-				1D096C0624C626F90078B6B5 /* InsulinModelSettings.swift in Sources */,
 				A9E675B722713F4700E25293 /* NSManagedObjectContext.swift in Sources */,
 				A9E675B822713F4700E25293 /* StoredCarbEntry.swift in Sources */,
-				A9498D7D23386C3300DAA9B9 /* AnalyticsService.swift in Sources */,
 				A9E675BA22713F4700E25293 /* InsulinValue.swift in Sources */,
 				A9E675BB22713F4700E25293 /* NumberFormatter.swift in Sources */,
 				A95A1D802460BBC70079378D /* DosingDecisionObject+CoreDataClass.swift in Sources */,
@@ -3713,6 +3747,7 @@
 				C17F39CA23CD2D2000FA1113 /* PersistentDeviceLog.swift in Sources */,
 				A9E675BE22713F4700E25293 /* InsulinModel.swift in Sources */,
 				89AE222D228BC66E00BDFD85 /* Locked.swift in Sources */,
+				A9CE912624CA051A00302A40 /* StoredInsulinModel.swift in Sources */,
 				89F53E9522B437570024A67C /* MutableCollection.swift in Sources */,
 				A9E675BF22713F4700E25293 /* QuantityFormatter.swift in Sources */,
 				A9E675C022713F4700E25293 /* ServiceAuthentication.swift in Sources */,
@@ -3729,6 +3764,7 @@
 				A9E675C822713F4700E25293 /* NSUserActivity+CarbKit.swift in Sources */,
 				A9E675C922713F4700E25293 /* CachedInsulinDeliveryObject+CoreDataProperties.swift in Sources */,
 				A9E675CA22713F4700E25293 /* UploadState.swift in Sources */,
+				A967D94A24F99B6A00CDDF8A /* OutputStream.swift in Sources */,
 				A9E675CB22713F4700E25293 /* StoredGlucoseSample.swift in Sources */,
 				A9E675CC22713F4700E25293 /* GlucoseEffect.swift in Sources */,
 				A9E675CD22713F4700E25293 /* WeakSynchronizedSet.swift in Sources */,
@@ -3744,7 +3780,6 @@
 				A9E675D522713F4700E25293 /* WalshInsulinModel.swift in Sources */,
 				A9E675D622713F4700E25293 /* GlucoseEffectVelocity.swift in Sources */,
 				A9E675D722713F4700E25293 /* PumpEvent+CoreDataClass.swift in Sources */,
-				E9086B3B24B3CFFD0062F5C8 /* TherapySettings.swift in Sources */,
 				A9E675D822713F4700E25293 /* UpdateSource.swift in Sources */,
 				A9E675D922713F4700E25293 /* Reservoir+CoreDataProperties.swift in Sources */,
 				A9E675DA22713F4700E25293 /* HKQuantitySample+CarbKit.swift in Sources */,
@@ -3754,7 +3789,6 @@
 				A9E675DD22713F4700E25293 /* PumpManagerError.swift in Sources */,
 				A9E675E022713F4700E25293 /* GlucoseStore.swift in Sources */,
 				A912BE2D245B9F9800CBE199 /* SettingsObject+CoreDataClass.swift in Sources */,
-				A919889D2354E5EB00B75EEE /* SettingsStore.swift in Sources */,
 				A9E675E122713F4700E25293 /* WeakSynchronizedDelegate.swift in Sources */,
 				A9E675E222713F4700E25293 /* CGMManager.swift in Sources */,
 				A9E675E322713F4700E25293 /* CarbStoreError.swift in Sources */,

--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -549,6 +549,9 @@
 		A971C8A223C6B17D0099BEFC /* SettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A971C8A123C6B17D0099BEFC /* SettingsStoreTests.swift */; };
 		A971C8A423C6B1890099BEFC /* DosingDecisionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A971C8A323C6B1890099BEFC /* DosingDecisionStoreTests.swift */; };
 		A975BE8E24FEEE5700FE7B35 /* CarbStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 437AFF192039F149008C4892 /* CarbStoreTests.swift */; };
+		A985464B251442010099C1A6 /* OutputStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A985464A251442010099C1A6 /* OutputStreamTests.swift */; };
+		A985464F251449FE0099C1A6 /* NotificationSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A985464E251449FE0099C1A6 /* NotificationSettings.swift */; };
+		A985465125144ABA0099C1A6 /* NotificationSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A985465025144ABA0099C1A6 /* NotificationSettingsTests.swift */; };
 		A987CD4624A5893500439ADC /* JSONStreamEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A987CD4524A5893500439ADC /* JSONStreamEncoder.swift */; };
 		A987CD4724A5893500439ADC /* JSONStreamEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A987CD4524A5893500439ADC /* JSONStreamEncoder.swift */; };
 		A991161423426A0A00A4B2E9 /* ServiceSetupNotifying.swift in Sources */ = {isa = PBXBuildFile; fileRef = A991161323426A0A00A4B2E9 /* ServiceSetupNotifying.swift */; };
@@ -1414,6 +1417,9 @@
 		A971C89E23C68B030099BEFC /* GlucoseStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseStoreTests.swift; sourceTree = "<group>"; };
 		A971C8A123C6B17D0099BEFC /* SettingsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStoreTests.swift; sourceTree = "<group>"; };
 		A971C8A323C6B1890099BEFC /* DosingDecisionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DosingDecisionStoreTests.swift; sourceTree = "<group>"; };
+		A985464A251442010099C1A6 /* OutputStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputStreamTests.swift; sourceTree = "<group>"; };
+		A985464E251449FE0099C1A6 /* NotificationSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettings.swift; sourceTree = "<group>"; };
+		A985465025144ABA0099C1A6 /* NotificationSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsTests.swift; sourceTree = "<group>"; };
 		A987CD4524A5893500439ADC /* JSONStreamEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONStreamEncoder.swift; sourceTree = "<group>"; };
 		A991161323426A0A00A4B2E9 /* ServiceSetupNotifying.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceSetupNotifying.swift; sourceTree = "<group>"; };
 		A996FB6924F089F900864646 /* Modelv3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Modelv3.xcdatamodel; sourceTree = "<group>"; };
@@ -2070,6 +2076,7 @@
 				89AC792E224C781200B8E9BA /* Locked.swift */,
 				A9498D7123386C3200DAA9B9 /* LoggingService.swift */,
 				43D8FDEF1C7290350073BE78 /* LoopMath.swift */,
+				A985464E251449FE0099C1A6 /* NotificationSettings.swift */,
 				434C5F9B2098352500B2FD1A /* QuantityFormatter.swift */,
 				A9498D7523386C3300DAA9B9 /* RemoteDataService.swift */,
 				43D8FDF31C7290350073BE78 /* SampleValue.swift */,
@@ -2136,6 +2143,7 @@
 				43D8FDDA1C728FDF0073BE78 /* LoopKitTests.swift */,
 				43D9888C1C87EBE400DA4467 /* LoopMathTests.swift */,
 				43D8FE1B1C72906E0073BE78 /* NSDateTests.swift */,
+				A985464A251442010099C1A6 /* OutputStreamTests.swift */,
 				A9DF02D024F7449E00B7C988 /* PersistentDeviceLogTests.swift */,
 				A95A1D882460F8930079378D /* PumpManagerStatusTests.swift */,
 				434C5F9F209ABD4700B2FD1A /* QuantityFormatterTests.swift */,
@@ -2148,6 +2156,7 @@
 				8974AFBF22120D7A0043F01B /* TemporaryScheduleOverrideTests.swift */,
 				E93C86AF24CF7C470073089B /* TherapySettingsTests.swift */,
 				C1E7035C24FFFA5C00DAB534 /* CollectionTests.swift */,
+				A985465025144ABA0099C1A6 /* NotificationSettingsTests.swift */,
 			);
 			path = LoopKitTests;
 			sourceTree = "<group>";
@@ -3520,6 +3529,7 @@
 				43AF1FB21C926CDD00EA2F3D /* HKQuantity.swift in Sources */,
 				A91A601A23CD023800C0E8A1 /* Modelv2.xcmappingmodel in Sources */,
 				89F6E30F244A1A5D00CB9E15 /* Guardrail.swift in Sources */,
+				A985464F251449FE0099C1A6 /* NotificationSettings.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3550,6 +3560,7 @@
 				43D9888D1C87EBE400DA4467 /* LoopMathTests.swift in Sources */,
 				A9DF02D324F762DC00B7C988 /* CarbStoreTests.swift in Sources */,
 				437874B5202FDD1200A3D8B9 /* DoseStoreTests.swift in Sources */,
+				A985465125144ABA0099C1A6 /* NotificationSettingsTests.swift in Sources */,
 				A99C7375233993FE00C80963 /* DiagnosticLogTests.swift in Sources */,
 				4322B76C202F9ECD0002837D /* CarbMathTests.swift in Sources */,
 				434113B520F2BDB500D05747 /* CachedInsulinDeliveryObjectTests.swift in Sources */,
@@ -3561,6 +3572,7 @@
 				A9DF02D124F7449E00B7C988 /* PersistentDeviceLogTests.swift in Sources */,
 				43260F6E21C4BF7A00DD6837 /* UUID.swift in Sources */,
 				A9DF02C524F6FA5100B7C988 /* PumpEventTests.swift in Sources */,
+				A985464B251442010099C1A6 /* OutputStreamTests.swift in Sources */,
 				A971C8A223C6B17D0099BEFC /* SettingsStoreTests.swift in Sources */,
 				C1E7035D24FFFA5C00DAB534 /* CollectionTests.swift in Sources */,
 				1DFB99D6245CB2E900DCC8C9 /* AlertTests.swift in Sources */,

--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -548,7 +548,6 @@
 		A971C8A023C69E0F0099BEFC /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434FB64B1D712449007B9C70 /* NSData.swift */; };
 		A971C8A223C6B17D0099BEFC /* SettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A971C8A123C6B17D0099BEFC /* SettingsStoreTests.swift */; };
 		A971C8A423C6B1890099BEFC /* DosingDecisionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A971C8A323C6B1890099BEFC /* DosingDecisionStoreTests.swift */; };
-		A975BE8E24FEEE5700FE7B35 /* CarbStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 437AFF192039F149008C4892 /* CarbStoreTests.swift */; };
 		A985464B251442010099C1A6 /* OutputStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A985464A251442010099C1A6 /* OutputStreamTests.swift */; };
 		A985464F251449FE0099C1A6 /* NotificationSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A985464E251449FE0099C1A6 /* NotificationSettings.swift */; };
 		A985465125144ABA0099C1A6 /* NotificationSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A985465025144ABA0099C1A6 /* NotificationSettingsTests.swift */; };
@@ -3585,7 +3584,6 @@
 				A9DF02C924F724D900B7C988 /* CriticalEventLogTests.swift in Sources */,
 				8974AFC022120D7A0043F01B /* TemporaryScheduleOverrideTests.swift in Sources */,
 				437AFF1D203A45DB008C4892 /* CacheStore.swift in Sources */,
-				A975BE8E24FEEE5700FE7B35 /* CarbStoreTests.swift in Sources */,
 				891A3FD12249948A00378B27 /* TemporaryScheduleOverrideHistoryTests.swift in Sources */,
 				A9BFA03E245CCCB9001E4AE3 /* DailyQuantityScheduleTests.swift in Sources */,
 				A99C73772339A67A00C80963 /* GlucoseThresholdTests.swift in Sources */,

--- a/LoopKit/CarbKit/CachedCarbObject+CoreDataProperties.swift
+++ b/LoopKit/CarbKit/CachedCarbObject+CoreDataProperties.swift
@@ -34,3 +34,44 @@ extension CachedCarbObject {
     @NSManaged public var anchorKey: Int64
 
 }
+
+extension CachedCarbObject: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(absorptionTime, forKey: .absorptionTime)
+        try container.encode(createdByCurrentApp, forKey: .createdByCurrentApp)
+        try container.encodeIfPresent(foodType, forKey: .foodType)
+        try container.encode(grams, forKey: .grams)
+        try container.encode(startDate, forKey: .startDate)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encodeIfPresent(provenanceIdentifier, forKey: .provenanceIdentifier)
+        try container.encodeIfPresent(syncIdentifier, forKey: .syncIdentifier)
+        try container.encodeIfPresent(syncVersion, forKey: .syncVersion)
+        try container.encodeIfPresent(userCreatedDate, forKey: .userCreatedDate)
+        try container.encodeIfPresent(userUpdatedDate, forKey: .userUpdatedDate)
+        try container.encodeIfPresent(userDeletedDate, forKey: .userDeletedDate)
+        try container.encodeIfPresent(operation, forKey: .operation)
+        try container.encodeIfPresent(addedDate, forKey: .addedDate)
+        try container.encodeIfPresent(supercededDate, forKey: .supercededDate)
+        try container.encode(anchorKey, forKey: .anchorKey)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case absorptionTime
+        case createdByCurrentApp
+        case foodType
+        case grams
+        case startDate
+        case uuid
+        case provenanceIdentifier
+        case syncIdentifier
+        case syncVersion
+        case userCreatedDate
+        case userUpdatedDate
+        case userDeletedDate
+        case operation
+        case addedDate
+        case supercededDate
+        case anchorKey
+    }
+}

--- a/LoopKit/CriticalEventLog.swift
+++ b/LoopKit/CriticalEventLog.swift
@@ -8,28 +8,18 @@
 
 import Foundation
 
-public protocol EstimatedDurationProgressor {
-
-    /// Has the operation been cancelled?
-    var isCancelled: Bool { get }
-
-    /// Some progress was made toward the estimated duration of the operation.
-    /// - Parameter: estimatedDuration: The estimated duration completed since the last invocation.
-    func didProgress(for estimatedDuration: TimeInterval)
-}
-
 public protocol CriticalEventLog {
 
     /// The name for the critical event log export.
     var exportName: String { get }
 
-    /// Calculate the estimated duration for the critical event log export for the specified date range.
+    /// Calculate the progress total unit count for the critical event log export for the specified date range.
     ///
     /// - Parameters:
     ///   - startDate: The start date for the critical events to export.
     ///   - endDate: The end date for the critical events to export. Optional. If not specified, default to now.
-    /// - Returns: An estimated duration, as TimeInterval, or an error.
-    func exportEstimatedDuration(startDate: Date, endDate: Date?) -> Result<TimeInterval, Error>
+    /// - Returns: An progress total unit count, or an error.
+    func exportProgressTotalUnitCount(startDate: Date, endDate: Date?) -> Result<Int64, Error>
 
     /// Export the critical event log for the specified date range.
     ///
@@ -39,7 +29,7 @@ public protocol CriticalEventLog {
     ///   - stream: The output stream to write the critical event log to. Typically writes JSON UTF-8 text.
     ///   - progressor: The estimated duration progress to use to check if cancelled and report progress.
     /// - Returns: Any error that occurs during the export, or nil if successful.
-    func export(startDate: Date, endDate: Date, to stream: OutputStream, progressor: EstimatedDurationProgressor) -> Error?
+    func export(startDate: Date, endDate: Date, to stream: OutputStream, progress: Progress) -> Error?
 }
 
 public enum CriticalEventLogError: Error {
@@ -48,4 +38,4 @@ public enum CriticalEventLogError: Error {
     case cancelled
 }
 
-public let criticalEventLogExportMinimumProgressDuration = TimeInterval(0.25)
+public let criticalEventLogExportProgressUnitCountPerFetch: Int64 = 250

--- a/LoopKit/CriticalEventLog.swift
+++ b/LoopKit/CriticalEventLog.swift
@@ -1,0 +1,51 @@
+//
+//  CriticalEventLog.swift
+//  LoopKit
+//
+//  Created by Darin Krauss on 7/15/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+
+public protocol EstimatedDurationProgressor {
+
+    /// Has the operation been cancelled?
+    var isCancelled: Bool { get }
+
+    /// Some progress was made toward the estimated duration of the operation.
+    /// - Parameter: estimatedDuration: The estimated duration completed since the last invocation.
+    func didProgress(for estimatedDuration: TimeInterval)
+}
+
+public protocol CriticalEventLog {
+
+    /// The name for the critical event log export.
+    var exportName: String { get }
+
+    /// Calculate the estimated duration for the critical event log export for the specified date range.
+    ///
+    /// - Parameters:
+    ///   - startDate: The start date for the critical events to export.
+    ///   - endDate: The end date for the critical events to export. Optional. If not specified, default to now.
+    /// - Returns: An estimated duration, as TimeInterval, or an error.
+    func exportEstimatedDuration(startDate: Date, endDate: Date?) -> Result<TimeInterval, Error>
+
+    /// Export the critical event log for the specified date range.
+    ///
+    /// - Parameters:
+    ///   - startDate: The start date for the critical events to export.
+    ///   - endDate: The end date for the critical events to export.
+    ///   - stream: The output stream to write the critical event log to. Typically writes JSON UTF-8 text.
+    ///   - progressor: The estimated duration progress to use to check if cancelled and report progress.
+    /// - Returns: Any error that occurs during the export, or nil if successful.
+    func export(startDate: Date, endDate: Date, to stream: OutputStream, progressor: EstimatedDurationProgressor) -> Error?
+}
+
+public enum CriticalEventLogError: Error {
+
+    /// The export was cancelled either by the user or the OS.
+    case cancelled
+}
+
+public let criticalEventLogExportMinimumProgressDuration = TimeInterval(0.25)

--- a/LoopKit/DeviceManager/DeviceLog/DeviceLog.xcdatamodeld/DeviceCommsLog.xcdatamodel/contents
+++ b/LoopKit/DeviceManager/DeviceLog/DeviceLog.xcdatamodeld/DeviceCommsLog.xcdatamodel/contents
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="15400" systemVersion="19C57" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="16119" systemVersion="19G2021" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Entry" representedClassName=".DeviceLogEntry" syncable="YES">
         <attribute name="deviceIdentifier" optional="YES" attributeType="String"/>
         <attribute name="managerIdentifier" attributeType="String"/>
         <attribute name="message" attributeType="String"/>
+        <attribute name="modificationCounter" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="timestamp" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="type" attributeType="String"/>
+        <fetchIndex name="byTimestampIndex">
+            <fetchIndexElement property="timestamp" type="Binary" order="ascending"/>
+        </fetchIndex>
     </entity>
     <elements>
-        <element name="Entry" positionX="-36" positionY="9" width="128" height="118"/>
+        <element name="Entry" positionX="-36" positionY="9" width="128" height="133"/>
     </elements>
 </model>

--- a/LoopKit/DeviceManager/DeviceLog/DeviceLogEntry+CoreDataClass.swift
+++ b/LoopKit/DeviceManager/DeviceLog/DeviceLogEntry+CoreDataClass.swift
@@ -28,4 +28,19 @@ class DeviceLogEntry: NSManagedObject {
         }
     }
 
+    var hasUpdatedModificationCounter: Bool { changedValues().keys.contains("modificationCounter") }
+
+    func updateModificationCounter() { setPrimitiveValue(managedObjectContext!.modificationCounter!, forKey: "modificationCounter") }
+
+    override func awakeFromInsert() {
+        super.awakeFromInsert()
+        updateModificationCounter()
+    }
+
+    override func willSave() {
+        if isUpdated && !hasUpdatedModificationCounter {
+            updateModificationCounter()
+        }
+        super.willSave()
+    }
 }

--- a/LoopKit/DeviceManager/DeviceLog/DeviceLogEntry+CoreDataProperties.swift
+++ b/LoopKit/DeviceManager/DeviceLog/DeviceLogEntry+CoreDataProperties.swift
@@ -22,7 +22,29 @@ extension DeviceLogEntry {
     @NSManaged public var deviceIdentifier: String?
     @NSManaged public var message: String?
     @NSManaged public var timestamp: Date?
+    @NSManaged public var modificationCounter: Int64
 
+}
+
+extension DeviceLogEntry: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(type?.rawValue, forKey: .type)
+        try container.encodeIfPresent(managerIdentifier, forKey: .managerIdentifier)
+        try container.encodeIfPresent(deviceIdentifier, forKey: .deviceIdentifier)
+        try container.encodeIfPresent(message, forKey: .message)
+        try container.encodeIfPresent(timestamp, forKey: .timestamp)
+        try container.encode(modificationCounter, forKey: .modificationCounter)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case managerIdentifier
+        case deviceIdentifier
+        case message
+        case timestamp
+        case modificationCounter
+    }
 }
 
 extension DeviceLogEntry {

--- a/LoopKit/DeviceManager/DeviceLog/PersistentDeviceLog.swift
+++ b/LoopKit/DeviceManager/DeviceLog/PersistentDeviceLog.swift
@@ -117,6 +117,84 @@ public class PersistentDeviceLog {
     }
 }
 
+// MARK: - Critical Event Log Export
+
+extension PersistentDeviceLog: CriticalEventLog {
+    private var exportEstimatedDurationPerObject: TimeInterval { 0.0006 }   // Estimated during development on iPhone 8, absolute duration is less important than relative to other critical event logs
+    private var exportFetchLimit: Int { Int(criticalEventLogExportMinimumProgressDuration / exportEstimatedDurationPerObject) }
+
+    public var exportName: String { "DeviceLog.json" }
+
+    public func exportEstimatedDuration(startDate: Date, endDate: Date? = nil) -> Result<TimeInterval, Error> {
+        var result: Result<TimeInterval, Error>?
+
+        self.managedObjectContext.performAndWait {
+            do {
+                let request: NSFetchRequest<DeviceLogEntry> = DeviceLogEntry.fetchRequest()
+                request.predicate = self.exportDatePredicate(startDate: startDate, endDate: endDate)
+
+                let objectCount = try self.managedObjectContext.count(for: request)
+                result = .success(Double(objectCount) * exportEstimatedDurationPerObject)
+            } catch let error {
+                result = .failure(error)
+            }
+        }
+
+        return result!
+    }
+
+    public func export(startDate: Date, endDate: Date, to stream: OutputStream, progressor: EstimatedDurationProgressor) -> Error? {
+        let encoder = JSONStreamEncoder(stream: stream)
+        var modificationCounter: Int64 = 0
+        var fetching = true
+        var error: Error?
+
+        while fetching && error == nil {
+            self.managedObjectContext.performAndWait {
+                do {
+                    guard !progressor.isCancelled else {
+                        throw CriticalEventLogError.cancelled
+                    }
+
+                    let request: NSFetchRequest<DeviceLogEntry> = DeviceLogEntry.fetchRequest()
+                    request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [NSPredicate(format: "modificationCounter > %d", modificationCounter),
+                                                                                            self.exportDatePredicate(startDate: startDate, endDate: endDate)])
+                    request.sortDescriptors = [NSSortDescriptor(key: "modificationCounter", ascending: true)]
+                    request.fetchLimit = self.exportFetchLimit
+
+                    let objects = try self.managedObjectContext.fetch(request)
+                    if objects.isEmpty {
+                        fetching = false
+                        return
+                    }
+
+                    try encoder.encode(objects)
+
+                    modificationCounter = objects.last!.modificationCounter
+
+                    progressor.didProgress(for: Double(objects.count) * exportEstimatedDurationPerObject)
+                } catch let fetchError {
+                    error = fetchError
+                }
+            }
+        }
+
+        if let closeError = encoder.close(), error == nil {
+            error = closeError
+        }
+
+        return error
+    }
+
+    private func exportDatePredicate(startDate: Date, endDate: Date? = nil) -> NSPredicate {
+        var predicate = NSPredicate(format: "timestamp >= %@", startDate as NSDate)
+        if let endDate = endDate {
+            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, NSPredicate(format: "timestamp < %@", endDate as NSDate)])
+        }
+        return predicate
+    }
+}
+
 // MARK: - Core Data (Bulk) - TEST ONLY
 
 extension PersistentDeviceLog {

--- a/LoopKit/DeviceManager/DeviceLog/PersistentDeviceLog.swift
+++ b/LoopKit/DeviceManager/DeviceLog/PersistentDeviceLog.swift
@@ -120,13 +120,13 @@ public class PersistentDeviceLog {
 // MARK: - Critical Event Log Export
 
 extension PersistentDeviceLog: CriticalEventLog {
-    private var exportEstimatedDurationPerObject: TimeInterval { 0.0006 }   // Estimated during development on iPhone 8, absolute duration is less important than relative to other critical event logs
-    private var exportFetchLimit: Int { Int(criticalEventLogExportMinimumProgressDuration / exportEstimatedDurationPerObject) }
+    private var exportProgressUnitCountPerObject: Int64 { 1 }
+    private var exportFetchLimit: Int { Int(criticalEventLogExportProgressUnitCountPerFetch / exportProgressUnitCountPerObject) }
 
     public var exportName: String { "DeviceLog.json" }
 
-    public func exportEstimatedDuration(startDate: Date, endDate: Date? = nil) -> Result<TimeInterval, Error> {
-        var result: Result<TimeInterval, Error>?
+    public func exportProgressTotalUnitCount(startDate: Date, endDate: Date? = nil) -> Result<Int64, Error> {
+        var result: Result<Int64, Error>?
 
         self.managedObjectContext.performAndWait {
             do {
@@ -134,7 +134,7 @@ extension PersistentDeviceLog: CriticalEventLog {
                 request.predicate = self.exportDatePredicate(startDate: startDate, endDate: endDate)
 
                 let objectCount = try self.managedObjectContext.count(for: request)
-                result = .success(Double(objectCount) * exportEstimatedDurationPerObject)
+                result = .success(Int64(objectCount) * exportProgressUnitCountPerObject)
             } catch let error {
                 result = .failure(error)
             }
@@ -143,7 +143,7 @@ extension PersistentDeviceLog: CriticalEventLog {
         return result!
     }
 
-    public func export(startDate: Date, endDate: Date, to stream: OutputStream, progressor: EstimatedDurationProgressor) -> Error? {
+    public func export(startDate: Date, endDate: Date, to stream: OutputStream, progress: Progress) -> Error? {
         let encoder = JSONStreamEncoder(stream: stream)
         var modificationCounter: Int64 = 0
         var fetching = true
@@ -152,7 +152,7 @@ extension PersistentDeviceLog: CriticalEventLog {
         while fetching && error == nil {
             self.managedObjectContext.performAndWait {
                 do {
-                    guard !progressor.isCancelled else {
+                    guard !progress.isCancelled else {
                         throw CriticalEventLogError.cancelled
                     }
 
@@ -172,7 +172,7 @@ extension PersistentDeviceLog: CriticalEventLog {
 
                     modificationCounter = objects.last!.modificationCounter
 
-                    progressor.didProgress(for: Double(objects.count) * exportEstimatedDurationPerObject)
+                    progress.completedUnitCount += Int64(objects.count) * exportProgressUnitCountPerObject
                 } catch let fetchError {
                     error = fetchError
                 }

--- a/LoopKit/DeviceManager/PumpManagerStatus.swift
+++ b/LoopKit/DeviceManager/PumpManagerStatus.swift
@@ -98,8 +98,8 @@ extension PumpManagerStatus: Codable {
         self.pumpBatteryChargeRemaining = try container.decodeIfPresent(Double.self, forKey: .pumpBatteryChargeRemaining)
         self.basalDeliveryState = try container.decode(BasalDeliveryState.self, forKey: .basalDeliveryState)
         self.bolusState = try container.decode(BolusState.self, forKey: .bolusState)
-        self.pumpStatusHighlight = try container.decode(PumpStatusHighlight.self, forKey: .pumpStatusHighlight)
-        self.pumpLifecycleProgress = try container.decode(PumpLifecycleProgress.self, forKey: .pumpLifecycleProgress)
+        self.pumpStatusHighlight = try container.decodeIfPresent(PumpStatusHighlight.self, forKey: .pumpStatusHighlight)
+        self.pumpLifecycleProgress = try container.decodeIfPresent(PumpLifecycleProgress.self, forKey: .pumpLifecycleProgress)
         self.deliveryIsUncertain = try container.decode(Bool.self, forKey: .deliveryIsUncertain)
     }
 
@@ -110,8 +110,8 @@ extension PumpManagerStatus: Codable {
         try container.encodeIfPresent(pumpBatteryChargeRemaining, forKey: .pumpBatteryChargeRemaining)
         try container.encode(basalDeliveryState, forKey: .basalDeliveryState)
         try container.encode(bolusState, forKey: .bolusState)
-        try container.encode(pumpStatusHighlight, forKey: .pumpStatusHighlight)
-        try container.encode(pumpLifecycleProgress, forKey: .pumpLifecycleProgress)
+        try container.encodeIfPresent(pumpStatusHighlight, forKey: .pumpStatusHighlight)
+        try container.encodeIfPresent(pumpLifecycleProgress, forKey: .pumpLifecycleProgress)
         try container.encode(deliveryIsUncertain, forKey: .deliveryIsUncertain)
     }
 

--- a/LoopKit/DosingDecisionObject+CoreDataClass.swift
+++ b/LoopKit/DosingDecisionObject+CoreDataClass.swift
@@ -8,17 +8,17 @@
 
 import CoreData
 
-class DosingDecisionObject: NSManagedObject {
+public class DosingDecisionObject: NSManagedObject {
     var hasUpdatedModificationCounter: Bool { changedValues().keys.contains("modificationCounter") }
 
     func updateModificationCounter() { setPrimitiveValue(managedObjectContext!.modificationCounter!, forKey: "modificationCounter") }
 
-    override func awakeFromInsert() {
+    public override func awakeFromInsert() {
         super.awakeFromInsert()
         updateModificationCounter()
     }
 
-    override func willSave() {
+    public override func willSave() {
         if isUpdated && !hasUpdatedModificationCounter {
             updateModificationCounter()
         }

--- a/LoopKit/DosingDecisionStore.swift
+++ b/LoopKit/DosingDecisionStore.swift
@@ -9,7 +9,6 @@
 import os.log
 import Foundation
 import CoreData
-import UserNotifications
 
 public protocol DosingDecisionStoreDelegate: AnyObject {
     /**
@@ -234,130 +233,6 @@ public struct StoredDosingDecision {
         public init(recommendation: BolusRecommendation, date: Date) {
             self.recommendation = recommendation
             self.date = date
-        }
-    }
-
-    public struct NotificationSettings: Codable, Equatable {
-        public enum AuthorizationStatus: String, Codable {
-            case notDetermined
-            case denied
-            case authorized
-            case provisional
-            case unknown
-
-            public init(_ authorizationStatus: UNAuthorizationStatus) {
-                switch authorizationStatus {
-                case .notDetermined:
-                    self = .notDetermined
-                case .denied:
-                    self = .denied
-                case .authorized:
-                    self = .authorized
-                case .provisional:
-                    self = .provisional
-                @unknown default:
-                    self = .unknown
-                }
-            }
-        }
-
-        public enum NotificationSetting: String, Codable {
-            case notSupported
-            case disabled
-            case enabled
-            case unknown
-
-            public init(_ notificationSetting: UNNotificationSetting) {
-                switch notificationSetting {
-                case .notSupported:
-                    self = .notSupported
-                case .disabled:
-                    self = .disabled
-                case .enabled:
-                    self = .enabled
-                @unknown default:
-                    self = .unknown
-                }
-            }
-        }
-
-        public enum AlertStyle: String, Codable {
-            case none
-            case banner
-            case alert
-            case unknown
-
-            public init(_ alertStyle: UNAlertStyle) {
-                switch alertStyle {
-                case .none:
-                    self = .none
-                case .banner:
-                    self = .banner
-                case .alert:
-                    self = .alert
-                @unknown default:
-                    self = .unknown
-                }
-            }
-        }
-
-        public enum ShowPreviewsSetting: String, Codable {
-            case always
-            case whenAuthenticated
-            case never
-            case unknown
-
-            public init(_ showPreviewsSetting: UNShowPreviewsSetting) {
-                switch showPreviewsSetting {
-                case .always:
-                    self = .always
-                case .whenAuthenticated:
-                    self = .whenAuthenticated
-                case .never:
-                    self = .never
-                @unknown default:
-                    self = .unknown
-                }
-            }
-        }
-
-        public let authorizationStatus: AuthorizationStatus
-        public let soundSetting: NotificationSetting
-        public let badgeSetting: NotificationSetting
-        public let alertSetting: NotificationSetting
-        public let notificationCenterSetting: NotificationSetting
-        public let lockScreenSetting: NotificationSetting
-        public let carPlaySetting: NotificationSetting
-        public let alertStyle: AlertStyle
-        public let showPreviewsSetting: ShowPreviewsSetting
-        public let criticalAlertSetting: NotificationSetting
-        public let providesAppNotificationSettings: Bool
-        public let announcementSetting: NotificationSetting
-
-        public init(authorizationStatus: AuthorizationStatus,
-                    soundSetting: NotificationSetting,
-                    badgeSetting: NotificationSetting,
-                    alertSetting: NotificationSetting,
-                    notificationCenterSetting: NotificationSetting,
-                    lockScreenSetting: NotificationSetting,
-                    carPlaySetting: NotificationSetting,
-                    alertStyle: AlertStyle,
-                    showPreviewsSetting: ShowPreviewsSetting,
-                    criticalAlertSetting: NotificationSetting,
-                    providesAppNotificationSettings: Bool,
-                    announcementSetting: NotificationSetting) {
-            self.authorizationStatus = authorizationStatus
-            self.soundSetting = soundSetting
-            self.badgeSetting = badgeSetting
-            self.alertSetting = alertSetting
-            self.notificationCenterSetting = notificationCenterSetting
-            self.lockScreenSetting = lockScreenSetting
-            self.carPlaySetting = carPlaySetting
-            self.alertStyle = alertStyle
-            self.showPreviewsSetting = showPreviewsSetting
-            self.criticalAlertSetting = criticalAlertSetting
-            self.providesAppNotificationSettings = providesAppNotificationSettings
-            self.announcementSetting = announcementSetting
         }
     }
 

--- a/LoopKit/Extensions/OutputStream.swift
+++ b/LoopKit/Extensions/OutputStream.swift
@@ -1,0 +1,40 @@
+//
+//  OutputStream.swift
+//  LoopKit
+//
+//  Created by Darin Krauss on 8/28/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+
+extension OutputStream {
+    func write(_ string: String) throws {
+        if let streamError = streamError {
+            throw streamError
+        }
+        let bytes = [UInt8](string.utf8)
+        write(bytes, maxLength: bytes.count)
+        if let streamError = streamError {
+            throw streamError
+        }
+    }
+
+    func write(_ data: Data) throws {
+        if let streamError = streamError {
+            throw streamError
+        }
+        if data.isEmpty {
+            return
+        }
+        _ = data.withUnsafeBytes { (unsafeRawBuffer: UnsafeRawBufferPointer) -> UInt8 in
+            if let unsafe = unsafeRawBuffer.baseAddress?.assumingMemoryBound(to: UInt8.self) {
+                write(unsafe, maxLength: unsafeRawBuffer.count)
+            }
+            return 0
+        }
+        if let streamError = streamError {
+            throw streamError
+        }
+    }
+}

--- a/LoopKit/GlucoseKit/CachedGlucoseObject+CoreDataProperties.swift
+++ b/LoopKit/GlucoseKit/CachedGlucoseObject+CoreDataProperties.swift
@@ -29,3 +29,34 @@ extension CachedGlucoseObject {
     @NSManaged public var modificationCounter: Int64
 
 }
+
+extension CachedGlucoseObject: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encodeIfPresent(syncIdentifier, forKey: .syncIdentifier)
+        try container.encode(syncVersion, forKey: .syncVersion)
+        try container.encode(uploadState.rawValue, forKey: .uploadState)
+        try container.encode(value, forKey: .value)
+        try container.encodeIfPresent(unitString, forKey: .unitString)
+        try container.encode(startDate, forKey: .startDate)
+        try container.encodeIfPresent(provenanceIdentifier, forKey: .provenanceIdentifier)
+        try container.encode(isDisplayOnly, forKey: .isDisplayOnly)
+        try container.encode(wasUserEntered, forKey: .wasUserEntered)
+        try container.encode(modificationCounter, forKey: .modificationCounter)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case uuid
+        case syncIdentifier
+        case syncVersion
+        case uploadState
+        case value
+        case unitString
+        case startDate
+        case provenanceIdentifier
+        case isDisplayOnly
+        case wasUserEntered
+        case modificationCounter
+    }
+}

--- a/LoopKit/GlucoseKit/GlucoseStore.swift
+++ b/LoopKit/GlucoseKit/GlucoseStore.swift
@@ -771,6 +771,84 @@ extension NSManagedObjectContext {
     }
 }
 
+// MARK: - Critical Event Log Export
+
+extension GlucoseStore: CriticalEventLog {
+    private var exportEstimatedDurationPerObject: TimeInterval { 0.0004 }   // Estimated during development on iPhone 8, absolute duration is less important than relative to other critical event logs
+    private var exportFetchLimit: Int { Int(criticalEventLogExportMinimumProgressDuration / exportEstimatedDurationPerObject) }
+
+    public var exportName: String { "Glucoses.json" }
+
+    public func exportEstimatedDuration(startDate: Date, endDate: Date? = nil) -> Result<TimeInterval, Error> {
+        var result: Result<TimeInterval, Error>?
+
+        self.cacheStore.managedObjectContext.performAndWait {
+            do {
+                let request: NSFetchRequest<CachedGlucoseObject> = CachedGlucoseObject.fetchRequest()
+                request.predicate = self.exportDatePredicate(startDate: startDate, endDate: endDate)
+
+                let objectCount = try self.cacheStore.managedObjectContext.count(for: request)
+                result = .success(Double(objectCount) * exportEstimatedDurationPerObject)
+            } catch let error {
+                result = .failure(error)
+            }
+        }
+
+        return result!
+    }
+
+    public func export(startDate: Date, endDate: Date, to stream: OutputStream, progressor: EstimatedDurationProgressor) -> Error? {
+        let encoder = JSONStreamEncoder(stream: stream)
+        var modificationCounter: Int64 = 0
+        var fetching = true
+        var error: Error?
+
+        while fetching && error == nil {
+            self.cacheStore.managedObjectContext.performAndWait {
+                do {
+                    guard !progressor.isCancelled else {
+                        throw CriticalEventLogError.cancelled
+                    }
+
+                    let request: NSFetchRequest<CachedGlucoseObject> = CachedGlucoseObject.fetchRequest()
+                    request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [NSPredicate(format: "modificationCounter > %d", modificationCounter),
+                                                                                            self.exportDatePredicate(startDate: startDate, endDate: endDate)])
+                    request.sortDescriptors = [NSSortDescriptor(key: "modificationCounter", ascending: true)]
+                    request.fetchLimit = self.exportFetchLimit
+
+                    let objects = try self.cacheStore.managedObjectContext.fetch(request)
+                    if objects.isEmpty {
+                        fetching = false
+                        return
+                    }
+
+                    try encoder.encode(objects)
+
+                    modificationCounter = objects.last!.modificationCounter
+
+                    progressor.didProgress(for: Double(objects.count) * exportEstimatedDurationPerObject)
+                } catch let fetchError {
+                    error = fetchError
+                }
+            }
+        }
+
+        if let closeError = encoder.close(), error == nil {
+            error = closeError
+        }
+
+        return error
+    }
+
+    private func exportDatePredicate(startDate: Date, endDate: Date? = nil) -> NSPredicate {
+        var predicate = NSPredicate(format: "startDate >= %@", startDate as NSDate)
+        if let endDate = endDate {
+            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, NSPredicate(format: "startDate < %@", endDate as NSDate)])
+        }
+        return predicate
+    }
+}
+
 // MARK: - Core Data (Bulk) - TEST ONLY
 
 extension GlucoseStore {

--- a/LoopKit/GlucoseKit/GlucoseStore.swift
+++ b/LoopKit/GlucoseKit/GlucoseStore.swift
@@ -774,13 +774,13 @@ extension NSManagedObjectContext {
 // MARK: - Critical Event Log Export
 
 extension GlucoseStore: CriticalEventLog {
-    private var exportEstimatedDurationPerObject: TimeInterval { 0.0004 }   // Estimated during development on iPhone 8, absolute duration is less important than relative to other critical event logs
-    private var exportFetchLimit: Int { Int(criticalEventLogExportMinimumProgressDuration / exportEstimatedDurationPerObject) }
+    private var exportProgressUnitCountPerObject: Int64 { 1 }
+    private var exportFetchLimit: Int { Int(criticalEventLogExportProgressUnitCountPerFetch / exportProgressUnitCountPerObject) }
 
     public var exportName: String { "Glucoses.json" }
 
-    public func exportEstimatedDuration(startDate: Date, endDate: Date? = nil) -> Result<TimeInterval, Error> {
-        var result: Result<TimeInterval, Error>?
+    public func exportProgressTotalUnitCount(startDate: Date, endDate: Date? = nil) -> Result<Int64, Error> {
+        var result: Result<Int64, Error>?
 
         self.cacheStore.managedObjectContext.performAndWait {
             do {
@@ -788,7 +788,7 @@ extension GlucoseStore: CriticalEventLog {
                 request.predicate = self.exportDatePredicate(startDate: startDate, endDate: endDate)
 
                 let objectCount = try self.cacheStore.managedObjectContext.count(for: request)
-                result = .success(Double(objectCount) * exportEstimatedDurationPerObject)
+                result = .success(Int64(objectCount) * exportProgressUnitCountPerObject)
             } catch let error {
                 result = .failure(error)
             }
@@ -797,7 +797,7 @@ extension GlucoseStore: CriticalEventLog {
         return result!
     }
 
-    public func export(startDate: Date, endDate: Date, to stream: OutputStream, progressor: EstimatedDurationProgressor) -> Error? {
+    public func export(startDate: Date, endDate: Date, to stream: OutputStream, progress: Progress) -> Error? {
         let encoder = JSONStreamEncoder(stream: stream)
         var modificationCounter: Int64 = 0
         var fetching = true
@@ -806,7 +806,7 @@ extension GlucoseStore: CriticalEventLog {
         while fetching && error == nil {
             self.cacheStore.managedObjectContext.performAndWait {
                 do {
-                    guard !progressor.isCancelled else {
+                    guard !progress.isCancelled else {
                         throw CriticalEventLogError.cancelled
                     }
 
@@ -826,7 +826,7 @@ extension GlucoseStore: CriticalEventLog {
 
                     modificationCounter = objects.last!.modificationCounter
 
-                    progressor.didProgress(for: Double(objects.count) * exportEstimatedDurationPerObject)
+                    progress.completedUnitCount += Int64(objects.count) * exportProgressUnitCountPerObject
                 } catch let fetchError {
                     error = fetchError
                 }

--- a/LoopKit/Insulin/InsulinModelSettings.swift
+++ b/LoopKit/Insulin/InsulinModelSettings.swift
@@ -118,7 +118,7 @@ extension InsulinModelSettings: RawRepresentable {
 }
 
 public extension InsulinModelSettings {
-    init(from storedSettingsInsulinModel: StoredSettings.InsulinModel) {
+    init(from storedSettingsInsulinModel: StoredInsulinModel) {
         switch storedSettingsInsulinModel.modelType {
         case .fiasp:
             self = .exponentialPreset(.fiasp)
@@ -132,9 +132,9 @@ public extension InsulinModelSettings {
     }
 }
 
-public extension StoredSettings.InsulinModel {
+public extension StoredInsulinModel {
     init(_ insulinModelSettings: InsulinModelSettings) {       
-        var modelType: StoredSettings.InsulinModel.ModelType
+        var modelType: StoredInsulinModel.ModelType
         var actionDuration: TimeInterval
         var peakActivity: TimeInterval?
         

--- a/LoopKit/InsulinKit/PumpEvent+CoreDataProperties.swift
+++ b/LoopKit/InsulinKit/PumpEvent+CoreDataProperties.swift
@@ -31,3 +31,38 @@ extension PumpEvent {
     @NSManaged var modificationCounter: Int64
 
 }
+
+extension PumpEvent: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(createdAt, forKey: .createdAt)
+        try container.encode(date, forKey: .date)
+        try container.encodeIfPresent(doseType?.rawValue, forKey: .doseType)
+        try container.encode(duration, forKey: .duration)
+        try container.encodeIfPresent(type?.rawValue, forKey: .type)
+        try container.encodeIfPresent(unit?.rawValue, forKey: .unit)
+        try container.encode(uploaded, forKey: .uploaded)
+        try container.encodeIfPresent(value, forKey: .value)
+        try container.encodeIfPresent(deliveredUnits, forKey: .deliveredUnits)
+        try container.encode(mutable, forKey: .mutable)
+        try container.encodeIfPresent(raw?.base64EncodedString(), forKey: .raw)
+        try container.encodeIfPresent(title, forKey: .title)
+        try container.encode(modificationCounter, forKey: .modificationCounter)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case createdAt
+        case date
+        case doseType
+        case duration
+        case type
+        case unit
+        case uploaded
+        case value
+        case deliveredUnits
+        case mutable
+        case raw
+        case title
+        case modificationCounter
+    }
+}

--- a/LoopKit/JSONStreamEncoder.swift
+++ b/LoopKit/JSONStreamEncoder.swift
@@ -1,0 +1,73 @@
+//
+//  JSONStreamEncoder.swift
+//  LoopKit
+//
+//  Created by Darin Krauss on 6/25/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+
+public enum JSONStreamEncoderError: Error {
+    case encoderClosed
+}
+
+public class JSONStreamEncoder {
+    private let stream: OutputStream
+    private var encoded: Bool
+    private var closed: Bool
+
+    public init(stream: OutputStream) {
+        self.stream = stream
+        self.encoded = false
+        self.closed = false
+    }
+
+    public func close() -> Error? {
+        guard !closed else {
+            return nil
+        }
+
+        self.closed = true
+
+        do {
+            try stream.write(encoded ? "\n]" : "[]")
+        } catch let error {
+            return error
+        }
+
+        return nil
+    }
+
+    public func encode<T>(_ values: T) throws where T: Collection, T.Element: Encodable {
+        guard !closed else {
+            throw JSONStreamEncoderError.encoderClosed
+        }
+
+        for value in values {
+            try stream.write(encoded ? ",\n" : "[\n")
+            try stream.write(try Self.encoder.encode(value))
+            encoded = true
+        }
+    }
+
+    private static var encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        if #available(watchOSApplicationExtension 6.0, *) {
+            encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        } else {
+            encoder.outputFormatting = [.sortedKeys]
+        }
+        encoder.dateEncodingStrategy = .custom { (date, encoder) in
+            var encoder = encoder.singleValueContainer()
+            try encoder.encode(dateFormatter.string(from: date))
+        }
+        return encoder
+    }()
+
+    private static let dateFormatter: ISO8601DateFormatter = {
+        var dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return dateFormatter
+    }()
+}

--- a/LoopKit/NotificationSettings.swift
+++ b/LoopKit/NotificationSettings.swift
@@ -1,0 +1,135 @@
+//
+//  NotificationSettings.swift
+//  LoopKit
+//
+//  Created by Darin Krauss on 9/17/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+import UserNotifications
+
+public struct NotificationSettings: Codable, Equatable {
+    public enum AuthorizationStatus: String, Codable {
+        case notDetermined
+        case denied
+        case authorized
+        case provisional
+        case unknown
+
+        public init(_ authorizationStatus: UNAuthorizationStatus) {
+            switch authorizationStatus {
+            case .notDetermined:
+                self = .notDetermined
+            case .denied:
+                self = .denied
+            case .authorized:
+                self = .authorized
+            case .provisional:
+                self = .provisional
+            @unknown default:
+                self = .unknown
+            }
+        }
+    }
+
+    public enum NotificationSetting: String, Codable {
+        case notSupported
+        case disabled
+        case enabled
+        case unknown
+
+        public init(_ notificationSetting: UNNotificationSetting) {
+            switch notificationSetting {
+            case .notSupported:
+                self = .notSupported
+            case .disabled:
+                self = .disabled
+            case .enabled:
+                self = .enabled
+            @unknown default:
+                self = .unknown
+            }
+        }
+    }
+
+    public enum AlertStyle: String, Codable {
+        case none
+        case banner
+        case alert
+        case unknown
+
+        public init(_ alertStyle: UNAlertStyle) {
+            switch alertStyle {
+            case .none:
+                self = .none
+            case .banner:
+                self = .banner
+            case .alert:
+                self = .alert
+            @unknown default:
+                self = .unknown
+            }
+        }
+    }
+
+    public enum ShowPreviewsSetting: String, Codable {
+        case always
+        case whenAuthenticated
+        case never
+        case unknown
+
+        public init(_ showPreviewsSetting: UNShowPreviewsSetting) {
+            switch showPreviewsSetting {
+            case .always:
+                self = .always
+            case .whenAuthenticated:
+                self = .whenAuthenticated
+            case .never:
+                self = .never
+            @unknown default:
+                self = .unknown
+            }
+        }
+    }
+
+    public let authorizationStatus: AuthorizationStatus
+    public let soundSetting: NotificationSetting
+    public let badgeSetting: NotificationSetting
+    public let alertSetting: NotificationSetting
+    public let notificationCenterSetting: NotificationSetting
+    public let lockScreenSetting: NotificationSetting
+    public let carPlaySetting: NotificationSetting
+    public let alertStyle: AlertStyle
+    public let showPreviewsSetting: ShowPreviewsSetting
+    public let criticalAlertSetting: NotificationSetting
+    public let providesAppNotificationSettings: Bool
+    public let announcementSetting: NotificationSetting
+
+    public init(authorizationStatus: AuthorizationStatus,
+                soundSetting: NotificationSetting,
+                badgeSetting: NotificationSetting,
+                alertSetting: NotificationSetting,
+                notificationCenterSetting: NotificationSetting,
+                lockScreenSetting: NotificationSetting,
+                carPlaySetting: NotificationSetting,
+                alertStyle: AlertStyle,
+                showPreviewsSetting: ShowPreviewsSetting,
+                criticalAlertSetting: NotificationSetting,
+                providesAppNotificationSettings: Bool,
+                announcementSetting: NotificationSetting) {
+        self.authorizationStatus = authorizationStatus
+        self.soundSetting = soundSetting
+        self.badgeSetting = badgeSetting
+        self.alertSetting = alertSetting
+        self.notificationCenterSetting = notificationCenterSetting
+        self.lockScreenSetting = lockScreenSetting
+        self.carPlaySetting = carPlaySetting
+        self.alertStyle = alertStyle
+        self.showPreviewsSetting = showPreviewsSetting
+        self.criticalAlertSetting = criticalAlertSetting
+        self.providesAppNotificationSettings = providesAppNotificationSettings
+        self.announcementSetting = announcementSetting
+    }
+}
+

--- a/LoopKit/Persistence/Model.xcdatamodeld/Modelv3.xcdatamodel/contents
+++ b/LoopKit/Persistence/Model.xcdatamodeld/Modelv3.xcdatamodel/contents
@@ -86,6 +86,9 @@
         <attribute name="data" attributeType="Binary"/>
         <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="modificationCounter" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <fetchIndex name="byDateIndex">
+            <fetchIndexElement property="date" type="Binary" order="ascending"/>
+        </fetchIndex>
     </entity>
     <entity name="PumpEvent" representedClassName=".PumpEvent" syncable="YES">
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>

--- a/LoopKit/SettingsObject+CoreDataProperties.swift
+++ b/LoopKit/SettingsObject+CoreDataProperties.swift
@@ -18,3 +18,21 @@ extension SettingsObject {
     @NSManaged public var date: Date
     @NSManaged public var modificationCounter: Int64
 }
+
+extension SettingsObject: Encodable {
+    func encode(to encoder: Encoder) throws {
+        try EncodableSettingsObject(self).encode(to: encoder)
+    }
+}
+
+fileprivate struct EncodableSettingsObject: Encodable {
+    var data: StoredSettings
+    var date: Date
+    var modificationCounter: Int64
+
+    init(_ object: SettingsObject) throws {
+        self.data = try PropertyListDecoder().decode(StoredSettings.self, from: object.data)
+        self.date = object.date
+        self.modificationCounter = object.modificationCounter
+    }
+}

--- a/LoopKit/SettingsStore.swift
+++ b/LoopKit/SettingsStore.swift
@@ -187,7 +187,7 @@ public struct StoredSettings {
     public let maximumBolus: Double?
     public let suspendThreshold: GlucoseThreshold?
     public let deviceToken: String?
-    public let insulinModel: InsulinModel?
+    public let insulinModel: StoredInsulinModel?
     public let basalRateSchedule: BasalRateSchedule?
     public let insulinSensitivitySchedule: InsulinSensitivitySchedule?
     public let carbRatioSchedule: CarbRatioSchedule?
@@ -206,7 +206,7 @@ public struct StoredSettings {
                 maximumBolus: Double? = nil,
                 suspendThreshold: GlucoseThreshold? = nil,
                 deviceToken: String? = nil,
-                insulinModel: InsulinModel? = nil,
+                insulinModel: StoredInsulinModel? = nil,
                 basalRateSchedule: BasalRateSchedule? = nil,
                 insulinSensitivitySchedule: InsulinSensitivitySchedule? = nil,
                 carbRatioSchedule: CarbRatioSchedule? = nil,
@@ -231,25 +231,6 @@ public struct StoredSettings {
         self.bloodGlucoseUnit = bloodGlucoseUnit
         self.syncIdentifier = syncIdentifier
     }
-
-    public struct InsulinModel: Codable, Equatable {
-        public enum ModelType: String, Codable {
-            case fiasp
-            case rapidAdult
-            case rapidChild
-            case walsh
-        }
-        
-        public let modelType: ModelType
-        public let actionDuration: TimeInterval
-        public let peakActivity: TimeInterval?
-
-        public init(modelType: ModelType, actionDuration: TimeInterval, peakActivity: TimeInterval? = nil) {
-            self.modelType = modelType
-            self.actionDuration = actionDuration
-            self.peakActivity = peakActivity
-        }
-    }
 }
 
 extension StoredSettings: Codable {
@@ -271,7 +252,7 @@ extension StoredSettings: Codable {
                   maximumBolus: try container.decodeIfPresent(Double.self, forKey: .maximumBolus),
                   suspendThreshold: try container.decodeIfPresent(GlucoseThreshold.self, forKey: .suspendThreshold),
                   deviceToken: try container.decodeIfPresent(String.self, forKey: .deviceToken),
-                  insulinModel: try container.decodeIfPresent(InsulinModel.self, forKey: .insulinModel),
+                  insulinModel: try container.decodeIfPresent(StoredInsulinModel.self, forKey: .insulinModel),
                   basalRateSchedule: try container.decodeIfPresent(BasalRateSchedule.self, forKey: .basalRateSchedule),
                   insulinSensitivitySchedule: try container.decodeIfPresent(InsulinSensitivitySchedule.self, forKey: .insulinSensitivitySchedule),
                   carbRatioSchedule: try container.decodeIfPresent(CarbRatioSchedule.self, forKey: .carbRatioSchedule),
@@ -320,6 +301,84 @@ extension StoredSettings: Codable {
         case carbRatioSchedule
         case bloodGlucoseUnit
         case syncIdentifier
+    }
+}
+
+// MARK: - Critical Event Log Export
+
+extension SettingsStore: CriticalEventLog {
+    private var exportEstimatedDurationPerObject: TimeInterval { 0.0108 }   // Estimated during development on iPhone 8, absolute duration is less important than relative to other critical event logs
+    private var exportFetchLimit: Int { Int(criticalEventLogExportMinimumProgressDuration / exportEstimatedDurationPerObject) }
+
+    public var exportName: String { "Settings.json" }
+
+    public func exportEstimatedDuration(startDate: Date, endDate: Date? = nil) -> Result<TimeInterval, Error> {
+        var result: Result<TimeInterval, Error>?
+
+        self.store.managedObjectContext.performAndWait {
+            do {
+                let request: NSFetchRequest<SettingsObject> = SettingsObject.fetchRequest()
+                request.predicate = self.exportDatePredicate(startDate: startDate, endDate: endDate)
+
+                let objectCount = try self.store.managedObjectContext.count(for: request)
+                result = .success(Double(objectCount) * exportEstimatedDurationPerObject)
+            } catch let error {
+                result = .failure(error)
+            }
+        }
+
+        return result!
+    }
+
+    public func export(startDate: Date, endDate: Date, to stream: OutputStream, progressor: EstimatedDurationProgressor) -> Error? {
+        let encoder = JSONStreamEncoder(stream: stream)
+        var modificationCounter: Int64 = 0
+        var fetching = true
+        var error: Error?
+
+        while fetching && error == nil {
+            self.store.managedObjectContext.performAndWait {
+                do {
+                    guard !progressor.isCancelled else {
+                        throw CriticalEventLogError.cancelled
+                    }
+
+                    let request: NSFetchRequest<SettingsObject> = SettingsObject.fetchRequest()
+                    request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [NSPredicate(format: "modificationCounter > %d", modificationCounter),
+                                                                                            self.exportDatePredicate(startDate: startDate, endDate: endDate)])
+                    request.sortDescriptors = [NSSortDescriptor(key: "modificationCounter", ascending: true)]
+                    request.fetchLimit = self.exportFetchLimit
+
+                    let objects = try self.store.managedObjectContext.fetch(request)
+                    if objects.isEmpty {
+                        fetching = false
+                        return
+                    }
+
+                    try encoder.encode(objects)
+
+                    modificationCounter = objects.last!.modificationCounter
+
+                    progressor.didProgress(for: Double(objects.count) * exportEstimatedDurationPerObject)
+                } catch let fetchError {
+                    error = fetchError
+                }
+            }
+        }
+
+        if let closeError = encoder.close(), error == nil {
+            error = closeError
+        }
+
+        return error
+    }
+
+    private func exportDatePredicate(startDate: Date, endDate: Date? = nil) -> NSPredicate {
+        var predicate = NSPredicate(format: "date >= %@", startDate as NSDate)
+        if let endDate = endDate {
+            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, NSPredicate(format: "date < %@", endDate as NSDate)])
+        }
+        return predicate
     }
 }
 

--- a/LoopKit/StoredInsulinModel.swift
+++ b/LoopKit/StoredInsulinModel.swift
@@ -1,0 +1,28 @@
+//
+//  StoredInsulinModel.swift
+//  LoopKit
+//
+//  Created by Darin Krauss on 7/23/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+
+public struct StoredInsulinModel: Codable, Equatable {
+    public enum ModelType: String, Codable {
+        case fiasp
+        case rapidAdult
+        case rapidChild
+        case walsh
+    }
+
+    public let modelType: ModelType
+    public let actionDuration: TimeInterval
+    public let peakActivity: TimeInterval?
+
+    public init(modelType: ModelType, actionDuration: TimeInterval, peakActivity: TimeInterval? = nil) {
+        self.modelType = modelType
+        self.actionDuration = actionDuration
+        self.peakActivity = peakActivity
+    }
+}

--- a/LoopKitTests/CarbStoreTests.swift
+++ b/LoopKitTests/CarbStoreTests.swift
@@ -67,8 +67,8 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                                 self.carbStore.getCarbEntries(start: Date().addingTimeInterval(-.minutes(1))) { result in
                                     getCarbEntriesCompletion.fulfill()
                                     switch result {
-                                    case .failure:
-                                        XCTFail("Unexpected failure")
+                                    case .failure(let error):
+                                        XCTFail("Unexpected failure: \(error)")
                                     case .success(let entries):
                                         XCTAssertEqual(entries.count, 3)
 
@@ -188,8 +188,8 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                         carbStore.getCarbEntries(start: Date().addingTimeInterval(-.minutes(1))) { result in
                             getCarbEntriesCompletion.fulfill()
                             switch result {
-                            case .failure:
-                                XCTFail("Unexpected failure")
+                            case .failure(let error):
+                                XCTFail("Unexpected failure: \(error)")
                             case .success(let entries):
                                 XCTAssertEqual(entries.count, 1)
 
@@ -357,8 +357,8 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                         carbStore.getCarbEntries(start: Date().addingTimeInterval(-.minutes(1))) { result in
                             getCarbEntriesCompletion.fulfill()
                             switch result {
-                            case .failure:
-                                XCTFail("Unexpected failure")
+                            case .failure(let error):
+                                XCTFail("Unexpected failure: \(error)")
                             case .success(let entries):
                                 XCTAssertEqual(entries.count, 1)
 
@@ -513,8 +513,8 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                         carbStore.getCarbEntries(start: Date().addingTimeInterval(-.minutes(1))) { result in
                             getCarbEntriesCompletion.fulfill()
                             switch result {
-                            case .failure:
-                                XCTFail("Unexpected failure")
+                            case .failure(let error):
+                                XCTFail("Unexpected failure: \(error)")
                             case .success(let entries):
                                 XCTAssertEqual(entries.count, 0)
                             }
@@ -745,8 +745,8 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                         carbStore.getCarbEntries(start: Date().addingTimeInterval(-.minutes(1))) { result in
                             getCarbEntriesCompletion.fulfill()
                             switch result {
-                            case .failure:
-                                XCTFail("Unexpected failure")
+                            case .failure(let error):
+                                XCTFail("Unexpected failure: \(error)")
                             case .success(let entries):
                                 XCTAssertEqual(entries.count, 0)
                             }
@@ -783,8 +783,8 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                                 self.carbStore.getSyncCarbObjects(start: Date().addingTimeInterval(-.minutes(1))) { result in
                                     getSyncCarbObjectsCompletion.fulfill()
                                     switch result {
-                                    case .failure:
-                                        XCTFail("Unexpected failure")
+                                    case .failure(let error):
+                                        XCTFail("Unexpected failure: \(error)")
                                     case .success(let objects):
                                         XCTAssertEqual(objects.count, 3)
 
@@ -909,8 +909,8 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
                         self.carbStore.getCarbEntries(start: Date().addingTimeInterval(-.minutes(1))) { result in
                             getCarbEntriesCompletion.fulfill()
                             switch result {
-                            case .failure:
-                                XCTFail("Unexpected failure")
+                            case .failure(let error):
+                                XCTFail("Unexpected failure: \(error)")
                             case .success(let entries):
                                 XCTAssertEqual(entries.count, 3)
                                 for index in 0..<3 {
@@ -1233,4 +1233,100 @@ class CarbStoreQueryTests: PersistenceControllerTestCase {
         return UUID().uuidString
     }
     
+}
+
+class CarbStoreCriticalEventLogTests: PersistenceControllerTestCase {
+    var carbStore: CarbStore!
+    var outputStream: MockOutputStream!
+    var progressor: MockEstimatedDurationProgressor!
+
+    override func setUp() {
+        super.setUp()
+
+        let objects = [SyncCarbObject(absorptionTime: nil, createdByCurrentApp: true, foodType: nil, grams: 11, startDate: dateFormatter.date(from: "2100-01-02T03:08:00Z")!, uuid: nil, provenanceIdentifier: nil, syncIdentifier: nil, syncVersion: nil, userCreatedDate: nil, userUpdatedDate: nil, userDeletedDate: nil, operation: .create, addedDate: dateFormatter.date(from: "2100-01-02T03:08:00Z")!, supercededDate: nil),
+                       SyncCarbObject(absorptionTime: nil, createdByCurrentApp: true, foodType: nil, grams: 12, startDate: dateFormatter.date(from: "2100-01-02T03:10:00Z")!, uuid: nil, provenanceIdentifier: nil, syncIdentifier: nil, syncVersion: nil, userCreatedDate: nil, userUpdatedDate: nil, userDeletedDate: nil, operation: .create, addedDate: dateFormatter.date(from: "2100-01-02T03:10:00Z")!, supercededDate: nil),
+                       SyncCarbObject(absorptionTime: nil, createdByCurrentApp: true, foodType: nil, grams: 13, startDate: dateFormatter.date(from: "2100-01-02T03:04:00Z")!, uuid: nil, provenanceIdentifier: nil, syncIdentifier: nil, syncVersion: nil, userCreatedDate: nil, userUpdatedDate: nil, userDeletedDate: nil, operation: .create, addedDate: dateFormatter.date(from: "2100-01-02T02:04:00Z")!, supercededDate: dateFormatter.date(from: "2100-01-02T03:04:00Z")!),
+                       SyncCarbObject(absorptionTime: nil, createdByCurrentApp: true, foodType: nil, grams: 14, startDate: dateFormatter.date(from: "2100-01-02T03:06:00Z")!, uuid: nil, provenanceIdentifier: nil, syncIdentifier: nil, syncVersion: nil, userCreatedDate: nil, userUpdatedDate: nil, userDeletedDate: nil, operation: .create, addedDate: dateFormatter.date(from: "2100-01-02T03:06:00Z")!, supercededDate: nil),
+                       SyncCarbObject(absorptionTime: nil, createdByCurrentApp: true, foodType: nil, grams: 15, startDate: dateFormatter.date(from: "2100-01-02T03:02:00Z")!, uuid: nil, provenanceIdentifier: nil, syncIdentifier: nil, syncVersion: nil, userCreatedDate: nil, userUpdatedDate: nil, userDeletedDate: nil, operation: .create, addedDate: dateFormatter.date(from: "2100-01-02T03:02:00Z")!, supercededDate: nil)]
+
+        carbStore = CarbStore(
+            healthStore: HKHealthStoreMock(),
+            cacheStore: cacheStore,
+            cacheLength: .hours(24),
+            defaultAbsorptionTimes: (fast: .minutes(30), medium: .hours(3), slow: .hours(5)),
+            observationInterval: 0,
+            provenanceIdentifier: Bundle.main.bundleIdentifier!)
+
+        let dispatchGroup = DispatchGroup()
+        dispatchGroup.enter()
+        carbStore.setSyncCarbObjects(objects) { error in
+            XCTAssertNil(error)
+            dispatchGroup.leave()
+        }
+        dispatchGroup.wait()
+
+        outputStream = MockOutputStream()
+        progressor = MockEstimatedDurationProgressor()
+    }
+
+    override func tearDown() {
+        carbStore = nil
+
+        super.tearDown()
+    }
+
+    func testExportEstimatedDuration() {
+        switch carbStore.exportEstimatedDuration(startDate: dateFormatter.date(from: "2100-01-02T03:03:00Z")!,
+                                                 endDate: dateFormatter.date(from: "2100-01-02T03:09:00Z")!) {
+        case .failure(let error):
+            XCTFail("Unexpected failure: \(error)")
+        case .success(let estimatedDuration):
+            XCTAssertEqual(estimatedDuration, 3 * 0.0009, accuracy: 0.0001)
+        }
+    }
+
+    func testExportEstimatedDurationEmpty() {
+        switch carbStore.exportEstimatedDuration(startDate: dateFormatter.date(from: "2100-01-02T03:00:00Z")!,
+                                                 endDate: dateFormatter.date(from: "2100-01-02T03:01:00Z")!) {
+        case .failure(let error):
+            XCTFail("Unexpected failure: \(error)")
+        case .success(let estimatedDuration):
+            XCTAssertEqual(estimatedDuration, 0)
+        }
+    }
+
+    func testExport() {
+        XCTAssertNil(carbStore.export(startDate: dateFormatter.date(from: "2100-01-02T03:03:00Z")!,
+                                      endDate: dateFormatter.date(from: "2100-01-02T03:09:00Z")!,
+                                      to: outputStream,
+                                      progressor: progressor))
+        XCTAssertEqual(outputStream.string, """
+[
+{"addedDate":"2100-01-02T03:08:00.000Z","anchorKey":1,"createdByCurrentApp":true,"grams":11,"operation":0,"startDate":"2100-01-02T03:08:00.000Z"},
+{"addedDate":"2100-01-02T02:04:00.000Z","anchorKey":3,"createdByCurrentApp":true,"grams":13,"operation":0,"startDate":"2100-01-02T03:04:00.000Z","supercededDate":"2100-01-02T03:04:00.000Z"},
+{"addedDate":"2100-01-02T03:06:00.000Z","anchorKey":4,"createdByCurrentApp":true,"grams":14,"operation":0,"startDate":"2100-01-02T03:06:00.000Z"}
+]
+"""
+        )
+        XCTAssertEqual(progressor.estimatedDuration, 3 * 0.0009, accuracy: 0.0001)
+    }
+
+    func testExportEmpty() {
+        XCTAssertNil(carbStore.export(startDate: dateFormatter.date(from: "2100-01-02T03:00:00Z")!,
+                                      endDate: dateFormatter.date(from: "2100-01-02T03:01:00Z")!,
+                                      to: outputStream,
+                                      progressor: progressor))
+        XCTAssertEqual(outputStream.string, "[]")
+        XCTAssertEqual(progressor.estimatedDuration, 0)
+    }
+
+    func testExportCancelled() {
+        progressor.isCancelled = true
+        XCTAssertEqual(carbStore.export(startDate: dateFormatter.date(from: "2100-01-02T03:03:00Z")!,
+                                        endDate: dateFormatter.date(from: "2100-01-02T03:09:00Z")!,
+                                        to: outputStream,
+                                        progressor: progressor) as? CriticalEventLogError, CriticalEventLogError.cancelled)
+    }
+
+    private let dateFormatter = ISO8601DateFormatter()
 }

--- a/LoopKitTests/CriticalEventLogTests.swift
+++ b/LoopKitTests/CriticalEventLogTests.swift
@@ -24,12 +24,3 @@ class MockOutputStream: OutputStream {
 
     var string: String { String(data: data, encoding: .utf8)! }
 }
-
-class MockEstimatedDurationProgressor: EstimatedDurationProgressor {
-    var isCancelled: Bool = false
-    var estimatedDuration: TimeInterval = 0
-
-    func didProgress(for estimatedDuration: TimeInterval) {
-        self.estimatedDuration += estimatedDuration
-    }
-}

--- a/LoopKitTests/CriticalEventLogTests.swift
+++ b/LoopKitTests/CriticalEventLogTests.swift
@@ -1,0 +1,35 @@
+//
+//  CriticalEventLogTests.swift
+//  LoopKitTests
+//
+//  Created by Darin Krauss on 8/26/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+import LoopKit
+
+class MockOutputStream: OutputStream {
+    var status: Status = .open
+    var error: Error? = nil
+    var data: Data = Data()
+
+    override var streamStatus: Status { status }
+    override var streamError: Error? { error }
+
+    override func write(_ buffer: UnsafePointer<UInt8>, maxLength len: Int) -> Int {
+        data.append(UnsafeBufferPointer(start: buffer, count: len))
+        return len
+    }
+
+    var string: String { String(data: data, encoding: .utf8)! }
+}
+
+class MockEstimatedDurationProgressor: EstimatedDurationProgressor {
+    var isCancelled: Bool = false
+    var estimatedDuration: TimeInterval = 0
+
+    func didProgress(for estimatedDuration: TimeInterval) {
+        self.estimatedDuration += estimatedDuration
+    }
+}

--- a/LoopKitTests/DoseStoreTests.swift
+++ b/LoopKitTests/DoseStoreTests.swift
@@ -747,6 +747,100 @@ class DoseStoreQueryTests: PersistenceControllerTestCase {
     
 }
 
+class DoseStoreCriticalEventLogTests: PersistenceControllerTestCase {
+    let insulinModel = WalshInsulinModel(actionDuration: .hours(4))
+    let basalProfile = BasalRateSchedule(rawValue: ["timeZone": -28800, "items": [["value": 0.75, "startTime": 0.0], ["value": 0.8, "startTime": 10800.0], ["value": 0.85, "startTime": 32400.0], ["value": 1.0, "startTime": 68400.0]]])
+    let insulinSensitivitySchedule = InsulinSensitivitySchedule(rawValue: ["unit": "mg/dL", "timeZone": -28800, "items": [["value": 40.0, "startTime": 0.0], ["value": 35.0, "startTime": 21600.0], ["value": 40.0, "startTime": 57600.0]]])
+
+    var doseStore: DoseStore!
+    var outputStream: MockOutputStream!
+    var progressor: MockEstimatedDurationProgressor!
+
+    override func setUp() {
+        super.setUp()
+
+        let persistedDate = dateFormatter.date(from: "2100-01-02T03:000:00Z")!
+        let url = URL(string: "http://a.b.com")!
+        let events = [PersistedPumpEvent(date: dateFormatter.date(from: "2100-01-02T03:08:00Z")!, persistedDate: persistedDate, dose: nil, isUploaded: false, objectIDURL: url, raw: nil, title: nil, type: nil, isMutable: false),
+                      PersistedPumpEvent(date: dateFormatter.date(from: "2100-01-02T03:10:00Z")!, persistedDate: persistedDate, dose: nil, isUploaded: false, objectIDURL: url, raw: nil, title: nil, type: nil, isMutable: false),
+                      PersistedPumpEvent(date: dateFormatter.date(from: "2100-01-02T03:04:00Z")!, persistedDate: persistedDate, dose: nil, isUploaded: false, objectIDURL: url, raw: nil, title: nil, type: nil, isMutable: false),
+                      PersistedPumpEvent(date: dateFormatter.date(from: "2100-01-02T03:06:00Z")!, persistedDate: persistedDate, dose: nil, isUploaded: false, objectIDURL: url, raw: nil, title: nil, type: nil, isMutable: false),
+                      PersistedPumpEvent(date: dateFormatter.date(from: "2100-01-02T03:02:00Z")!, persistedDate: persistedDate, dose: nil, isUploaded: false, objectIDURL: url, raw: nil, title: nil, type: nil, isMutable: false)]
+
+        doseStore = DoseStore(healthStore: HKHealthStoreMock(),
+                              cacheStore: cacheStore,
+                              observationEnabled: false,
+                              insulinModel: insulinModel,
+                              basalProfile: basalProfile,
+                              insulinSensitivitySchedule: insulinSensitivitySchedule)
+        XCTAssertNil(doseStore.addPumpEvents(events: events))
+
+        outputStream = MockOutputStream()
+        progressor = MockEstimatedDurationProgressor()
+    }
+
+    override func tearDown() {
+        doseStore = nil
+
+        super.tearDown()
+    }
+
+    func testExportEstimatedDuration() {
+        switch doseStore.exportEstimatedDuration(startDate: dateFormatter.date(from: "2100-01-02T03:03:00Z")!,
+                                                 endDate: dateFormatter.date(from: "2100-01-02T03:09:00Z")!) {
+        case .failure(let error):
+            XCTFail("Unexpected failure: \(error)")
+        case .success(let estimatedDuration):
+            XCTAssertEqual(estimatedDuration, 3 * 0.0005, accuracy: 0.0001)
+        }
+    }
+
+    func testExportEstimatedDurationEmpty() {
+        switch doseStore.exportEstimatedDuration(startDate: dateFormatter.date(from: "2100-01-02T03:00:00Z")!,
+                                                 endDate: dateFormatter.date(from: "2100-01-02T03:01:00Z")!) {
+        case .failure(let error):
+            XCTFail("Unexpected failure: \(error)")
+        case .success(let estimatedDuration):
+            XCTAssertEqual(estimatedDuration, 0)
+        }
+    }
+
+    func testExport() {
+        XCTAssertNil(doseStore.export(startDate: dateFormatter.date(from: "2100-01-02T03:03:00Z")!,
+                                      endDate: dateFormatter.date(from: "2100-01-02T03:09:00Z")!,
+                                      to: outputStream,
+                                      progressor: progressor))
+        XCTAssertEqual(outputStream.string, """
+[
+{"createdAt":"2100-01-02T03:00:00.000Z","date":"2100-01-02T03:08:00.000Z","duration":0,"modificationCounter":1,"mutable":false,"uploaded":false},
+{"createdAt":"2100-01-02T03:00:00.000Z","date":"2100-01-02T03:04:00.000Z","duration":0,"modificationCounter":3,"mutable":false,"uploaded":false},
+{"createdAt":"2100-01-02T03:00:00.000Z","date":"2100-01-02T03:06:00.000Z","duration":0,"modificationCounter":4,"mutable":false,"uploaded":false}
+]
+"""
+        )
+        XCTAssertEqual(progressor.estimatedDuration, 3 * 0.0005, accuracy: 0.0001)
+    }
+    
+    func testExportEmpty() {
+        XCTAssertNil(doseStore.export(startDate: dateFormatter.date(from: "2100-01-02T03:00:00Z")!,
+                                      endDate: dateFormatter.date(from: "2100-01-02T03:01:00Z")!,
+                                      to: outputStream,
+                                      progressor: progressor))
+        XCTAssertEqual(outputStream.string, "[]")
+        XCTAssertEqual(progressor.estimatedDuration, 0)
+    }
+
+    func testExportCancelled() {
+        progressor.isCancelled = true
+        XCTAssertEqual(doseStore.export(startDate: dateFormatter.date(from: "2100-01-02T03:03:00Z")!,
+                                        endDate: dateFormatter.date(from: "2100-01-02T03:09:00Z")!,
+                                        to: outputStream,
+                                        progressor: progressor) as? CriticalEventLogError, CriticalEventLogError.cancelled)
+    }
+
+    private let dateFormatter = ISO8601DateFormatter()
+}
+
 class DoseStoreEffectTests: PersistenceControllerTestCase {
     var doseStore: DoseStore!
 

--- a/LoopKitTests/GlucoseStoreTests.swift
+++ b/LoopKitTests/GlucoseStoreTests.swift
@@ -369,8 +369,8 @@ class GlucoseStoreQueryTests: PersistenceControllerTestCase {
 class GlucoseStoreCriticalEventLogTests: PersistenceControllerTestCase {
     var glucoseStore: GlucoseStore!
     var outputStream: MockOutputStream!
-    var progressor: MockEstimatedDurationProgressor!
-
+    var progress: Progress!
+    
     override func setUp() {
         super.setUp()
 
@@ -391,7 +391,7 @@ class GlucoseStoreCriticalEventLogTests: PersistenceControllerTestCase {
         dispatchGroup.wait()
 
         outputStream = MockOutputStream()
-        progressor = MockEstimatedDurationProgressor()
+        progress = Progress()
     }
 
     override func tearDown() {
@@ -399,24 +399,24 @@ class GlucoseStoreCriticalEventLogTests: PersistenceControllerTestCase {
 
         super.tearDown()
     }
-
-    func testExportEstimatedDuration() {
-        switch glucoseStore.exportEstimatedDuration(startDate: dateFormatter.date(from: "2100-01-02T03:03:00Z")!,
-                                                    endDate: dateFormatter.date(from: "2100-01-02T03:09:00Z")!) {
+    
+    func testExportProgressTotalUnitCount() {
+        switch glucoseStore.exportProgressTotalUnitCount(startDate: dateFormatter.date(from: "2100-01-02T03:03:00Z")!,
+                                                         endDate: dateFormatter.date(from: "2100-01-02T03:09:00Z")!) {
         case .failure(let error):
             XCTFail("Unexpected failure: \(error)")
-        case .success(let estimatedDuration):
-            XCTAssertEqual(estimatedDuration, 3 * 0.0004, accuracy: 0.0001)
+        case .success(let progressTotalUnitCount):
+            XCTAssertEqual(progressTotalUnitCount, 3 * 1)
         }
     }
-
-    func testExportEstimatedDurationEmpty() {
-        switch glucoseStore.exportEstimatedDuration(startDate: dateFormatter.date(from: "2100-01-02T03:00:00Z")!,
-                                                    endDate: dateFormatter.date(from: "2100-01-02T03:01:00Z")!) {
+    
+    func testExportProgressTotalUnitCountEmpty() {
+        switch glucoseStore.exportProgressTotalUnitCount(startDate: dateFormatter.date(from: "2100-01-02T03:00:00Z")!,
+                                                         endDate: dateFormatter.date(from: "2100-01-02T03:01:00Z")!) {
         case .failure(let error):
             XCTFail("Unexpected failure: \(error)")
-        case .success(let estimatedDuration):
-            XCTAssertEqual(estimatedDuration, 0)
+        case .success(let progressTotalUnitCount):
+            XCTAssertEqual(progressTotalUnitCount, 0)
         }
     }
 
@@ -424,7 +424,7 @@ class GlucoseStoreCriticalEventLogTests: PersistenceControllerTestCase {
         XCTAssertNil(glucoseStore.export(startDate: dateFormatter.date(from: "2100-01-02T03:03:00Z")!,
                                          endDate: dateFormatter.date(from: "2100-01-02T03:09:00Z")!,
                                          to: outputStream,
-                                         progressor: progressor))
+                                         progress: progress))
         XCTAssertEqual(outputStream.string, """
 [
 {"isDisplayOnly":false,"modificationCounter":1,"provenanceIdentifier":"org.loopkit.Test.1","startDate":"2100-01-02T03:08:00.000Z","syncIdentifier":"18CF3948-0B3D-4B12-8BFE-14986B0E6784","syncVersion":1,"unitString":"mg/dL","uploadState":0,"uuid":"28CF3948-0B3D-4B12-8BFE-14986B0E6784","value":111,"wasUserEntered":false},
@@ -433,24 +433,24 @@ class GlucoseStoreCriticalEventLogTests: PersistenceControllerTestCase {
 ]
 """
         )
-        XCTAssertEqual(progressor.estimatedDuration, 3 * 0.0004, accuracy: 0.0001)
+        XCTAssertEqual(progress.completedUnitCount, 3 * 1)
     }
 
     func testExportEmpty() {
         XCTAssertNil(glucoseStore.export(startDate: dateFormatter.date(from: "2100-01-02T03:00:00Z")!,
                                          endDate: dateFormatter.date(from: "2100-01-02T03:01:00Z")!,
                                          to: outputStream,
-                                         progressor: progressor))
+                                         progress: progress))
         XCTAssertEqual(outputStream.string, "[]")
-        XCTAssertEqual(progressor.estimatedDuration, 0)
+        XCTAssertEqual(progress.completedUnitCount, 0)
     }
 
     func testExportCancelled() {
-        progressor.isCancelled = true
+        progress.cancel()
         XCTAssertEqual(glucoseStore.export(startDate: dateFormatter.date(from: "2100-01-02T03:03:00Z")!,
                                            endDate: dateFormatter.date(from: "2100-01-02T03:09:00Z")!,
                                            to: outputStream,
-                                           progressor: progressor) as? CriticalEventLogError, CriticalEventLogError.cancelled)
+                                           progress: progress) as? CriticalEventLogError, CriticalEventLogError.cancelled)
     }
 
     private let dateFormatter = ISO8601DateFormatter()

--- a/LoopKitTests/GlucoseStoreTests.swift
+++ b/LoopKitTests/GlucoseStoreTests.swift
@@ -365,3 +365,93 @@ class GlucoseStoreQueryTests: PersistenceControllerTestCase {
     }
 
 }
+
+class GlucoseStoreCriticalEventLogTests: PersistenceControllerTestCase {
+    var glucoseStore: GlucoseStore!
+    var outputStream: MockOutputStream!
+    var progressor: MockEstimatedDurationProgressor!
+
+    override func setUp() {
+        super.setUp()
+
+        let samples = [StoredGlucoseSample(sampleUUID: UUID(uuidString: "28CF3948-0B3D-4B12-8BFE-14986B0E6784")!, syncIdentifier: "18CF3948-0B3D-4B12-8BFE-14986B0E6784", syncVersion: 1, startDate: dateFormatter.date(from: "2100-01-02T03:08:00Z")!, quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 111), isDisplayOnly: false, wasUserEntered: false, provenanceIdentifier: "org.loopkit.Test.1"),
+                       StoredGlucoseSample(sampleUUID: UUID(uuidString: "D86DEB61-68E9-464E-9DD5-96A9CB445FD3")!, syncIdentifier: "C86DEB61-68E9-464E-9DD5-96A9CB445FD3", syncVersion: 2, startDate: dateFormatter.date(from: "2100-01-02T03:10:00Z")!, quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 112), isDisplayOnly: false, wasUserEntered: false, provenanceIdentifier: "org.loopkit.Test.2"),
+                       StoredGlucoseSample(sampleUUID: UUID(uuidString: "3B03D96C-6F5D-4140-99CD-80C3E64D6010")!, syncIdentifier: "2B03D96C-6F5D-4140-99CD-80C3E64D6010", syncVersion: 3, startDate: dateFormatter.date(from: "2100-01-02T03:04:00Z")!, quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 113), isDisplayOnly: false, wasUserEntered: false, provenanceIdentifier: "org.loopkit.Test.3"),
+                       StoredGlucoseSample(sampleUUID: UUID(uuidString: "0F1C4F01-3558-4FB2-957E-FA1522C4735E")!, syncIdentifier: "FF1C4F01-3558-4FB2-957E-FA1522C4735E", syncVersion: 4, startDate: dateFormatter.date(from: "2100-01-02T03:06:00Z")!, quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 114), isDisplayOnly: false, wasUserEntered: false, provenanceIdentifier: "org.loopkit.Test.4"),
+                       StoredGlucoseSample(sampleUUID: UUID(uuidString: "81B699D7-0E8F-4B13-B7A1-E7751EB78E74")!, syncIdentifier: "71B699D7-0E8F-4B13-B7A1-E7751EB78E74", syncVersion: 5, startDate: dateFormatter.date(from: "2100-01-02T03:02:00Z")!, quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 115), isDisplayOnly: false, wasUserEntered: false, provenanceIdentifier: "org.loopkit.Test.5")]
+
+        glucoseStore = GlucoseStore(healthStore: HKHealthStoreMock(), cacheStore: cacheStore)
+
+        let dispatchGroup = DispatchGroup()
+        dispatchGroup.enter()
+        glucoseStore.addGlucoseSamples(samples: samples) { error in
+            XCTAssertNil(error)
+            dispatchGroup.leave()
+        }
+        dispatchGroup.wait()
+
+        outputStream = MockOutputStream()
+        progressor = MockEstimatedDurationProgressor()
+    }
+
+    override func tearDown() {
+        glucoseStore = nil
+
+        super.tearDown()
+    }
+
+    func testExportEstimatedDuration() {
+        switch glucoseStore.exportEstimatedDuration(startDate: dateFormatter.date(from: "2100-01-02T03:03:00Z")!,
+                                                    endDate: dateFormatter.date(from: "2100-01-02T03:09:00Z")!) {
+        case .failure(let error):
+            XCTFail("Unexpected failure: \(error)")
+        case .success(let estimatedDuration):
+            XCTAssertEqual(estimatedDuration, 3 * 0.0004, accuracy: 0.0001)
+        }
+    }
+
+    func testExportEstimatedDurationEmpty() {
+        switch glucoseStore.exportEstimatedDuration(startDate: dateFormatter.date(from: "2100-01-02T03:00:00Z")!,
+                                                    endDate: dateFormatter.date(from: "2100-01-02T03:01:00Z")!) {
+        case .failure(let error):
+            XCTFail("Unexpected failure: \(error)")
+        case .success(let estimatedDuration):
+            XCTAssertEqual(estimatedDuration, 0)
+        }
+    }
+
+    func testExport() {
+        XCTAssertNil(glucoseStore.export(startDate: dateFormatter.date(from: "2100-01-02T03:03:00Z")!,
+                                         endDate: dateFormatter.date(from: "2100-01-02T03:09:00Z")!,
+                                         to: outputStream,
+                                         progressor: progressor))
+        XCTAssertEqual(outputStream.string, """
+[
+{"isDisplayOnly":false,"modificationCounter":1,"provenanceIdentifier":"org.loopkit.Test.1","startDate":"2100-01-02T03:08:00.000Z","syncIdentifier":"18CF3948-0B3D-4B12-8BFE-14986B0E6784","syncVersion":1,"unitString":"mg/dL","uploadState":0,"uuid":"28CF3948-0B3D-4B12-8BFE-14986B0E6784","value":111,"wasUserEntered":false},
+{"isDisplayOnly":false,"modificationCounter":3,"provenanceIdentifier":"org.loopkit.Test.3","startDate":"2100-01-02T03:04:00.000Z","syncIdentifier":"2B03D96C-6F5D-4140-99CD-80C3E64D6010","syncVersion":3,"unitString":"mg/dL","uploadState":0,"uuid":"3B03D96C-6F5D-4140-99CD-80C3E64D6010","value":113,"wasUserEntered":false},
+{"isDisplayOnly":false,"modificationCounter":4,"provenanceIdentifier":"org.loopkit.Test.4","startDate":"2100-01-02T03:06:00.000Z","syncIdentifier":"FF1C4F01-3558-4FB2-957E-FA1522C4735E","syncVersion":4,"unitString":"mg/dL","uploadState":0,"uuid":"0F1C4F01-3558-4FB2-957E-FA1522C4735E","value":114,"wasUserEntered":false}
+]
+"""
+        )
+        XCTAssertEqual(progressor.estimatedDuration, 3 * 0.0004, accuracy: 0.0001)
+    }
+
+    func testExportEmpty() {
+        XCTAssertNil(glucoseStore.export(startDate: dateFormatter.date(from: "2100-01-02T03:00:00Z")!,
+                                         endDate: dateFormatter.date(from: "2100-01-02T03:01:00Z")!,
+                                         to: outputStream,
+                                         progressor: progressor))
+        XCTAssertEqual(outputStream.string, "[]")
+        XCTAssertEqual(progressor.estimatedDuration, 0)
+    }
+
+    func testExportCancelled() {
+        progressor.isCancelled = true
+        XCTAssertEqual(glucoseStore.export(startDate: dateFormatter.date(from: "2100-01-02T03:03:00Z")!,
+                                           endDate: dateFormatter.date(from: "2100-01-02T03:09:00Z")!,
+                                           to: outputStream,
+                                           progressor: progressor) as? CriticalEventLogError, CriticalEventLogError.cancelled)
+    }
+
+    private let dateFormatter = ISO8601DateFormatter()
+}

--- a/LoopKitTests/JSONStreamEncoderTests.swift
+++ b/LoopKitTests/JSONStreamEncoderTests.swift
@@ -1,0 +1,85 @@
+//
+//  JSONStreamEncoderTests.swift
+//  LoopKitTests
+//
+//  Created by Darin Krauss on 8/26/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import XCTest
+import LoopKit
+
+class JSONStreamEncoderTests: XCTestCase {
+    var outputStream: MockOutputStream!
+    var encoder: JSONStreamEncoder!
+
+    override func setUp() {
+        outputStream = MockOutputStream()
+        encoder = JSONStreamEncoder(stream: outputStream)
+    }
+
+    func testEmpty() {
+        XCTAssertNil(encoder.close())
+        XCTAssertEqual(outputStream.string, "[]")
+    }
+
+    func testMultipleClose() {
+        XCTAssertNil(encoder.close())
+        XCTAssertNil(encoder.close())
+    }
+
+    func testCloseError() {
+        let mockError = MockError()
+        outputStream.error = mockError
+        XCTAssertEqual(encoder.close() as! MockError, mockError)
+    }
+
+    func testEncode() {
+        let values = [MockValue(left: "Alpha", center: 1, right: dateFormatter.date(from: "2020-01-02T03:02:00Z")!),
+                      MockValue(left: "Bravo", center: 2, right: dateFormatter.date(from: "2020-01-02T03:04:00Z")!),
+                      MockValue(left: "Charlie", center: 3, right: dateFormatter.date(from: "2020-01-02T03:06:00Z")!)]
+        XCTAssertNoThrow(try encoder.encode(values))
+        XCTAssertNil(encoder.close())
+        XCTAssertEqual(outputStream.string, """
+[
+{"center":1,"left":"Alpha","right":"2020-01-02T03:02:00.000Z"},
+{"center":2,"left":"Bravo","right":"2020-01-02T03:04:00.000Z"},
+{"center":3,"left":"Charlie","right":"2020-01-02T03:06:00.000Z"}
+]
+"""
+        )
+    }
+
+    func testEncodeEmpty() {
+        XCTAssertNoThrow(try encoder.encode([MockValue]()))
+        XCTAssertNil(encoder.close())
+        XCTAssertEqual(outputStream.string, "[]")
+    }
+
+    func testEncodeClosed() {
+        let values = [MockValue(left: "Alpha", center: 1, right: dateFormatter.date(from: "2020-01-02T03:02:00Z")!)]
+        XCTAssertNil(encoder.close())
+        XCTAssertThrowsError(try encoder.encode(values)) { error in
+            XCTAssertEqual(error as! JSONStreamEncoderError, JSONStreamEncoderError.encoderClosed)
+        }
+    }
+
+    func testEncodeError() {
+        let values = [MockValue(left: "Alpha", center: 1, right: dateFormatter.date(from: "2020-01-02T03:02:00Z")!)]
+        let mockError = MockError()
+        outputStream.error = mockError
+        XCTAssertThrowsError(try encoder.encode(values)) { error in
+            XCTAssertEqual(error as! MockError, mockError)
+        }
+    }
+
+    private let dateFormatter = ISO8601DateFormatter()
+}
+
+fileprivate struct MockValue: Codable {
+    let left: String
+    let center: Int
+    let right: Date
+}
+
+fileprivate struct MockError: Error, Equatable {}

--- a/LoopKitTests/NotificationSettingsTests.swift
+++ b/LoopKitTests/NotificationSettingsTests.swift
@@ -1,0 +1,70 @@
+//
+//  NotificationSettingsTests.swift
+//  LoopKitTests
+//
+//  Created by Darin Krauss on 9/17/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import XCTest
+import Foundation
+import LoopKit
+
+class NotificationSettingsCodableTests: XCTestCase {
+    func testCodable() throws {
+        try assertNotificationSettingsCodable(NotificationSettings.test, encodesJSON: """
+{
+  "alertSetting" : "disabled",
+  "alertStyle" : "banner",
+  "announcementSetting" : "enabled",
+  "authorizationStatus" : "authorized",
+  "badgeSetting" : "enabled",
+  "carPlaySetting" : "notSupported",
+  "criticalAlertSetting" : "enabled",
+  "lockScreenSetting" : "disabled",
+  "notificationCenterSetting" : "notSupported",
+  "providesAppNotificationSettings" : true,
+  "showPreviewsSetting" : "whenAuthenticated",
+  "soundSetting" : "enabled"
+}
+"""
+        )
+    }
+    
+    private func assertNotificationSettingsCodable(_ original: NotificationSettings, encodesJSON string: String) throws {
+        let data = try encoder.encode(original)
+        XCTAssertEqual(String(data: data, encoding: .utf8), string)
+        let decoded = try decoder.decode(NotificationSettings.self, from: data)
+        XCTAssertEqual(decoded, original)
+    }
+    
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+    
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+}
+
+fileprivate extension NotificationSettings {
+    static var test: NotificationSettings {
+        return NotificationSettings(authorizationStatus: .authorized,
+                                    soundSetting: .enabled,
+                                    badgeSetting: .enabled,
+                                    alertSetting: .disabled,
+                                    notificationCenterSetting: .notSupported,
+                                    lockScreenSetting: .disabled,
+                                    carPlaySetting: .notSupported,
+                                    alertStyle: .banner,
+                                    showPreviewsSetting: .whenAuthenticated,
+                                    criticalAlertSetting: .enabled,
+                                    providesAppNotificationSettings: true,
+                                    announcementSetting: .enabled)
+    }
+}

--- a/LoopKitTests/OutputStreamTests.swift
+++ b/LoopKitTests/OutputStreamTests.swift
@@ -1,0 +1,47 @@
+//
+//  OutputStreamTests.swift
+//  LoopKitTests
+//
+//  Created by Darin Krauss on 9/17/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import XCTest
+import Foundation
+@testable import LoopKit
+
+class OutputStreamTests: XCTestCase {
+    private let string = "The quick brown fox jumps over the lazy dog"
+
+    func testWriteString() {
+        let outputStream = MockOutputStream()
+        XCTAssertNoThrow(try outputStream.write(string))
+        XCTAssertEqual(outputStream.string, string)
+    }
+
+    func testWriteStringThrowsError() {
+        let outputStream = MockOutputStream()
+        outputStream.error = MockError()
+        XCTAssertThrowsError(try outputStream.write(string)) { error in
+            XCTAssertEqual(error as! MockError, outputStream.error as! MockError)
+        }
+    }
+
+    func testWriteData() {
+        let data = string.data(using: .utf8)!
+        let outputStream = MockOutputStream()
+        XCTAssertNoThrow(try outputStream.write(data))
+        XCTAssertEqual(outputStream.data, data)
+    }
+
+    func testWriteDataThrowsError() {
+        let data = string.data(using: .utf8)!
+        let outputStream = MockOutputStream()
+        outputStream.error = MockError()
+        XCTAssertThrowsError(try outputStream.write(data)) { error in
+            XCTAssertEqual(error as! MockError, outputStream.error as! MockError)
+        }
+    }
+}
+
+fileprivate struct MockError: Error, Equatable {}

--- a/LoopKitTests/Persistence/CachedCarbObjectTests.swift
+++ b/LoopKitTests/Persistence/CachedCarbObjectTests.swift
@@ -27,6 +27,89 @@ class CachedCarbObjectTests: PersistenceControllerTestCase {
     }
 }
 
+class CachedCarbObjectEncodableTests: PersistenceControllerTestCase {
+    func testEncodable() throws {
+        cacheStore.managedObjectContext.performAndWait {
+            let cachedCarbObject = CachedCarbObject(context: cacheStore.managedObjectContext)
+            cachedCarbObject.absorptionTime = 18000
+            cachedCarbObject.createdByCurrentApp = true
+            cachedCarbObject.foodType = "Pizza"
+            cachedCarbObject.grams = 45
+            cachedCarbObject.startDate = dateFormatter.date(from: "2020-05-14T22:38:14Z")!
+            cachedCarbObject.uuid = UUID(uuidString: "2A67A303-5203-4CB8-8263-79498265368E")!
+            cachedCarbObject.provenanceIdentifier = "238E41EA-9576-4981-A1A4-51E10228584F"
+            cachedCarbObject.syncIdentifier = "7723A0EE-F6D5-46E0-BBFE-1DEEBF8ED6F2"
+            cachedCarbObject.syncVersion = 2
+            cachedCarbObject.userCreatedDate = dateFormatter.date(from: "2020-05-14T22:28:12Z")!
+            cachedCarbObject.userUpdatedDate = dateFormatter.date(from: "2020-05-14T22:33:47Z")!
+            cachedCarbObject.userDeletedDate = nil
+            cachedCarbObject.operation = .update
+            cachedCarbObject.addedDate = dateFormatter.date(from: "2020-05-14T22:33:48Z")!
+            cachedCarbObject.supercededDate = nil
+            cachedCarbObject.anchorKey = 123
+            try! assertCachedCarbObjectEncodable(cachedCarbObject, encodesJSON: """
+{
+  "absorptionTime" : 18000,
+  "addedDate" : "2020-05-14T22:33:48Z",
+  "anchorKey" : 123,
+  "createdByCurrentApp" : true,
+  "foodType" : "Pizza",
+  "grams" : 45,
+  "operation" : 1,
+  "provenanceIdentifier" : "238E41EA-9576-4981-A1A4-51E10228584F",
+  "startDate" : "2020-05-14T22:38:14Z",
+  "syncIdentifier" : "7723A0EE-F6D5-46E0-BBFE-1DEEBF8ED6F2",
+  "syncVersion" : 2,
+  "userCreatedDate" : "2020-05-14T22:28:12Z",
+  "userUpdatedDate" : "2020-05-14T22:33:47Z",
+  "uuid" : "2A67A303-5203-4CB8-8263-79498265368E"
+}
+"""
+            )
+        }
+    }
+
+    func testEncodableOptional() throws {
+        cacheStore.managedObjectContext.performAndWait {
+            let cachedCarbObject = CachedCarbObject(context: cacheStore.managedObjectContext)
+            cachedCarbObject.createdByCurrentApp = false
+            cachedCarbObject.grams = 34
+            cachedCarbObject.startDate = dateFormatter.date(from: "2020-05-15T22:38:14Z")!
+            cachedCarbObject.operation = .create
+            cachedCarbObject.anchorKey = 234
+            try! assertCachedCarbObjectEncodable(cachedCarbObject, encodesJSON: """
+{
+  "anchorKey" : 234,
+  "createdByCurrentApp" : false,
+  "grams" : 34,
+  "operation" : 0,
+  "startDate" : "2020-05-15T22:38:14Z"
+}
+"""
+            )
+        }
+    }
+
+    private func assertCachedCarbObjectEncodable(_ original: CachedCarbObject, encodesJSON string: String) throws {
+        let data = try encoder.encode(original)
+        XCTAssertEqual(String(data: data, encoding: .utf8), string)
+    }
+
+    private let dateFormatter = ISO8601DateFormatter()
+
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+}
 
 extension CachedCarbObject {
     fileprivate func setDefaultValues() {

--- a/LoopKitTests/Persistence/CachedGlucoseObjectTests.swift
+++ b/LoopKitTests/Persistence/CachedGlucoseObjectTests.swift
@@ -94,6 +94,84 @@ class CachedGlucoseObjectTests: PersistenceControllerTestCase {
 
 }
 
+class CachedGlucoseObjectEncodableTests: PersistenceControllerTestCase {
+    func testEncodable() throws {
+        cacheStore.managedObjectContext.performAndWait {
+            let cachedGlucoseObject = CachedGlucoseObject(context: cacheStore.managedObjectContext)
+            cachedGlucoseObject.uuid = UUID(uuidString: "2A67A303-5203-4CB8-8263-79498265368E")!
+            cachedGlucoseObject.syncIdentifier = "7723A0EE-F6D5-46E0-BBFE-1DEEBF8ED6F2"
+            cachedGlucoseObject.syncVersion = 2
+            cachedGlucoseObject.uploadState = .notUploaded
+            cachedGlucoseObject.value = 98.7
+            cachedGlucoseObject.unitString = "mg/dL"
+            cachedGlucoseObject.startDate = dateFormatter.date(from: "2020-05-14T22:38:14Z")!
+            cachedGlucoseObject.provenanceIdentifier = "238E41EA-9576-4981-A1A4-51E10228584F"
+            cachedGlucoseObject.isDisplayOnly = false
+            cachedGlucoseObject.wasUserEntered = true
+            cachedGlucoseObject.modificationCounter = 123
+            try! assertCachedGlucoseObjectEncodable(cachedGlucoseObject, encodesJSON: """
+{
+  "isDisplayOnly" : false,
+  "modificationCounter" : 123,
+  "provenanceIdentifier" : "238E41EA-9576-4981-A1A4-51E10228584F",
+  "startDate" : "2020-05-14T22:38:14Z",
+  "syncIdentifier" : "7723A0EE-F6D5-46E0-BBFE-1DEEBF8ED6F2",
+  "syncVersion" : 2,
+  "unitString" : "mg/dL",
+  "uploadState" : 0,
+  "uuid" : "2A67A303-5203-4CB8-8263-79498265368E",
+  "value" : 98.700000000000003,
+  "wasUserEntered" : true
+}
+"""
+            )
+        }
+    }
+
+    func testEncodableOptional() throws {
+        cacheStore.managedObjectContext.performAndWait {
+            let cachedGlucoseObject = CachedGlucoseObject(context: cacheStore.managedObjectContext)
+            cachedGlucoseObject.syncVersion = 1
+            cachedGlucoseObject.value = 87.6
+            cachedGlucoseObject.startDate = dateFormatter.date(from: "2020-05-14T22:38:14Z")!
+            cachedGlucoseObject.isDisplayOnly = true
+            cachedGlucoseObject.wasUserEntered = false
+            cachedGlucoseObject.modificationCounter = 234
+            try! assertCachedGlucoseObjectEncodable(cachedGlucoseObject, encodesJSON: """
+{
+  "isDisplayOnly" : true,
+  "modificationCounter" : 234,
+  "startDate" : "2020-05-14T22:38:14Z",
+  "syncVersion" : 1,
+  "uploadState" : 0,
+  "value" : 87.599999999999994,
+  "wasUserEntered" : false
+}
+"""
+            )
+        }
+    }
+
+    private func assertCachedGlucoseObjectEncodable(_ original: CachedGlucoseObject, encodesJSON string: String) throws {
+        let data = try encoder.encode(original)
+        XCTAssertEqual(String(data: data, encoding: .utf8), string)
+    }
+
+    private let dateFormatter = ISO8601DateFormatter()
+
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+}
 
 extension CachedGlucoseObject {
     fileprivate func setDefaultValues() {

--- a/LoopKitTests/Persistence/DeviceLogEntryTests.swift
+++ b/LoopKitTests/Persistence/DeviceLogEntryTests.swift
@@ -1,0 +1,95 @@
+//
+//  DeviceLogEntryTests.swift
+//  LoopKitTests
+//
+//  Created by Darin Krauss on 8/26/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import XCTest
+import CoreData
+@testable import LoopKit
+
+class DeviceLogEntryEncodableTests: XCTestCase {
+    private var persistentContainer: NSPersistentContainer!
+    private var managedObjectContext: NSManagedObjectContext!
+
+    override func setUp() {
+        super.setUp()
+
+        let persistentStoreDescription = NSPersistentStoreDescription()
+        persistentStoreDescription.type = NSInMemoryStoreType
+
+        persistentContainer = PersistentContainer(name: "DeviceLog")
+        persistentContainer.persistentStoreDescriptions = [persistentStoreDescription]
+        persistentContainer.loadPersistentStores { (_, _) in }
+
+        managedObjectContext = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+        managedObjectContext.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy
+        managedObjectContext.automaticallyMergesChangesFromParent = true
+        managedObjectContext.persistentStoreCoordinator = persistentContainer.persistentStoreCoordinator
+    }
+
+    override func tearDown() {
+        managedObjectContext = nil
+        persistentContainer = nil
+
+        super.tearDown()
+    }
+
+    func testEncodable() throws {
+        managedObjectContext.performAndWait {
+            let deviceLogEntry = DeviceLogEntry(context: managedObjectContext)
+            deviceLogEntry.type = .connection
+            deviceLogEntry.managerIdentifier = "238E41EA-9576-4981-A1A4-51E10228584F"
+            deviceLogEntry.deviceIdentifier = "7723A0EE-F6D5-46E0-BBFE-1DEEBF8ED6F2"
+            deviceLogEntry.message = "This is the message"
+            deviceLogEntry.timestamp = dateFormatter.date(from: "2020-05-14T22:38:14Z")!
+            deviceLogEntry.modificationCounter = 123
+            try! assertDeviceLogEntryEncodable(deviceLogEntry, encodesJSON: """
+{
+  "deviceIdentifier" : "7723A0EE-F6D5-46E0-BBFE-1DEEBF8ED6F2",
+  "managerIdentifier" : "238E41EA-9576-4981-A1A4-51E10228584F",
+  "message" : "This is the message",
+  "modificationCounter" : 123,
+  "timestamp" : "2020-05-14T22:38:14Z",
+  "type" : "connection"
+}
+"""
+            )
+        }
+    }
+
+    func testEncodableOptional() throws {
+        managedObjectContext.performAndWait {
+            let deviceLogEntry = DeviceLogEntry(context: managedObjectContext)
+            deviceLogEntry.modificationCounter = 234
+            try! assertDeviceLogEntryEncodable(deviceLogEntry, encodesJSON: """
+{
+  "modificationCounter" : 234
+}
+"""
+            )
+        }
+    }
+
+    private func assertDeviceLogEntryEncodable(_ original: DeviceLogEntry, encodesJSON string: String) throws {
+        let data = try encoder.encode(original)
+        XCTAssertEqual(String(data: data, encoding: .utf8), string)
+    }
+
+    private let dateFormatter = ISO8601DateFormatter()
+
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+}

--- a/LoopKitTests/Persistence/PumpEventTests.swift
+++ b/LoopKitTests/Persistence/PumpEventTests.swift
@@ -1,0 +1,92 @@
+//
+//  PumpEventTests.swift
+//  LoopKitTests
+//
+//  Created by Darin Krauss on 8/26/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import XCTest
+@testable import LoopKit
+
+class PumpEventEncodableTests: PersistenceControllerTestCase {
+    func testEncodable() throws {
+        cacheStore.managedObjectContext.performAndWait {
+            let pumpEvent = PumpEvent(context: cacheStore.managedObjectContext)
+            pumpEvent.createdAt = dateFormatter.date(from: "2020-05-14T22:33:48Z")!
+            pumpEvent.date = dateFormatter.date(from: "2020-05-14T22:38:14Z")!
+            pumpEvent.doseType = .tempBasal
+            pumpEvent.duration = .minutes(30)
+            pumpEvent.type = .tempBasal
+            pumpEvent.unit = .unitsPerHour
+            pumpEvent.uploaded = false
+            pumpEvent.value = 1.23
+            pumpEvent.deliveredUnits = 0.56
+            pumpEvent.mutable = true
+            pumpEvent.raw = Data(base64Encoded: "MTIzNDU2Nzg5MA==")!
+            pumpEvent.title = "This is the title"
+            pumpEvent.modificationCounter = 123
+            try! assertPumpEventEncodable(pumpEvent, encodesJSON: """
+{
+  "createdAt" : "2020-05-14T22:33:48Z",
+  "date" : "2020-05-14T22:38:14Z",
+  "deliveredUnits" : 0.56000000000000005,
+  "doseType" : "tempBasal",
+  "duration" : 1800,
+  "modificationCounter" : 123,
+  "mutable" : true,
+  "raw" : "MTIzNDU2Nzg5MA==",
+  "title" : "This is the title",
+  "type" : "TempBasal",
+  "unit" : "U/hour",
+  "uploaded" : false,
+  "value" : 1.23
+}
+"""
+            )
+        }
+    }
+
+    func testEncodableOptional() throws {
+        cacheStore.managedObjectContext.performAndWait {
+            let pumpEvent = PumpEvent(context: cacheStore.managedObjectContext)
+            pumpEvent.createdAt = dateFormatter.date(from: "2020-05-13T22:33:48Z")!
+            pumpEvent.date = dateFormatter.date(from: "2020-05-13T22:38:14Z")!
+            pumpEvent.duration = .minutes(60)
+            pumpEvent.uploaded = true
+            pumpEvent.mutable = false
+            pumpEvent.modificationCounter = 234
+            try! assertPumpEventEncodable(pumpEvent, encodesJSON: """
+{
+  "createdAt" : "2020-05-13T22:33:48Z",
+  "date" : "2020-05-13T22:38:14Z",
+  "duration" : 3600,
+  "modificationCounter" : 234,
+  "mutable" : false,
+  "uploaded" : true
+}
+"""
+            )
+        }
+    }
+
+    private func assertPumpEventEncodable(_ original: PumpEvent, encodesJSON string: String) throws {
+        let data = try encoder.encode(original)
+        XCTAssertEqual(String(data: data, encoding: .utf8), string)
+    }
+
+    private let dateFormatter = ISO8601DateFormatter()
+
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+}

--- a/LoopKitTests/PersistentDeviceLogTests.swift
+++ b/LoopKitTests/PersistentDeviceLogTests.swift
@@ -1,0 +1,93 @@
+//
+//  PersistentDeviceLogTests.swift
+//  LoopKitTests
+//
+//  Created by Darin Krauss on 8/26/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import XCTest
+import LoopKit
+
+class PersistentDeviceLogCriticalEventLogTests: XCTestCase {
+    var persistentDeviceLog: PersistentDeviceLog!
+    var outputStream: MockOutputStream!
+    var progressor: MockEstimatedDurationProgressor!
+
+    override func setUp() {
+        super.setUp()
+
+        let entries = [StoredDeviceLogEntry(type: .delegateResponse, managerIdentifier: "m1", deviceIdentifier: "d1", message: "Message 1", timestamp: dateFormatter.date(from: "2100-01-02T03:08:00Z")!),
+                       StoredDeviceLogEntry(type: .receive, managerIdentifier: "m2", deviceIdentifier: "d2", message: "Message 2", timestamp: dateFormatter.date(from: "2100-01-02T03:10:00Z")!),
+                       StoredDeviceLogEntry(type: .send, managerIdentifier: "m3", deviceIdentifier: "d3", message: "Message 3", timestamp: dateFormatter.date(from: "2100-01-02T03:04:00Z")!),
+                       StoredDeviceLogEntry(type: .delegate, managerIdentifier: "m4", deviceIdentifier: "d4", message: "Message 4", timestamp: dateFormatter.date(from: "2100-01-02T03:06:00Z")!),
+                       StoredDeviceLogEntry(type: .connection, managerIdentifier: "m5", deviceIdentifier: "d5", message: "Message 5", timestamp: dateFormatter.date(from: "2100-01-02T03:02:00Z")!)]
+
+        persistentDeviceLog = PersistentDeviceLog(storageFile: URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString), maxEntryAge: .hours(1))
+        XCTAssertNil(persistentDeviceLog.addStoredDeviceLogEntries(entries: entries))
+
+        outputStream = MockOutputStream()
+        progressor = MockEstimatedDurationProgressor()
+    }
+
+    override func tearDown() {
+        persistentDeviceLog = nil
+
+        super.tearDown()
+    }
+
+    func testExportEstimatedDuration() {
+        switch persistentDeviceLog.exportEstimatedDuration(startDate: dateFormatter.date(from: "2100-01-02T03:03:00Z")!,
+                                                     endDate: dateFormatter.date(from: "2100-01-02T03:09:00Z")!) {
+        case .failure(let error):
+            XCTFail("Unexpected failure: \(error)")
+        case .success(let estimatedDuration):
+            XCTAssertEqual(estimatedDuration, 3 * 0.0006, accuracy: 0.0001)
+        }
+    }
+
+    func testExportEstimatedDurationEmpty() {
+        switch persistentDeviceLog.exportEstimatedDuration(startDate: dateFormatter.date(from: "2100-01-02T03:00:00Z")!,
+                                                     endDate: dateFormatter.date(from: "2100-01-02T03:01:00Z")!) {
+        case .failure(let error):
+            XCTFail("Unexpected failure: \(error)")
+        case .success(let estimatedDuration):
+            XCTAssertEqual(estimatedDuration, 0)
+        }
+    }
+
+    func testExport() {
+        XCTAssertNil(persistentDeviceLog.export(startDate: dateFormatter.date(from: "2100-01-02T03:03:00Z")!,
+                                          endDate: dateFormatter.date(from: "2100-01-02T03:09:00Z")!,
+                                          to: outputStream,
+                                          progressor: progressor))
+        XCTAssertEqual(outputStream.string, """
+[
+{"deviceIdentifier":"d1","managerIdentifier":"m1","message":"Message 1","modificationCounter":1,"timestamp":"2100-01-02T03:08:00.000Z","type":"delegateResponse"},
+{"deviceIdentifier":"d3","managerIdentifier":"m3","message":"Message 3","modificationCounter":3,"timestamp":"2100-01-02T03:04:00.000Z","type":"send"},
+{"deviceIdentifier":"d4","managerIdentifier":"m4","message":"Message 4","modificationCounter":4,"timestamp":"2100-01-02T03:06:00.000Z","type":"delegate"}
+]
+"""
+        )
+        XCTAssertEqual(progressor.estimatedDuration, 3 * 0.0006, accuracy: 0.0001)
+    }
+
+    func testExportEmpty() {
+        XCTAssertNil(persistentDeviceLog.export(startDate: dateFormatter.date(from: "2100-01-02T03:00:00Z")!,
+                                          endDate: dateFormatter.date(from: "2100-01-02T03:01:00Z")!,
+                                          to: outputStream,
+                                          progressor: progressor))
+        XCTAssertEqual(outputStream.string, "[]")
+        XCTAssertEqual(progressor.estimatedDuration, 0)
+    }
+
+    func testExportCancelled() {
+        progressor.isCancelled = true
+        XCTAssertEqual(persistentDeviceLog.export(startDate: dateFormatter.date(from: "2100-01-02T03:03:00Z")!,
+                                            endDate: dateFormatter.date(from: "2100-01-02T03:09:00Z")!,
+                                            to: outputStream,
+                                            progressor: progressor) as? CriticalEventLogError, CriticalEventLogError.cancelled)
+    }
+
+    private let dateFormatter = ISO8601DateFormatter()
+}

--- a/LoopKitTests/SettingsStoreTests.swift
+++ b/LoopKitTests/SettingsStoreTests.swift
@@ -95,6 +95,234 @@ class SettingsStorePersistenceTests: PersistenceControllerTestCase, SettingsStor
         wait(for: [storeSettingsHandler1, storeSettingsCompletion1, storeSettingsHandler2, storeSettingsCompletion2], timeout: 2, enforceOrder: true)
     }
     
+    // MARK: -
+
+    func testSettingsObjectEncodable() throws {
+        cacheStore.managedObjectContext.performAndWait {
+            do {
+                let object = SettingsObject(context: cacheStore.managedObjectContext)
+                object.data = try PropertyListEncoder().encode(StoredSettings.test)
+                object.date = dateFormatter.date(from: "2100-01-02T03:03:00Z")!
+                object.modificationCounter = 123
+                try assertSettingsObjectEncodable(object, encodesJSON: """
+{
+  "data" : {
+    "basalRateSchedule" : {
+      "items" : [
+        {
+          "startTime" : 0,
+          "value" : 1
+        },
+        {
+          "startTime" : 21600,
+          "value" : 1.5
+        },
+        {
+          "startTime" : 64800,
+          "value" : 1.25
+        }
+      ],
+      "referenceTimeInterval" : 0,
+      "repeatInterval" : 86400,
+      "timeZone" : {
+        "identifier" : "America/Los_Angeles"
+      }
+    },
+    "bloodGlucoseUnit" : "mg/dL",
+    "carbRatioSchedule" : {
+      "unit" : "g",
+      "valueSchedule" : {
+        "items" : [
+          {
+            "startTime" : 0,
+            "value" : 15
+          },
+          {
+            "startTime" : 32400,
+            "value" : 14
+          },
+          {
+            "startTime" : 72000,
+            "value" : 18
+          }
+        ],
+        "referenceTimeInterval" : 0,
+        "repeatInterval" : 86400,
+        "timeZone" : {
+          "identifier" : "America/Los_Angeles"
+        }
+      }
+    },
+    "date" : "2020-05-14T22:48:15Z",
+    "deviceToken" : "DeviceTokenString",
+    "dosingEnabled" : true,
+    "glucoseTargetRangeSchedule" : {
+      "override" : {
+        "end" : "2020-05-14T14:48:15Z",
+        "start" : "2020-05-14T12:48:15Z",
+        "value" : {
+          "maxValue" : 115,
+          "minValue" : 105
+        }
+      },
+      "rangeSchedule" : {
+        "unit" : "mg/dL",
+        "valueSchedule" : {
+          "items" : [
+            {
+              "startTime" : 0,
+              "value" : {
+                "maxValue" : 110,
+                "minValue" : 100
+              }
+            },
+            {
+              "startTime" : 25200,
+              "value" : {
+                "maxValue" : 100,
+                "minValue" : 90
+              }
+            },
+            {
+              "startTime" : 75600,
+              "value" : {
+                "maxValue" : 120,
+                "minValue" : 110
+              }
+            }
+          ],
+          "referenceTimeInterval" : 0,
+          "repeatInterval" : 86400,
+          "timeZone" : {
+            "identifier" : "America/Los_Angeles"
+          }
+        }
+      }
+    },
+    "insulinModel" : {
+      "actionDuration" : 21600,
+      "modelType" : "rapidAdult",
+      "peakActivity" : 10800
+    },
+    "insulinSensitivitySchedule" : {
+      "unit" : "mg/dL",
+      "valueSchedule" : {
+        "items" : [
+          {
+            "startTime" : 0,
+            "value" : 45
+          },
+          {
+            "startTime" : 10800,
+            "value" : 40
+          },
+          {
+            "startTime" : 54000,
+            "value" : 50
+          }
+        ],
+        "referenceTimeInterval" : 0,
+        "repeatInterval" : 86400,
+        "timeZone" : {
+          "identifier" : "America/Los_Angeles"
+        }
+      }
+    },
+    "maximumBasalRatePerHour" : 3.5,
+    "maximumBolus" : 10,
+    "overridePresets" : [
+      {
+        "duration" : {
+          "finite" : {
+            "duration" : 3600
+          }
+        },
+        "id" : "2A67A303-5203-4CB8-8263-79498265368E",
+        "name" : "Apple",
+        "settings" : {
+          "insulinNeedsScaleFactor" : 2,
+          "targetRangeInMgdl" : {
+            "maxValue" : 140,
+            "minValue" : 130
+          }
+        },
+        "symbol" : "🍎"
+      }
+    ],
+    "preMealOverride" : {
+      "context" : "preMeal",
+      "duration" : "indefinite",
+      "enactTrigger" : "local",
+      "settings" : {
+        "insulinNeedsScaleFactor" : 0.5,
+        "targetRangeInMgdl" : {
+          "maxValue" : 90,
+          "minValue" : 80
+        }
+      },
+      "startDate" : "2020-05-14T14:38:39Z",
+      "syncIdentifier" : "2A67A303-5203-1234-8263-79498265368E"
+    },
+    "preMealTargetRange" : {
+      "maxValue" : 90,
+      "minValue" : 80
+    },
+    "scheduleOverride" : {
+      "context" : "preMeal",
+      "duration" : {
+        "finite" : {
+          "duration" : 3600
+        }
+      },
+      "enactTrigger" : {
+        "remote" : {
+          "address" : "127.0.0.1"
+        }
+      },
+      "settings" : {
+        "insulinNeedsScaleFactor" : 1.5,
+        "targetRangeInMgdl" : {
+          "maxValue" : 120,
+          "minValue" : 110
+        }
+      },
+      "startDate" : "2020-05-14T14:48:19Z",
+      "syncIdentifier" : "2A67A303-1234-4CB8-8263-79498265368E"
+    },
+    "suspendThreshold" : {
+      "unit" : "mg/dL",
+      "value" : 75
+    },
+    "syncIdentifier" : "2A67A303-1234-4CB8-1234-79498265368E",
+    "workoutTargetRange" : {
+      "maxValue" : 160,
+      "minValue" : 150
+    }
+  },
+  "date" : "2100-01-02T03:03:00Z",
+  "modificationCounter" : 123
+}
+"""
+                )
+            } catch let error {
+                XCTFail("Unexpected failure: \(error)")
+            }
+        }
+    }
+
+    private func assertSettingsObjectEncodable(_ original: SettingsObject, encodesJSON string: String) throws {
+        let data = try encoder.encode(original)
+        XCTAssertEqual(String(data: data, encoding: .utf8), string)
+    }
+
+    private let dateFormatter = ISO8601DateFormatter()
+
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
 }
 
 class SettingsStoreQueryAnchorTests: XCTestCase {
@@ -339,65 +567,99 @@ class SettingsStoreQueryTests: PersistenceControllerTestCase {
     
 }
 
+class SettingsStoreCriticalEventLogTests: PersistenceControllerTestCase {
+    var settingsStore: SettingsStore!
+    var outputStream: MockOutputStream!
+    var progressor: MockEstimatedDurationProgressor!
+
+    override func setUp() {
+        super.setUp()
+
+        let settings = [StoredSettings(date: dateFormatter.date(from: "2100-01-02T03:08:00Z")!, syncIdentifier: "18CF3948-0B3D-4B12-8BFE-14986B0E6784"),
+                        StoredSettings(date: dateFormatter.date(from: "2100-01-02T03:10:00Z")!, syncIdentifier: "C86DEB61-68E9-464E-9DD5-96A9CB445FD3"),
+                        StoredSettings(date: dateFormatter.date(from: "2100-01-02T03:04:00Z")!, syncIdentifier: "2B03D96C-6F5D-4140-99CD-80C3E64D6010"),
+                        StoredSettings(date: dateFormatter.date(from: "2100-01-02T03:06:00Z")!, syncIdentifier: "FF1C4F01-3558-4FB2-957E-FA1522C4735E"),
+                        StoredSettings(date: dateFormatter.date(from: "2100-01-02T03:02:00Z")!, syncIdentifier: "71B699D7-0E8F-4B13-B7A1-E7751EB78E74")]
+
+        settingsStore = SettingsStore(store: cacheStore, expireAfter: .hours(1))
+
+        let dispatchGroup = DispatchGroup()
+        dispatchGroup.enter()
+        settingsStore.addStoredSettings(settings: settings) { error in
+            XCTAssertNil(error)
+            dispatchGroup.leave()
+        }
+        dispatchGroup.wait()
+
+        outputStream = MockOutputStream()
+        progressor = MockEstimatedDurationProgressor()
+    }
+
+    override func tearDown() {
+        settingsStore = nil
+
+        super.tearDown()
+    }
+
+    func testExportEstimatedDuration() {
+        switch settingsStore.exportEstimatedDuration(startDate: dateFormatter.date(from: "2100-01-02T03:03:00Z")!,
+                                                     endDate: dateFormatter.date(from: "2100-01-02T03:09:00Z")!) {
+        case .failure(let error):
+            XCTFail("Unexpected failure: \(error)")
+        case .success(let estimatedDuration):
+            XCTAssertEqual(estimatedDuration, 3 * 0.0108, accuracy: 0.0001)
+        }
+    }
+
+    func testExportEstimatedDurationEmpty() {
+        switch settingsStore.exportEstimatedDuration(startDate: dateFormatter.date(from: "2100-01-02T03:00:00Z")!,
+                                                     endDate: dateFormatter.date(from: "2100-01-02T03:01:00Z")!) {
+        case .failure(let error):
+            XCTFail("Unexpected failure: \(error)")
+        case .success(let estimatedDuration):
+            XCTAssertEqual(estimatedDuration, 0)
+        }
+    }
+
+    func testExport() {
+        XCTAssertNil(settingsStore.export(startDate: dateFormatter.date(from: "2100-01-02T03:03:00Z")!,
+                                          endDate: dateFormatter.date(from: "2100-01-02T03:09:00Z")!,
+                                          to: outputStream,
+                                          progressor: progressor))
+        XCTAssertEqual(outputStream.string, """
+[
+{"data":{"date":"2100-01-02T03:08:00.000Z","dosingEnabled":false,"syncIdentifier":"18CF3948-0B3D-4B12-8BFE-14986B0E6784"},"date":"2100-01-02T03:08:00.000Z","modificationCounter":1},
+{"data":{"date":"2100-01-02T03:04:00.000Z","dosingEnabled":false,"syncIdentifier":"2B03D96C-6F5D-4140-99CD-80C3E64D6010"},"date":"2100-01-02T03:04:00.000Z","modificationCounter":3},
+{"data":{"date":"2100-01-02T03:06:00.000Z","dosingEnabled":false,"syncIdentifier":"FF1C4F01-3558-4FB2-957E-FA1522C4735E"},"date":"2100-01-02T03:06:00.000Z","modificationCounter":4}
+]
+"""
+        )
+        XCTAssertEqual(progressor.estimatedDuration, 3 * 0.0108, accuracy: 0.0001)
+    }
+
+    func testExportEmpty() {
+        XCTAssertNil(settingsStore.export(startDate: dateFormatter.date(from: "2100-01-02T03:00:00Z")!,
+                                          endDate: dateFormatter.date(from: "2100-01-02T03:01:00Z")!,
+                                          to: outputStream,
+                                          progressor: progressor))
+        XCTAssertEqual(outputStream.string, "[]")
+        XCTAssertEqual(progressor.estimatedDuration, 0)
+    }
+
+    func testExportCancelled() {
+        progressor.isCancelled = true
+        XCTAssertEqual(settingsStore.export(startDate: dateFormatter.date(from: "2100-01-02T03:03:00Z")!,
+                                            endDate: dateFormatter.date(from: "2100-01-02T03:09:00Z")!,
+                                            to: outputStream,
+                                            progressor: progressor) as? CriticalEventLogError, CriticalEventLogError.cancelled)
+    }
+
+    private let dateFormatter = ISO8601DateFormatter()
+}
+
 class StoredSettingsCodableTests: XCTestCase {
-    func testCodable() throws {
-        let settings = StoredSettings(date: dateFormatter.date(from: "2020-05-14T22:48:15Z")!,
-                                      dosingEnabled: true,
-                                      glucoseTargetRangeSchedule: GlucoseRangeSchedule(rangeSchedule: DailyQuantitySchedule(unit: .milligramsPerDeciliter,
-                                                                                                                            dailyItems: [RepeatingScheduleValue(startTime: .hours(0), value: DoubleRange(minValue: 100.0, maxValue: 110.0)),
-                                                                                                                                         RepeatingScheduleValue(startTime: .hours(7), value: DoubleRange(minValue: 90.0, maxValue: 100.0)),
-                                                                                                                                         RepeatingScheduleValue(startTime: .hours(21), value: DoubleRange(minValue: 110.0, maxValue: 120.0))],
-                                                                                                                            timeZone: TimeZone(identifier: "America/Los_Angeles")!)!,
-                                                                                       override: GlucoseRangeSchedule.Override(value: DoubleRange(minValue: 105.0, maxValue: 115.0),
-                                                                                                                               start: dateFormatter.date(from: "2020-05-14T12:48:15Z")!,
-                                                                                                                               end: dateFormatter.date(from: "2020-05-14T14:48:15Z")!)),
-                                      preMealTargetRange: DoubleRange(minValue: 80.0, maxValue: 90.0),
-                                      workoutTargetRange: DoubleRange(minValue: 150.0, maxValue: 160.0),
-                                      overridePresets: [TemporaryScheduleOverridePreset(id: UUID(uuidString: "2A67A303-5203-4CB8-8263-79498265368E")!,
-                                                                                        symbol: "🍎",
-                                                                                        name: "Apple",
-                                                                                        settings: TemporaryScheduleOverrideSettings(unit: .milligramsPerDeciliter,
-                                                                                                                                    targetRange: DoubleRange(minValue: 130.0, maxValue: 140.0),
-                                                                                                                                    insulinNeedsScaleFactor: 2.0),
-                                                                                        duration: .finite(.minutes(60)))],
-                                      scheduleOverride: TemporaryScheduleOverride(context: .preMeal,
-                                                                                  settings: TemporaryScheduleOverrideSettings(unit: .milligramsPerDeciliter,
-                                                                                                                              targetRange: DoubleRange(minValue: 110.0, maxValue: 120.0),
-                                                                                                                              insulinNeedsScaleFactor: 1.5),
-                                                                                  startDate: dateFormatter.date(from: "2020-05-14T14:48:19Z")!,
-                                                                                  duration: .finite(.minutes(60)),
-                                                                                  enactTrigger: .remote("127.0.0.1"),
-                                                                                  syncIdentifier: UUID(uuidString: "2A67A303-1234-4CB8-8263-79498265368E")!),
-                                      preMealOverride: TemporaryScheduleOverride(context: .preMeal,
-                                                                                 settings: TemporaryScheduleOverrideSettings(unit: .milligramsPerDeciliter,
-                                                                                                                             targetRange: DoubleRange(minValue: 80.0, maxValue: 90.0),
-                                                                                                                             insulinNeedsScaleFactor: 0.5),
-                                                                                 startDate: dateFormatter.date(from: "2020-05-14T14:38:39Z")!,
-                                                                                 duration: .indefinite,
-                                                                                 enactTrigger: .local,
-                                                                                 syncIdentifier: UUID(uuidString: "2A67A303-5203-1234-8263-79498265368E")!),
-                                      maximumBasalRatePerHour: 3.5,
-                                      maximumBolus: 10.0,
-                                      suspendThreshold: GlucoseThreshold(unit: .milligramsPerDeciliter, value: 75.0),
-                                      deviceToken: "DeviceTokenString",
-                                      insulinModel: StoredSettings.InsulinModel(modelType: .rapidAdult, actionDuration: .hours(6), peakActivity: .hours(3)),
-                                      basalRateSchedule: BasalRateSchedule(dailyItems: [RepeatingScheduleValue(startTime: .hours(0), value: 1.0),
-                                                                                        RepeatingScheduleValue(startTime: .hours(6), value: 1.5),
-                                                                                        RepeatingScheduleValue(startTime: .hours(18), value: 1.25)],
-                                                                           timeZone: TimeZone(identifier: "America/Los_Angeles")!),
-                                      insulinSensitivitySchedule: InsulinSensitivitySchedule(unit: .milligramsPerDeciliter,
-                                                                                             dailyItems: [RepeatingScheduleValue(startTime: .hours(0), value: 45.0),
-                                                                                                          RepeatingScheduleValue(startTime: .hours(3), value: 40.0),
-                                                                                                          RepeatingScheduleValue(startTime: .hours(15), value: 50.0)],
-                                                                                             timeZone: TimeZone(identifier: "America/Los_Angeles")!),
-                                      carbRatioSchedule: CarbRatioSchedule(unit: .gram(),
-                                                                           dailyItems: [RepeatingScheduleValue(startTime: .hours(0), value: 15.0),
-                                                                                        RepeatingScheduleValue(startTime: .hours(9), value: 14.0),
-                                                                                        RepeatingScheduleValue(startTime: .hours(20), value: 18.0)],
-                                                                           timeZone: TimeZone(identifier: "America/Los_Angeles")!),
-                                      bloodGlucoseUnit: .milligramsPerDeciliter,
-                                      syncIdentifier: "2A67A303-1234-4CB8-1234-79498265368E")
-        try assertStoredSettingsCodable(settings, encodesJSON: """
+    func testStoredSettingsCodable() throws {
+        try assertStoredSettingsCodable(StoredSettings.test, encodesJSON: """
 {
   "basalRateSchedule" : {
     "items" : [
@@ -639,4 +901,67 @@ extension StoredSettings: Equatable {
             lhs.bloodGlucoseUnit == rhs.bloodGlucoseUnit &&
             lhs.syncIdentifier == rhs.syncIdentifier
     }
+}
+
+fileprivate extension StoredSettings {
+    static var test: StoredSettings {
+        return StoredSettings(date: dateFormatter.date(from: "2020-05-14T22:48:15Z")!,
+                              dosingEnabled: true,
+                              glucoseTargetRangeSchedule: GlucoseRangeSchedule(rangeSchedule: DailyQuantitySchedule(unit: .milligramsPerDeciliter,
+                                                                                                                    dailyItems: [RepeatingScheduleValue(startTime: .hours(0), value: DoubleRange(minValue: 100.0, maxValue: 110.0)),
+                                                                                                                                 RepeatingScheduleValue(startTime: .hours(7), value: DoubleRange(minValue: 90.0, maxValue: 100.0)),
+                                                                                                                                 RepeatingScheduleValue(startTime: .hours(21), value: DoubleRange(minValue: 110.0, maxValue: 120.0))],
+                                                                                                                    timeZone: TimeZone(identifier: "America/Los_Angeles")!)!,
+                                                                               override: GlucoseRangeSchedule.Override(value: DoubleRange(minValue: 105.0, maxValue: 115.0),
+                                                                                                                       start: dateFormatter.date(from: "2020-05-14T12:48:15Z")!,
+                                                                                                                       end: dateFormatter.date(from: "2020-05-14T14:48:15Z")!)),
+                              preMealTargetRange: DoubleRange(minValue: 80.0, maxValue: 90.0),
+                              workoutTargetRange: DoubleRange(minValue: 150.0, maxValue: 160.0),
+                              overridePresets: [TemporaryScheduleOverridePreset(id: UUID(uuidString: "2A67A303-5203-4CB8-8263-79498265368E")!,
+                                                                                symbol: "🍎",
+                                                                                name: "Apple",
+                                                                                settings: TemporaryScheduleOverrideSettings(unit: .milligramsPerDeciliter,
+                                                                                                                            targetRange: DoubleRange(minValue: 130.0, maxValue: 140.0),
+                                                                                                                            insulinNeedsScaleFactor: 2.0),
+                                                                                duration: .finite(.minutes(60)))],
+                              scheduleOverride: TemporaryScheduleOverride(context: .preMeal,
+                                                                          settings: TemporaryScheduleOverrideSettings(unit: .milligramsPerDeciliter,
+                                                                                                                      targetRange: DoubleRange(minValue: 110.0, maxValue: 120.0),
+                                                                                                                      insulinNeedsScaleFactor: 1.5),
+                                                                          startDate: dateFormatter.date(from: "2020-05-14T14:48:19Z")!,
+                                                                          duration: .finite(.minutes(60)),
+                                                                          enactTrigger: .remote("127.0.0.1"),
+                                                                          syncIdentifier: UUID(uuidString: "2A67A303-1234-4CB8-8263-79498265368E")!),
+                              preMealOverride: TemporaryScheduleOverride(context: .preMeal,
+                                                                         settings: TemporaryScheduleOverrideSettings(unit: .milligramsPerDeciliter,
+                                                                                                                     targetRange: DoubleRange(minValue: 80.0, maxValue: 90.0),
+                                                                                                                     insulinNeedsScaleFactor: 0.5),
+                                                                         startDate: dateFormatter.date(from: "2020-05-14T14:38:39Z")!,
+                                                                         duration: .indefinite,
+                                                                         enactTrigger: .local,
+                                                                         syncIdentifier: UUID(uuidString: "2A67A303-5203-1234-8263-79498265368E")!),
+                              maximumBasalRatePerHour: 3.5,
+                              maximumBolus: 10.0,
+                              suspendThreshold: GlucoseThreshold(unit: .milligramsPerDeciliter, value: 75.0),
+                              deviceToken: "DeviceTokenString",
+                              insulinModel: StoredInsulinModel(modelType: .rapidAdult, actionDuration: .hours(6), peakActivity: .hours(3)),
+                              basalRateSchedule: BasalRateSchedule(dailyItems: [RepeatingScheduleValue(startTime: .hours(0), value: 1.0),
+                                                                                RepeatingScheduleValue(startTime: .hours(6), value: 1.5),
+                                                                                RepeatingScheduleValue(startTime: .hours(18), value: 1.25)],
+                                                                   timeZone: TimeZone(identifier: "America/Los_Angeles")!),
+                              insulinSensitivitySchedule: InsulinSensitivitySchedule(unit: .milligramsPerDeciliter,
+                                                                                     dailyItems: [RepeatingScheduleValue(startTime: .hours(0), value: 45.0),
+                                                                                                  RepeatingScheduleValue(startTime: .hours(3), value: 40.0),
+                                                                                                  RepeatingScheduleValue(startTime: .hours(15), value: 50.0)],
+                                                                                     timeZone: TimeZone(identifier: "America/Los_Angeles")!),
+                              carbRatioSchedule: CarbRatioSchedule(unit: .gram(),
+                                                                   dailyItems: [RepeatingScheduleValue(startTime: .hours(0), value: 15.0),
+                                                                                RepeatingScheduleValue(startTime: .hours(9), value: 14.0),
+                                                                                RepeatingScheduleValue(startTime: .hours(20), value: 18.0)],
+                                                                   timeZone: TimeZone(identifier: "America/Los_Angeles")!),
+                              bloodGlucoseUnit: .milligramsPerDeciliter,
+                              syncIdentifier: "2A67A303-1234-4CB8-1234-79498265368E")
+    }
+
+    private static let dateFormatter = ISO8601DateFormatter()
 }

--- a/LoopKitTests/StoredInsulinModelTests.swift
+++ b/LoopKitTests/StoredInsulinModelTests.swift
@@ -1,0 +1,55 @@
+//
+//  StoredInsulinModelTests.swift
+//  LoopKitTests
+//
+//  Created by Darin Krauss on 8/26/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import XCTest
+@testable import LoopKit
+
+class StoredInsulinModelCodableTests: XCTestCase {
+    func testCodable() throws {
+        let storedInsulinModel = StoredInsulinModel(modelType: .rapidAdult, actionDuration: .hours(6), peakActivity: .hours(3))
+        try! assertStoredInsulinModelCodable(storedInsulinModel, encodesJSON: """
+{
+  "actionDuration" : 21600,
+  "modelType" : "rapidAdult",
+  "peakActivity" : 10800
+}
+"""
+        )
+    }
+
+    func testCodableOptional() throws {
+        let storedInsulinModel = StoredInsulinModel(modelType: .rapidChild, actionDuration: .hours(5))
+        try! assertStoredInsulinModelCodable(storedInsulinModel, encodesJSON: """
+{
+  "actionDuration" : 18000,
+  "modelType" : "rapidChild"
+}
+"""
+        )
+    }
+
+    private func assertStoredInsulinModelCodable(_ original: StoredInsulinModel, encodesJSON string: String) throws {
+        let data = try encoder.encode(original)
+        XCTAssertEqual(String(data: data, encoding: .utf8), string)
+        let decoded = try decoder.decode(StoredInsulinModel.self, from: data)
+        XCTAssertEqual(decoded, original)
+    }
+
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+}


### PR DESCRIPTION
- https://tidepool.atlassian.net/browse/LOOP-1201
- Add critical event log export to several Core Data stores
- Add Encodable to various Core Data models
- Add modificationCounter to DeviceLogEntry
- Add JSONStreamEncoder
- Replace StoredSettings.InsulinModel with StoredInsulinModel
- Fix PumpManagerStatus Codable for optional pumpStatusHighlight and pumpLifecycleProgress

Note: This will require @ps2 and one other reviewer. Also, I looked into breaking this into smaller PRs, but could not come up with a way to do so that made any sense. (I could have broken out the `Codable` implementations, but that doesn't make this PR any easier, just a bit smaller, and is not worth the work.)

Note: All of the store implementations of `CriticalEventLog` are very similar (with only a few differences unique to each store). Once you've understood one, you've understood 95% of the rest).