### PR TITLE
LOOP-1964: rename glucoseTargetRangeScheduleApplyingOverrideIfActive to effectiveGlucoseTargetRangeSchedule

### DIFF
--- a/LoopKit/DosingDecisionStore.swift
+++ b/LoopKit/DosingDecisionStore.swift
@@ -160,7 +160,7 @@ public struct StoredDosingDecision {
     public let carbsOnBoard: CarbValue?
     public let scheduleOverride: TemporaryScheduleOverride?
     public let glucoseTargetRangeSchedule: GlucoseRangeSchedule?
-    public let glucoseTargetRangeScheduleApplyingOverrideIfActive: GlucoseRangeSchedule?
+    public let effectiveGlucoseTargetRangeSchedule: GlucoseRangeSchedule?
     public let predictedGlucose: [PredictedGlucoseValue]?
     public let predictedGlucoseIncludingPendingInsulin: [PredictedGlucoseValue]?
     public let lastReservoirValue: LastReservoirValue?
@@ -181,7 +181,7 @@ public struct StoredDosingDecision {
                 carbsOnBoard: CarbValue? = nil,
                 scheduleOverride: TemporaryScheduleOverride? = nil,
                 glucoseTargetRangeSchedule: GlucoseRangeSchedule? = nil,
-                glucoseTargetRangeScheduleApplyingOverrideIfActive: GlucoseRangeSchedule? = nil,
+                effectiveGlucoseTargetRangeSchedule: GlucoseRangeSchedule? = nil,
                 predictedGlucose: [PredictedGlucoseValue]? = nil,
                 predictedGlucoseIncludingPendingInsulin: [PredictedGlucoseValue]? = nil,
                 lastReservoirValue: LastReservoirValue? = nil,
@@ -201,7 +201,7 @@ public struct StoredDosingDecision {
         self.carbsOnBoard = carbsOnBoard
         self.scheduleOverride = scheduleOverride
         self.glucoseTargetRangeSchedule = glucoseTargetRangeSchedule
-        self.glucoseTargetRangeScheduleApplyingOverrideIfActive = glucoseTargetRangeScheduleApplyingOverrideIfActive
+        self.effectiveGlucoseTargetRangeSchedule = effectiveGlucoseTargetRangeSchedule
         self.predictedGlucose = predictedGlucose
         self.predictedGlucoseIncludingPendingInsulin = predictedGlucoseIncludingPendingInsulin
         self.lastReservoirValue = lastReservoirValue


### PR DESCRIPTION
See also https://github.com/tidepool-org/Loop/pull/283

LW PR: https://github.com/tidepool-org/LoopWorkspace/pull/285