### PR TITLE
[LOOP-2358] Configurable pump sim supported ranges

### DIFF
--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -696,6 +696,7 @@
 		B42C951B24A63B8100857C73 /* DeviceStatusHighlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42C94FD24A2A2B000857C73 /* DeviceStatusHighlight.swift */; };
 		B43DA43F24D49AA400CAFF4E /* GuidanceColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43DA43E24D49AA400CAFF4E /* GuidanceColors.swift */; };
 		B43DA44224D9CD8500CAFF4E /* Environment+Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45AF6EF24D4355A00EEAA4D /* Environment+Colors.swift */; };
+		B45774352562CCC6004B9466 /* SupportRangeTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45774342562CCC6004B9466 /* SupportRangeTableViewController.swift */; };
 		B46B62A723FEFE4D001E69BA /* InstructionList.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46B62A623FEFE4D001E69BA /* InstructionList.swift */; };
 		B46B62A923FF05F8001E69BA /* LabeledNumberInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46B62A823FF05F8001E69BA /* LabeledNumberInput.swift */; };
 		B46B62AB23FF0822001E69BA /* LabeledValueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46B62AA23FF0822001E69BA /* LabeledValueView.swift */; };
@@ -1467,6 +1468,7 @@
 		B42C94FD24A2A2B000857C73 /* DeviceStatusHighlight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceStatusHighlight.swift; sourceTree = "<group>"; };
 		B42C950C24A3BD4B00857C73 /* MeasurementFrequencyTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeasurementFrequencyTableViewController.swift; sourceTree = "<group>"; };
 		B43DA43E24D49AA400CAFF4E /* GuidanceColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceColors.swift; sourceTree = "<group>"; };
+		B45774342562CCC6004B9466 /* SupportRangeTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportRangeTableViewController.swift; sourceTree = "<group>"; };
 		B45AF6EF24D4355A00EEAA4D /* Environment+Colors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Environment+Colors.swift"; sourceTree = "<group>"; };
 		B46B62A623FEFE4D001E69BA /* InstructionList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstructionList.swift; sourceTree = "<group>"; };
 		B46B62A823FF05F8001E69BA /* LabeledNumberInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabeledNumberInput.swift; sourceTree = "<group>"; };
@@ -2488,6 +2490,7 @@
 				8907E35A21A9D1B200335852 /* SineCurveParametersTableViewController.swift */,
 				89D2046B21C83C3F001238CC /* GlucoseTrendTableViewController.swift */,
 				1DABAD392453615200ACF708 /* IssueAlertTableViewController.swift */,
+				B45774342562CCC6004B9466 /* SupportRangeTableViewController.swift */,
 			);
 			path = "View Controllers";
 			sourceTree = "<group>";
@@ -3702,6 +3705,7 @@
 				B42C950E24A3BD4B00857C73 /* MeasurementFrequencyTableViewController.swift in Sources */,
 				89D204B821CC7F34001238CC /* MockPumpManagerSettingsSetupViewController.swift in Sources */,
 				898E6E732241EE000019E459 /* Comparable.swift in Sources */,
+				B45774352562CCC6004B9466 /* SupportRangeTableViewController.swift in Sources */,
 				892A5D28222EF567008961AB /* (null) in Sources */,
 				89D204C221CC8008001238CC /* IdentifiableClass.swift in Sources */,
 				89D204CB21CC8228001238CC /* NumberFormatter.swift in Sources */,

--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -696,7 +696,7 @@
 		B42C951B24A63B8100857C73 /* DeviceStatusHighlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42C94FD24A2A2B000857C73 /* DeviceStatusHighlight.swift */; };
 		B43DA43F24D49AA400CAFF4E /* GuidanceColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43DA43E24D49AA400CAFF4E /* GuidanceColors.swift */; };
 		B43DA44224D9CD8500CAFF4E /* Environment+Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45AF6EF24D4355A00EEAA4D /* Environment+Colors.swift */; };
-		B45774352562CCC6004B9466 /* SupportRangeTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45774342562CCC6004B9466 /* SupportRangeTableViewController.swift */; };
+		B45774352562CCC6004B9466 /* SupportedRangeTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45774342562CCC6004B9466 /* SupportedRangeTableViewController.swift */; };
 		B46B62A723FEFE4D001E69BA /* InstructionList.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46B62A623FEFE4D001E69BA /* InstructionList.swift */; };
 		B46B62A923FF05F8001E69BA /* LabeledNumberInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46B62A823FF05F8001E69BA /* LabeledNumberInput.swift */; };
 		B46B62AB23FF0822001E69BA /* LabeledValueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46B62AA23FF0822001E69BA /* LabeledValueView.swift */; };
