### PR TITLE
LOOP-1916:  Move cursor to the end on begin editing (take 2)

### DIFF
--- a/Extensions/UITextField.swift
+++ b/Extensions/UITextField.swift
@@ -10,26 +10,20 @@ import UIKit
 
 extension UITextField {
     
-    func selectAll(completion: (() -> Void)? = nil) {
-        DispatchQueue.main.async {
-            self.selectedTextRange = self.textRange(from: self.beginningOfDocument, to: self.endOfDocument)
-            completion?()
-        }
+    func selectAll() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        self.selectedTextRange = self.textRange(from: self.beginningOfDocument, to: self.endOfDocument)
     }
 
-    func moveCursorToEnd(completion: (() -> Void)? = nil) {
-        DispatchQueue.main.async {
-            let newPosition = self.endOfDocument
-            self.selectedTextRange = self.textRange(from: newPosition, to: newPosition)
-            completion?()
-        }
+    func moveCursorToEnd() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        let newPosition = self.endOfDocument
+        self.selectedTextRange = self.textRange(from: newPosition, to: newPosition)
     }
     
-    func moveCursorToBeginning(completion: (() -> Void)? = nil) {
-        DispatchQueue.main.async {
-            let newPosition = self.beginningOfDocument
-            self.selectedTextRange = self.textRange(from: newPosition, to: newPosition)
-            completion?()
-        }
+    func moveCursorToBeginning() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        let newPosition = self.beginningOfDocument
+        self.selectedTextRange = self.textRange(from: newPosition, to: newPosition)
     }
 }

--- a/LoopKitUI/Views/DismissibleKeyboardTextField.swift
+++ b/LoopKitUI/Views/DismissibleKeyboardTextField.swift
@@ -98,7 +98,11 @@ public struct DismissibleKeyboardTextField: UIViewRepresentable {
         }
         
         @objc fileprivate func editingDidBegin(_ textField: UITextField) {
-            textField.moveCursorToEnd()
+            // Even though we are likely already on .main, we still need to queue this cursor (selection) change in
+            // order for it to work
+            DispatchQueue.main.async {
+                textField.moveCursorToEnd()
+            }
         }
     }
 }

--- a/LoopKitUI/Views/TextFieldTableViewCell.swift
+++ b/LoopKitUI/Views/TextFieldTableViewCell.swift
@@ -65,8 +65,11 @@ public class TextFieldTableViewCell: UITableViewCell, UITextFieldDelegate {
     // MARK: - UITextFieldDelegate
     
     public func textFieldDidBeginEditing(_ textField: UITextField) {
-        textField.moveCursorToEnd { [weak self] in
+        // Even though we are likely already on .main, we still need to queue this cursor (selection) change in
+        // order for it to work
+        DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
+            self.textField.moveCursorToEnd()
             self.delegate?.textFieldTableViewCellDidBeginEditing(self)
         }
     }


### PR DESCRIPTION
Pete gave good PR feedback that the caller should be responsible for deciding whether to queue on .main, not the callee.
In this case, too, since the callers were already on main, _but still need to queue due to timing issues_, I added comments explaining why.