### PR TITLE
LOOP-1963: Prevent crashing if DismissibleKeyboardTextField needs to become first responder

### DIFF
--- a/LoopKitUI/Views/DismissibleKeyboardTextField.swift
+++ b/LoopKitUI/Views/DismissibleKeyboardTextField.swift
@@ -71,8 +71,9 @@ public struct DismissibleKeyboardTextField: UIViewRepresentable {
         textField.autocorrectionType = autocorrectionType
 
         if shouldBecomeFirstResponder && !context.coordinator.didBecomeFirstResponder {
-            textField.becomeFirstResponder()
-            context.coordinator.didBecomeFirstResponder = true
+            if textField.canBecomeFirstResponder && textField.becomeFirstResponder() {
+                context.coordinator.didBecomeFirstResponder = true
+            }
         } else if !shouldBecomeFirstResponder && context.coordinator.didBecomeFirstResponder {
             context.coordinator.didBecomeFirstResponder = false
         }

--- a/LoopKitUI/Views/DismissibleKeyboardTextField.swift
+++ b/LoopKitUI/Views/DismissibleKeyboardTextField.swift
@@ -72,7 +72,7 @@ public struct DismissibleKeyboardTextField: UIViewRepresentable {
 
         if shouldBecomeFirstResponder && !context.coordinator.didBecomeFirstResponder {
             // See https://developer.apple.com/documentation/uikit/uiresponder/1621113-becomefirstresponder for why
-            // we check the window property here
+            // we check the window property here (otherwise it might crash)
             if textField.window != nil && textField.becomeFirstResponder() {
                 context.coordinator.didBecomeFirstResponder = true
             }

--- a/LoopKitUI/Views/DismissibleKeyboardTextField.swift
+++ b/LoopKitUI/Views/DismissibleKeyboardTextField.swift
@@ -71,7 +71,9 @@ public struct DismissibleKeyboardTextField: UIViewRepresentable {
         textField.autocorrectionType = autocorrectionType
 
         if shouldBecomeFirstResponder && !context.coordinator.didBecomeFirstResponder {
-            if textField.canBecomeFirstResponder && textField.becomeFirstResponder() {
+            // See https://developer.apple.com/documentation/uikit/uiresponder/1621113-becomefirstresponder for why
+            // we check the window property here
+            if textField.window != nil && textField.becomeFirstResponder() {
                 context.coordinator.didBecomeFirstResponder = true
             }
         } else if !shouldBecomeFirstResponder && context.coordinator.didBecomeFirstResponder {


### PR DESCRIPTION
@nhamming I took a crack at another way to fix this.  This simply avoids the crash, because it checks to make sure the `textField` `canBecomeFirstResponder` before calling `becomeFirstResponder()`