@@ -1468,7 +1468,7 @@
 		B42C94FD24A2A2B000857C73 /* DeviceStatusHighlight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceStatusHighlight.swift; sourceTree = "<group>"; };
 		B42C950C24A3BD4B00857C73 /* MeasurementFrequencyTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeasurementFrequencyTableViewController.swift; sourceTree = "<group>"; };
 		B43DA43E24D49AA400CAFF4E /* GuidanceColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceColors.swift; sourceTree = "<group>"; };
-		B45774342562CCC6004B9466 /* SupportRangeTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportRangeTableViewController.swift; sourceTree = "<group>"; };
+		B45774342562CCC6004B9466 /* SupportedRangeTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportedRangeTableViewController.swift; sourceTree = "<group>"; };
 		B45AF6EF24D4355A00EEAA4D /* Environment+Colors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Environment+Colors.swift"; sourceTree = "<group>"; };
 		B46B62A623FEFE4D001E69BA /* InstructionList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstructionList.swift; sourceTree = "<group>"; };
 		B46B62A823FF05F8001E69BA /* LabeledNumberInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabeledNumberInput.swift; sourceTree = "<group>"; };
@@ -2490,7 +2490,7 @@
 				8907E35A21A9D1B200335852 /* SineCurveParametersTableViewController.swift */,
 				89D2046B21C83C3F001238CC /* GlucoseTrendTableViewController.swift */,
 				1DABAD392453615200ACF708 /* IssueAlertTableViewController.swift */,
-				B45774342562CCC6004B9466 /* SupportRangeTableViewController.swift */,
+				B45774342562CCC6004B9466 /* SupportedRangeTableViewController.swift */,
 			);
 			path = "View Controllers";
 			sourceTree = "<group>";
@@ -3705,7 +3705,7 @@
 				B42C950E24A3BD4B00857C73 /* MeasurementFrequencyTableViewController.swift in Sources */,
 				89D204B821CC7F34001238CC /* MockPumpManagerSettingsSetupViewController.swift in Sources */,
 				898E6E732241EE000019E459 /* Comparable.swift in Sources */,
-				B45774352562CCC6004B9466 /* SupportRangeTableViewController.swift in Sources */,
+				B45774352562CCC6004B9466 /* SupportedRangeTableViewController.swift in Sources */,
 				892A5D28222EF567008961AB /* (null) in Sources */,
 				89D204C221CC8008001238CC /* IdentifiableClass.swift in Sources */,
 				89D204CB21CC8228001238CC /* NumberFormatter.swift in Sources */,

--- a/LoopKitUI/Views/BaseHUDView.swift
+++ b/LoopKitUI/Views/BaseHUDView.swift
@@ -14,7 +14,7 @@ public typealias HUDViewOrderPriority = Int
 
     @IBOutlet weak public var caption: UILabel! {
         didSet {
-            caption?.text = "—"
+            caption?.text = "–"
             // TODO: Setting this color in code because the nib isn't being applied correctly. Review at a later date.
             if #available(iOSApplicationExtension 13.0, *) {
                 caption?.textColor = .label

--- a/LoopKitUI/Views/GuardrailConstraintedQuantityView.swift
+++ b/LoopKitUI/Views/GuardrailConstraintedQuantityView.swift
@@ -61,7 +61,7 @@ public struct GuardrailConstrainedQuantityView: View {
                         .foregroundColor(warningColor)
                         .fixedSize(horizontal: true, vertical: false)
                 } else {
-                    Text("—")
+                    Text("–")
                         .foregroundColor(.secondary)
                 }
             }

--- a/LoopKitUI/Views/SegmentedControlTableViewCell.swift
+++ b/LoopKitUI/Views/SegmentedControlTableViewCell.swift
@@ -41,7 +41,7 @@ open class SegmentedControlTableViewCell: UITableViewCell {
         NSLayoutConstraint.activate([
             segmentedControl.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
             segmentedControl.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            segmentedControl.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.5),
+            segmentedControl.leadingAnchor.constraint(equalTo: textLabel?.trailingAnchor ?? contentView.leadingAnchor)
         ])
     }
 

