### PR TITLE
LOOP-1983: Prevent crash in MockService

### DIFF
--- a/MockKit/MockService.swift
+++ b/MockKit/MockService.swift
@@ -23,7 +23,10 @@ public final class MockService: Service {
     
     public var analytics: Bool
     
+    public let maxHistoryItems = 1000
+    
     public var history: [String]
+    private let historyQueue = DispatchQueue(label: "MockService_historyQueue")
     
     private var dateFormatter = ISO8601DateFormatter()
     
@@ -60,8 +63,14 @@ public final class MockService: Service {
     public func completeDelete() {}
     
     private func record(_ message: String) {
-        let timestamp = dateFormatter.string(from: Date())
-        history.append("\(timestamp): \(message)")
+        historyQueue.async { [weak self] in
+            guard let self = self else { return }
+            let timestamp = self.dateFormatter.string(from: Date())
+            self.history.append("\(timestamp): \(message)")
+            if self.history.count > self.maxHistoryItems {
+                self.history.removeFirst(self.history.count - self.maxHistoryItems)
+            }
+        }
     }
     
 }

--- a/MockKit/MockService.swift
+++ b/MockKit/MockService.swift
@@ -25,10 +25,10 @@ public final class MockService: Service {
     
     public let maxHistoryItems = 1000
     
-    private var _history = Locked<[String]>([])
+    private var lockedHistory = Locked<[String]>([])
     
     public var history: [String] {
-        _history.value
+        lockedHistory.value
     }
     
     private var dateFormatter = ISO8601DateFormatter()
@@ -62,12 +62,12 @@ public final class MockService: Service {
     public func completeDelete() {}
     
     public func clearHistory() {
-        _history.value = []
+        lockedHistory.value = []
     }
     
     private func record(_ message: String) {
         let timestamp = self.dateFormatter.string(from: Date())
-        _history.mutate { history in
+        lockedHistory.mutate { history in
             history.append("\(timestamp): \(message)")
             if history.count > self.maxHistoryItems {
                 history.removeFirst(history.count - self.maxHistoryItems)

--- a/MockKitUI/View Controllers/MockServiceTableViewController.swift
+++ b/MockKitUI/View Controllers/MockServiceTableViewController.swift
@@ -210,7 +210,7 @@ final class MockServiceTableViewController: UITableViewController {
                 show(MockServiceHistoryViewController.init(mockService: service), sender: tableView.cellForRow(at: indexPath))
             case .clearHistory:
                 let alert = UIAlertController(clearHistoryHandler: {
-                    self.service.history = []
+                    self.service.clearHistory()
                 })
                 present(alert, animated: true) {
                     tableView.deselectRow(at: indexPath, animated: true)


### PR DESCRIPTION
Stack traces seem to indicate a crash in MockService.  Either this array is being illegally accessed from multiple threads (more likely), or it is running out of memory (less likely, but still plausible given that  says he’s set the CGM update every 5 sec and it has run for hours).
[LOOP-1983](https://tidepool.atlassian.net/browse/LOOP-1983)