--- a/MockKit/MockPumpManager.swift
+++ b/MockKit/MockPumpManager.swift
@@ -269,8 +269,11 @@ public final class MockPumpManager: TestingPumpManager {
     private var stateObservers = WeakSynchronizedSet<MockPumpManagerStateObserver>()
 
     public init() {
+        let deliverableIncrements: MockPumpManagerState.DeliverableIncrements = .medtronicX22
         state = MockPumpManagerState(
-            deliverableIncrements: .medtronicX22,
+            deliverableIncrements: deliverableIncrements,
+            supportedBolusVolumes: deliverableIncrements.supportedBolusVolumes ?? [],
+            supportedBasalRates: deliverableIncrements.supportedBasalRates ?? [],
             reservoirUnitsRemaining: MockPumpManager.pumpReservoirCapacity,
             tempBasalEnactmentShouldError: false,
             bolusEnactmentShouldError: false,

--- a/MockKit/MockPumpManagerState.swift
+++ b/MockKit/MockPumpManagerState.swift
@@ -118,7 +118,7 @@ public struct MockPumpManagerState {
             guard let minBolusVolume = supportedBolusVolumes.first, let maxBolusVolume = supportedBolusVolumes.last, supportedBolusVolumes.indices.contains(1) else {
                 return "–"
             }
-            return "\(minBolusVolume)-\(maxBolusVolume) by \(supportedBolusVolumes[1]-minBolusVolume)"
+            return String(format: "\(minBolusVolume)-\(maxBolusVolume) by %.3f", (supportedBolusVolumes[1]-minBolusVolume))
         }
         return bolusVolumesDescription
     }
@@ -129,7 +129,7 @@ public struct MockPumpManagerState {
             guard let minBasalRate = supportedBasalRates.first, let maxBasalRate = supportedBasalRates.last, supportedBasalRates.indices.contains(1) else {
                 return "–"
             }
-            return "\(minBasalRate)-\(maxBasalRate) by \(supportedBasalRates[1]-minBasalRate)"
+            return String(format: "\(minBasalRate)-\(maxBasalRate) by %.3f", (supportedBasalRates[1]-minBasalRate))
         }
         return basalRatesDescription
     }

--- a/MockKit/MockPumpManagerState.swift
+++ b/MockKit/MockPumpManagerState.swift
@@ -13,9 +13,127 @@ public struct MockPumpManagerState {
         case omnipod
         case medtronicX22
         case medtronicX23
+        case custom
+        
+        var supportedBolusVolumes: [Double]? {
+            switch self {
+            case .omnipod:
+                // 0.05 units for volumes between 0.05-30U
+                return (1...600).map { Double($0) * 0.05 }
+            case .medtronicX22:
+                // 0.1 units for volumes between 0.1-25U
+                return (1...250).map { Double($0) * 0.1 }
+            case .medtronicX23:
+                let breakpoints = [0, 1, 10, 25]
+                let scales = [40, 20, 10]
+                let scalingGroups = zip(scales, breakpoints.adjacentPairs().map(...))
+                return scalingGroups.flatMap { (scale, range) -> [Double] in
+                    let scaledRanges = (range.lowerBound * scale + 1)...(range.upperBound * scale)
+                    return scaledRanges.map { Double($0) / Double(scale) }
+                }
+            case .custom:
+                return nil
+            }
+        }
+        
+        var bolusVolumesDescription: String? {
+            switch self {
+            case .omnipod:
+                // 0.05 units for volumes between 0.05-30U
+                return "0.05-30 by 0.05"
+            case .medtronicX22:
+                // 0.1 units for volumes between 0.1-25U
+                return "0.1-25 by 0.1"
+            case .medtronicX23:
+                // 0.025 units for rates between 0.0-0.975 U/h
+                // 0.05 units for rates between 1-9.95 U/h
+                // 0.1 units for rates between 10-25 U/h
+                return "0-1-10-25 by 0.025|0.05|0.1"
+            case .custom:
+                return nil
+            }
+        }
+        
+        var supportedBasalRates: [Double]? {
+            switch self {
+            case .omnipod:
+                // 0.05 units for rates between 0.05-30U/hr
+                return (1...600).map { Double($0) / 20 }
+            case .medtronicX22:
+                // 0.05 units for rates between 0.0-35U/hr
+                return (0...700).map { Double($0) / 20 }
+            case .medtronicX23:
+                // 0.025 units for rates between 0.0-0.975 U/h
+                let rateGroup1 = (0...39).map { Double($0) / 40 }
+                // 0.05 units for rates between 1-9.95 U/h
+                let rateGroup2 = (20...199).map { Double($0) / 20 }
+                // 0.1 units for rates between 10-35 U/h
+                let rateGroup3 = (100...350).map { Double($0) / 10 }
+                return rateGroup1 + rateGroup2 + rateGroup3
+            case .custom:
+                return nil
+            }
+        }
+        
+        public var basalRateDescription: String? {
+            switch self {
+            case .omnipod:
+                // 0.05 units for rates between 0.05-30U/hr
+                return "0.05-30 by 0.05"
+            case .medtronicX22:
+                // 0.05 units for rates between 0.0-35U/hr
+                return "0-35 by 0.05"
+            case .medtronicX23:
+                // 0.025 units for rates between 0.0-0.975 U/h
+                // 0.05 units for rates between 1-9.95 U/h
+                // 0.1 units for rates between 10-35 U/h
+                return "0-1-10-35 by 0.025|0.05|0.1"
+            case .custom:
+                return nil
+            }
+        }
     }
 
-    public var deliverableIncrements: DeliverableIncrements
+    public var deliverableIncrements: DeliverableIncrements {
+        didSet {
+            if let supportedBasalRates = deliverableIncrements.supportedBasalRates {
+                self.supportedBasalRates = supportedBasalRates
+            } else if let minBasalRates = supportedBasalRates.first, let maxBasalRates = supportedBasalRates.last, supportedBasalRates.indices.contains(1) {
+                let stepSize = supportedBasalRates[1]-minBasalRates
+                self.supportedBasalRates = (Int(minBasalRates/stepSize)...Int(maxBasalRates/stepSize)).map { Double($0) / (1 / stepSize) }
+            }
+
+            if let supportedBolusVolumes = deliverableIncrements.supportedBolusVolumes {
+                self.supportedBolusVolumes = supportedBolusVolumes
+            } else if let minBolusVolumes = supportedBolusVolumes.first, let maxBolusVolumes = supportedBolusVolumes.last, supportedBolusVolumes.indices.contains(1) {
+                let stepSize = supportedBolusVolumes[1]-minBolusVolumes
+                self.supportedBolusVolumes = (Int(minBolusVolumes/stepSize)...Int(maxBolusVolumes/stepSize)).map { Double($0) / (1 / stepSize) }
+            }
+        }
+    }
+    
+    public var supportedBolusVolumes: [Double]
+    public var supportedBolusVolumesDescription: String {
+        guard let bolusVolumesDescription = deliverableIncrements.basalRateDescription else {
+            guard let minBolusVolume = supportedBolusVolumes.first, let maxBolusVolume = supportedBolusVolumes.last, supportedBolusVolumes.indices.contains(1) else {
+                return "–"
+            }
+            return "\(minBolusVolume)-\(maxBolusVolume) by \(supportedBolusVolumes[1]-minBolusVolume)"
+        }
+        return bolusVolumesDescription
+    }
+    
+    public var supportedBasalRates: [Double]
+    public var supportedBasalRatesDescription: String {
+        guard let basalRatesDescription = deliverableIncrements.basalRateDescription else {
+            guard let minBasalRate = supportedBasalRates.first, let maxBasalRate = supportedBasalRates.last, supportedBasalRates.indices.contains(1) else {
+                return "–"
+            }
+            return "\(minBasalRate)-\(maxBasalRate) by \(supportedBasalRates[1]-minBasalRate)"
+        }
+        return basalRatesDescription
+    }
+    
     public var reservoirUnitsRemaining: Double
     public var tempBasalEnactmentShouldError: Bool
     public var bolusEnactmentShouldError: Bool
@@ -55,44 +173,6 @@ public struct MockPumpManagerState {
             unfinalizedTempBasal = nil
         }
     }
-
-    var supportedBolusVolumes: [Double] {
-        switch deliverableIncrements {
-        case .omnipod:
-            // 0.05 units for volumes between 0.05-30U
-            return (1...600).map { Double($0) * 0.05 }
-        case .medtronicX22:
-            // 0.1 units for volumes between 0.1-25U
-            return (1...250).map { Double($0) * 0.1 }
-        case .medtronicX23:
-            let breakpoints = [0, 1, 10, 25]
-            let scales = [40, 20, 10]
-            let scalingGroups = zip(scales, breakpoints.adjacentPairs().map(...))
-            return scalingGroups.flatMap { (scale, range) -> [Double] in
-                let scaledRanges = (range.lowerBound * scale + 1)...(range.upperBound * scale)
-                return scaledRanges.map { Double($0) / Double(scale) }
-            }
-        }
-    }
-
-    var supportedBasalRates: [Double] {
-        switch deliverableIncrements {
-        case .omnipod:
-            // 0.05 units for rates between 0.05-30U/hr
-            return (1...600).map { Double($0) / 20 }
-        case .medtronicX22:
-            // 0.05 units for rates between 0.0-35U/hr
-            return (0...700).map { Double($0) / 20 }
-        case .medtronicX23:
-            // 0.025 units for rates between 0.0-0.975 U/h
-            let rateGroup1 = (0...39).map { Double($0) / 40 }
-            // 0.05 units for rates between 1-9.95 U/h
-            let rateGroup2 = (20...199).map { Double($0) / 20 }
-            // 0.1 units for rates between 10-35 U/h
-            let rateGroup3 = (100...350).map { Double($0) / 10 }
-            return rateGroup1 + rateGroup2 + rateGroup3
-        }
-    }
 }
 
 
@@ -104,7 +184,10 @@ extension MockPumpManagerState: RawRepresentable {
             return nil
         }
 
-        self.deliverableIncrements = (rawValue["deliverableIncrements"] as? DeliverableIncrements.RawValue).flatMap(DeliverableIncrements.init(rawValue:)) ?? .medtronicX22
+        let defaultDeliverableIncrements: DeliverableIncrements = .medtronicX22
+        self.deliverableIncrements = (rawValue["deliverableIncrements"] as? DeliverableIncrements.RawValue).flatMap(DeliverableIncrements.init(rawValue:)) ?? defaultDeliverableIncrements
+        self.supportedBolusVolumes = rawValue["supportedBolusVolumes"] as? [Double] ?? defaultDeliverableIncrements.supportedBolusVolumes ?? []
+        self.supportedBasalRates = rawValue["supportedBasalRates"] as? [Double] ?? defaultDeliverableIncrements.supportedBasalRates ?? []
         self.reservoirUnitsRemaining = reservoirUnitsRemaining
         self.tempBasalEnactmentShouldError = rawValue["tempBasalEnactmentShouldError"] as? Bool ?? false
         self.bolusEnactmentShouldError = rawValue["bolusEnactmentShouldError"] as? Bool ?? false
@@ -148,6 +231,8 @@ extension MockPumpManagerState: RawRepresentable {
 
         var raw: RawValue = [
             "deliverableIncrements": deliverableIncrements.rawValue,
+            "supportedBolusVolumes": supportedBolusVolumes,
+            "supportedBasalRates": supportedBasalRates,
             "reservoirUnitsRemaining": reservoirUnitsRemaining,
         ]
 
@@ -206,6 +291,8 @@ extension MockPumpManagerState: CustomDebugStringConvertible {
     public var debugDescription: String {
         return """
         ## MockPumpManagerState
+        * supportedBolusVolumes: \(supportedBolusVolumes)
+        * supportedBasalRates: \(supportedBasalRates)
         * reservoirUnitsRemaining: \(reservoirUnitsRemaining)
         * tempBasalEnactmentShouldError: \(tempBasalEnactmentShouldError)
         * bolusEnactmentShouldError: \(bolusEnactmentShouldError)

--- a/MockKitUI/View Controllers/MockPumpManagerSettingsViewController.swift
+++ b/MockKitUI/View Controllers/MockPumpManagerSettingsViewController.swift
@@ -81,6 +81,8 @@ final class MockPumpManagerSettingsViewController: UITableViewController {
 
     private enum SettingsRow: Int, CaseIterable {
         case deliverableIncrements = 0
+        case supportedBasalRates
+        case supportedBolusVolumes
         case reservoirRemaining
         case batteryRemaining
         case tempBasalErrorToggle
@@ -169,11 +171,30 @@ final class MockPumpManagerSettingsViewController: UITableViewController {
                         return "x22"
                     case .medtronicX23:
                         return "x23"
+                    case .custom:
+                        return "Custom"
                     }
                 }
                 cell.segmentedControl.selectedSegmentIndex = possibleDeliverableIncrements.firstIndex(of: pumpManager.state.deliverableIncrements)!
                 cell.onSelection { [pumpManager] index in
                     pumpManager.state.deliverableIncrements = possibleDeliverableIncrements[index]
+                    tableView.reloadRows(at: [IndexPath(row: SettingsRow.supportedBasalRates.rawValue, section: Section.settings.rawValue), IndexPath(row: SettingsRow.supportedBolusVolumes.rawValue, section: Section.settings.rawValue)], with: .automatic)
+                }
+                return cell
+            case .supportedBasalRates:
+                let cell = tableView.dequeueReusableCell(withIdentifier: SettingsTableViewCell.className, for: indexPath)
+                cell.textLabel?.text = "Basal Rates"
+                cell.detailTextLabel?.text = pumpManager.state.supportedBasalRatesDescription
+                if pumpManager.state.deliverableIncrements == .custom {
+                    cell.accessoryType = .disclosureIndicator
+                }
+                return cell
+            case .supportedBolusVolumes:
+                let cell = tableView.dequeueReusableCell(withIdentifier: SettingsTableViewCell.className, for: indexPath)
+                cell.textLabel?.text = "Bolus Volumes"
+                cell.detailTextLabel?.text = pumpManager.state.supportedBolusVolumesDescription
+                if pumpManager.state.deliverableIncrements == .custom {
+                    cell.accessoryType = .disclosureIndicator
                 }
                 return cell
             case .reservoirRemaining:
@@ -283,8 +304,29 @@ final class MockPumpManagerSettingsViewController: UITableViewController {
                 tableView.reloadRows(at: [indexPath], with: .automatic)
             }
         case .settings:
+            tableView.deselectRow(at: indexPath, animated: true)
             switch SettingsRow(rawValue: indexPath.row)! {
             case .deliverableIncrements:
+                break
+            case .supportedBasalRates:
+                if pumpManager.state.deliverableIncrements == .custom, pumpManager.state.supportedBasalRates.indices.contains(1) {
+                    let basalRates = pumpManager.state.supportedBasalRates
+                    let vc = SupportRangeTableViewController(minValue: basalRates.first!, maxValue: basalRates.last!, stepSize: basalRates[1] - basalRates.first!)
+                    vc.title = "Supported Basal Rates"
+                    vc.indexPath = indexPath
+                    vc.delegate = self
+                    show(vc, sender: sender)
+                }
+                break
+            case .supportedBolusVolumes:
+                if pumpManager.state.deliverableIncrements == .custom, pumpManager.state.supportedBolusVolumes.indices.contains(1) {
+                    let bolusVolumes = pumpManager.state.supportedBolusVolumes
+                    let vc = SupportRangeTableViewController(minValue: bolusVolumes.first!, maxValue: bolusVolumes.last!, stepSize: bolusVolumes[1] - bolusVolumes.first!)
+                    vc.title = "Supported Bolus Volumes"
+                    vc.indexPath = indexPath
+                    vc.delegate = self
+                    show(vc, sender: sender)
+                }
                 break
             case .reservoirRemaining:
                 let vc = TextFieldTableViewController()
@@ -493,5 +535,30 @@ private extension UIAlertController {
             style: .default,
             handler: nil
         ))
+    }
+}
+
+extension MockPumpManagerSettingsViewController: SupportRangeTableViewControllerDelegate {
+    func supportedRangeDidUpdate(_ controller: SupportRangeTableViewController) {
+        guard let indexPath = controller.indexPath else {
+            assertionFailure()
+            return
+        }
+
+        let rangeMin = Int(controller.minValue/controller.stepSize)
+        let rangeMax = Int(controller.maxValue/controller.stepSize)
+        let rangeStep = 1/controller.stepSize
+        let values: [Double] = (rangeMin...rangeMax).map { Double($0) / rangeStep }
+        
+        switch indexPath {
+        case [Section.settings.rawValue, SettingsRow.supportedBasalRates.rawValue]:
+            pumpManager.state.supportedBasalRates = values
+            tableView.reloadRows(at: [indexPath], with: .automatic)
+        case [Section.settings.rawValue, SettingsRow.supportedBolusVolumes.rawValue]:
+            pumpManager.state.supportedBolusVolumes = values
+            tableView.reloadRows(at: [indexPath], with: .automatic)
+        default:
+            assertionFailure()
+        }
     }
 }

--- a/MockKitUI/View Controllers/MockPumpManagerSettingsViewController.swift
+++ b/MockKitUI/View Controllers/MockPumpManagerSettingsViewController.swift
@@ -311,7 +311,7 @@ final class MockPumpManagerSettingsViewController: UITableViewController {
             case .supportedBasalRates:
                 if pumpManager.state.deliverableIncrements == .custom, pumpManager.state.supportedBasalRates.indices.contains(1) {
                     let basalRates = pumpManager.state.supportedBasalRates
-                    let vc = SupportRangeTableViewController(minValue: basalRates.first!, maxValue: basalRates.last!, stepSize: basalRates[1] - basalRates.first!)
+                    let vc = SupportedRangeTableViewController(minValue: basalRates.first!, maxValue: basalRates.last!, stepSize: basalRates[1] - basalRates.first!)
                     vc.title = "Supported Basal Rates"
                     vc.indexPath = indexPath
                     vc.delegate = self
@@ -321,7 +321,7 @@ final class MockPumpManagerSettingsViewController: UITableViewController {
             case .supportedBolusVolumes:
                 if pumpManager.state.deliverableIncrements == .custom, pumpManager.state.supportedBolusVolumes.indices.contains(1) {
                     let bolusVolumes = pumpManager.state.supportedBolusVolumes
-                    let vc = SupportRangeTableViewController(minValue: bolusVolumes.first!, maxValue: bolusVolumes.last!, stepSize: bolusVolumes[1] - bolusVolumes.first!)
+                    let vc = SupportedRangeTableViewController(minValue: bolusVolumes.first!, maxValue: bolusVolumes.last!, stepSize: bolusVolumes[1] - bolusVolumes.first!)
                     vc.title = "Supported Bolus Volumes"
                     vc.indexPath = indexPath
                     vc.delegate = self
@@ -538,8 +538,8 @@ private extension UIAlertController {
     }
 }
 
-extension MockPumpManagerSettingsViewController: SupportRangeTableViewControllerDelegate {
-    func supportedRangeDidUpdate(_ controller: SupportRangeTableViewController) {
+extension MockPumpManagerSettingsViewController: SupportedRangeTableViewControllerDelegate {
+    func supportedRangeDidUpdate(_ controller: SupportedRangeTableViewController) {
         guard let indexPath = controller.indexPath else {
             assertionFailure()
             return

--- a/MockKitUI/View Controllers/SupportRangeTableViewController.swift
+++ b/MockKitUI/View Controllers/SupportRangeTableViewController.swift
@@ -24,11 +24,11 @@ final class SupportRangeTableViewController: UITableViewController {
 
     weak var delegate: SupportRangeTableViewControllerDelegate?
 
-    var minValue: Double = 0
+    var minValue: Double
     
-    var maxValue: Double = 100
+    var maxValue: Double
     
-    var stepSize: Double = 1
+    var stepSize: Double
     
     var indexPath: IndexPath?
     
@@ -40,7 +40,6 @@ final class SupportRangeTableViewController: UITableViewController {
         self.maxValue = maxValue
         self.stepSize = stepSize
         super.init(style: .grouped)
-        self.title = title
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -69,7 +68,7 @@ final class SupportRangeTableViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        return "Changing the supported values of the pump may cause the app to crash. Ensure you are changing them such that the set therapy value are still valid (e.g., basal rate, max bolus, etc.)"
+        return "Changing the supported values of the pump may cause the app to crash. Ensure you are changing them such that the set therapy values are still valid (e.g., basal rate, max bolus, etc.)"
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -105,7 +104,7 @@ final class SupportRangeTableViewController: UITableViewController {
         }
 
         let vc = TextFieldTableViewController()
-        vc.value = String(format: "%.3f", value)
+        vc.value = "\(value)"
         vc.keyboardType = .decimalPad
         vc.indexPath = indexPath
         vc.delegate = self

--- a/MockKitUI/View Controllers/SupportRangeTableViewController.swift
+++ b/MockKitUI/View Controllers/SupportRangeTableViewController.swift
@@ -1,0 +1,142 @@
+//
+//  SupportRangeTableViewController.swift
+//  MockKitUI
+//
+//  Created by Nathaniel Hamming on 2020-11-16.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+
+
+import UIKit
+import HealthKit
+import LoopKit
+import LoopKitUI
+import MockKit
+
+
+protocol SupportRangeTableViewControllerDelegate: class {
+    func supportedRangeDidUpdate(_ controller: SupportRangeTableViewController)
+}
+
+final class SupportRangeTableViewController: UITableViewController {
+
+    weak var delegate: SupportRangeTableViewControllerDelegate?
+
+    var minValue: Double = 0
+    
+    var maxValue: Double = 100
+    
+    var stepSize: Double = 1
+    
+    var indexPath: IndexPath?
+    
+    init(minValue: Double,
+         maxValue: Double,
+         stepSize: Double)
+    {
+        self.minValue = minValue
+        self.maxValue = maxValue
+        self.stepSize = stepSize
+        super.init(style: .grouped)
+        self.title = title
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableView.register(SettingsTableViewCell.self, forCellReuseIdentifier: SettingsTableViewCell.className)
+    }
+
+    // MARK: - Data Source
+
+    private enum Row: Int, CaseIterable {
+        case minValue = 0
+        case maxValue
+        case stepSize
+    }
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return Row.allCases.count
+    }
+    
+    override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return "Changing the supported values of the pump may cause the app to crash. Ensure you are changing them such that the set therapy value are still valid (e.g., basal rate, max bolus, etc.)"
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: SettingsTableViewCell.className, for: indexPath) as! SettingsTableViewCell
+
+        switch Row(rawValue: indexPath.row)! {
+        case .minValue:
+            cell.textLabel?.text = "Minimum Value"
+            cell.detailTextLabel?.text = "\(minValue)"
+        case .maxValue:
+            cell.textLabel?.text = "Maximum Value"
+            cell.detailTextLabel?.text = "\(maxValue)"
+        case .stepSize:
+            cell.textLabel?.text = "Step Size"
+            cell.detailTextLabel?.text = "\(stepSize)"
+        }
+
+        cell.accessoryType = .disclosureIndicator
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let sender = tableView.cellForRow(at: indexPath)
+        
+        let value: Double
+        switch Row(rawValue: indexPath.row)! {
+        case .minValue:
+            value = minValue
+        case .maxValue:
+            value = maxValue
+        case .stepSize:
+            value = stepSize
+        }
+
+        let vc = TextFieldTableViewController()
+        vc.value = String(format: "%.3f", value)
+        vc.keyboardType = .decimalPad
+        vc.indexPath = indexPath
+        vc.delegate = self
+        show(vc, sender: sender)
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
+}
+
+extension SupportRangeTableViewController: TextFieldTableViewControllerDelegate {
+    func textFieldTableViewControllerDidReturn(_ controller: TextFieldTableViewController) {
+        update(from: controller)
+    }
+
+    func textFieldTableViewControllerDidEndEditing(_ controller: TextFieldTableViewController) {
+        update(from: controller)
+    }
+
+    private func update(from controller: TextFieldTableViewController) {
+        guard let indexPath = controller.indexPath,
+              let value = controller.value.flatMap(Double.init) else { assertionFailure(); return }
+
+        switch Row(rawValue: indexPath.row)! {
+        case .minValue:
+            minValue = max(value, 0.0)
+        case .maxValue:
+            maxValue = max(value, 0.0)
+        case .stepSize:
+            stepSize = max(value, 0.0)
+        }
+
+        delegate?.supportedRangeDidUpdate(self)
+        tableView.reloadRows(at: [indexPath], with: .automatic)
+    }
+}

--- a/MockKitUI/View Controllers/SupportedRangeTableViewController.swift
+++ b/MockKitUI/View Controllers/SupportedRangeTableViewController.swift
@@ -32,6 +32,16 @@ final class SupportedRangeTableViewController: UITableViewController {
     
     var indexPath: IndexPath?
     
+    private let numberFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 3
+
+        return formatter
+    }()
+    
     init(minValue: Double,
          maxValue: Double,
          stepSize: Double)
@@ -77,13 +87,13 @@ final class SupportedRangeTableViewController: UITableViewController {
         switch Row(rawValue: indexPath.row)! {
         case .minValue:
             cell.textLabel?.text = "Minimum Value"
-            cell.detailTextLabel?.text = "\(minValue)"
+            cell.detailTextLabel?.text = numberFormatter.string(from: minValue)
         case .maxValue:
             cell.textLabel?.text = "Maximum Value"
-            cell.detailTextLabel?.text = "\(maxValue)"
+            cell.detailTextLabel?.text = numberFormatter.string(from: maxValue)
         case .stepSize:
             cell.textLabel?.text = "Step Size"
-            cell.detailTextLabel?.text = "\(stepSize)"
+            cell.detailTextLabel?.text = numberFormatter.string(from: stepSize)
         }
 
         cell.accessoryType = .disclosureIndicator
@@ -104,7 +114,7 @@ final class SupportedRangeTableViewController: UITableViewController {
         }
 
         let vc = TextFieldTableViewController()
-        vc.value = "\(value)"
+        vc.value = numberFormatter.string(from: value)
         vc.keyboardType = .decimalPad
         vc.indexPath = indexPath
         vc.delegate = self

--- a/MockKitUI/View Controllers/SupportedRangeTableViewController.swift
+++ b/MockKitUI/View Controllers/SupportedRangeTableViewController.swift
@@ -1,5 +1,5 @@
 //
-//  SupportRangeTableViewController.swift
+//  SupportedRangeTableViewController.swift
 //  MockKitUI
 //
 //  Created by Nathaniel Hamming on 2020-11-16.
@@ -16,13 +16,13 @@ import LoopKitUI
 import MockKit
 
 
-protocol SupportRangeTableViewControllerDelegate: class {
-    func supportedRangeDidUpdate(_ controller: SupportRangeTableViewController)
+protocol SupportedRangeTableViewControllerDelegate: class {
+    func supportedRangeDidUpdate(_ controller: SupportedRangeTableViewController)
 }
 
-final class SupportRangeTableViewController: UITableViewController {
+final class SupportedRangeTableViewController: UITableViewController {
 
-    weak var delegate: SupportRangeTableViewControllerDelegate?
+    weak var delegate: SupportedRangeTableViewControllerDelegate?
 
     var minValue: Double
     
@@ -113,7 +113,7 @@ final class SupportRangeTableViewController: UITableViewController {
     }
 }
 
-extension SupportRangeTableViewController: TextFieldTableViewControllerDelegate {
+extension SupportedRangeTableViewController: TextFieldTableViewControllerDelegate {
     func textFieldTableViewControllerDidReturn(_ controller: TextFieldTableViewController) {
         update(from: controller)
     }


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-2358

pump sim basal and bolus ranges are now configuration in the pump sim settings

Also includes replacement of `em` with `en` dashes (as requested by design).