### PR TITLE
LOOP-2430: Show default low value warning for max bolus and max basal rates

### DIFF
--- a/Extensions/Guardrail+Settings.swift
+++ b/Extensions/Guardrail+Settings.swift
@@ -125,11 +125,22 @@ public extension Guardrail where Value == HKQuantity {
 
         } else {
             return Guardrail(
-                absoluteBounds: supportedBasalRates.first!...absoluteUpperBound,
-                recommendedBounds:  supportedBasalRates.first!...absoluteUpperBound,
+                absoluteBounds: supportedBasalRates.drop { $0 <= 0 }.first!...absoluteUpperBound,
+                recommendedBounds:  supportedBasalRates.drop { $0 <= 0 }.first!...absoluteUpperBound,
                 unit: .internationalUnitsPerHour
             )
         }
+    }
+    
+    static func selectableBasalRates(supportedBasalRates: [Double],
+                                     scheduledBasalRange: ClosedRange<Double>?,
+                                     lowestCarbRatio: Double?,
+                                     maximumBasalRatePrecision decimalPlaces: Int = 3) -> [Double] {
+        let basalGuardrail = Guardrail.maximumBasalRate(supportedBasalRates: supportedBasalRates, scheduledBasalRange: scheduledBasalRange, lowestCarbRatio: lowestCarbRatio)
+        let maximumScheduledBasalRate = scheduledBasalRange?.upperBound ?? -Double.infinity
+        return supportedBasalRates
+            .drop { $0 < maximumScheduledBasalRate }
+            .filter { basalGuardrail.absoluteBounds.contains(HKQuantity(unit: .internationalUnitsPerHour, doubleValue: $0)) }
     }
 
     static func maximumBolus(supportedBolusVolumes: [Double]) -> Guardrail {
@@ -142,5 +153,11 @@ public extension Guardrail where Value == HKQuantity {
             recommendedBounds: supportedBolusVolumes.dropFirst().first!...recommendedUpperBound!,
             unit: .internationalUnit()
         )
+    }
+    
+    static func selectableBolusVolumes(supportedBolusVolumes: [Double]) -> [Double] {
+        return supportedBolusVolumes.filter {
+            Guardrail.maximumBolus(supportedBolusVolumes: supportedBolusVolumes).absoluteBounds.contains(HKQuantity(unit: .internationalUnit(), doubleValue: $0))
+        }
     }
 }

--- a/Extensions/Guardrail+Settings.swift
+++ b/Extensions/Guardrail+Settings.swift
@@ -132,7 +132,7 @@ public extension Guardrail where Value == HKQuantity {
         }
     }
     
-    static func selectableBasalRates(supportedBasalRates: [Double],
+    static func selectableMaxBasalRates(supportedBasalRates: [Double],
                                      scheduledBasalRange: ClosedRange<Double>?,
                                      lowestCarbRatio: Double?,
                                      maximumBasalRatePrecision decimalPlaces: Int = 3) -> [Double] {
@@ -156,8 +156,9 @@ public extension Guardrail where Value == HKQuantity {
     }
     
     static func selectableBolusVolumes(supportedBolusVolumes: [Double]) -> [Double] {
+        let guardrail = Guardrail.maximumBolus(supportedBolusVolumes: supportedBolusVolumes)
         return supportedBolusVolumes.filter {
-            Guardrail.maximumBolus(supportedBolusVolumes: supportedBolusVolumes).absoluteBounds.contains(HKQuantity(unit: .internationalUnit(), doubleValue: $0))
+            guardrail.absoluteBounds.contains(HKQuantity(unit: .internationalUnit(), doubleValue: $0))
         }
     }
 }

--- a/LoopKitTests/GuardrailTests.swift
+++ b/LoopKitTests/GuardrailTests.swift
@@ -189,15 +189,15 @@ class GuardrailTests: XCTestCase {
         let supportedBasalRates = [0, 0.05, 1.0]
         let scheduledBasalRange = 0.05...0.78125
         let lowestCarbRatio = 10.0
-        let selectableBasalRates = Guardrail.selectableMaxBasalRates(supportedBasalRates: supportedBasalRates, scheduledBasalRange: scheduledBasalRange, lowestCarbRatio: lowestCarbRatio)
-        XCTAssertEqual([1.0], selectableBasalRates)
+        let selectableMaxBasalRates = Guardrail.selectableMaxBasalRates(supportedBasalRates: supportedBasalRates, scheduledBasalRange: scheduledBasalRange, lowestCarbRatio: lowestCarbRatio)
+        XCTAssertEqual([1.0], selectableMaxBasalRates)
     }
     
     func testSelectableBasalRatesGuardrailNoScheduledBasalRates() {
         let supportedBasalRates = [0, 0.05, 1.0]
         let lowestCarbRatio = 10.0
-        let selectableBasalRates = Guardrail.selectableMaxBasalRates(supportedBasalRates: supportedBasalRates, scheduledBasalRange: nil, lowestCarbRatio: lowestCarbRatio)
-        XCTAssertEqual([0.05, 1.0], selectableBasalRates)
+        let selectableMaxBasalRates = Guardrail.selectableMaxBasalRates(supportedBasalRates: supportedBasalRates, scheduledBasalRange: nil, lowestCarbRatio: lowestCarbRatio)
+        XCTAssertEqual([0.05, 1.0], selectableMaxBasalRates)
     }
     
     func testMaxBolusGuardrailInsideLimits() {

--- a/LoopKitTests/GuardrailTests.swift
+++ b/LoopKitTests/GuardrailTests.swift
@@ -178,11 +178,26 @@ class GuardrailTests: XCTestCase {
     }
     
     func testMaxBasalRateGuardrailNoScheduledBasalRates() {
-        let supportedBasalRates = [0.0, 1.0]
+        let supportedBasalRates = [0, 0.05, 1.0]
         let lowestCarbRatio = 10.0
         let guardrail = Guardrail.maximumBasalRate(supportedBasalRates: supportedBasalRates, scheduledBasalRange: nil, lowestCarbRatio: lowestCarbRatio)
-        XCTAssertEqual(guardrail.absoluteBounds.range(withUnit: .internationalUnitsPerHour), 0.0...1.0)
-        XCTAssertEqual(guardrail.recommendedBounds.range(withUnit: .internationalUnitsPerHour), 0.0...1.0)
+        XCTAssertEqual(guardrail.absoluteBounds.range(withUnit: .internationalUnitsPerHour), 0.05...1.0)
+        XCTAssertEqual(guardrail.recommendedBounds.range(withUnit: .internationalUnitsPerHour), 0.05...1.0)
+    }
+    
+    func testSelectableBasalRatesGuardrail() {
+        let supportedBasalRates = [0, 0.05, 1.0]
+        let scheduledBasalRange = 0.05...0.78125
+        let lowestCarbRatio = 10.0
+        let selectableBasalRates = Guardrail.selectableBasalRates(supportedBasalRates: supportedBasalRates, scheduledBasalRange: scheduledBasalRange, lowestCarbRatio: lowestCarbRatio)
+        XCTAssertEqual([1.0], selectableBasalRates)
+    }
+    
+    func testSelectableBasalRatesGuardrailNoScheduledBasalRates() {
+        let supportedBasalRates = [0, 0.05, 1.0]
+        let lowestCarbRatio = 10.0
+        let selectableBasalRates = Guardrail.selectableBasalRates(supportedBasalRates: supportedBasalRates, scheduledBasalRange: nil, lowestCarbRatio: lowestCarbRatio)
+        XCTAssertEqual([0.05, 1.0], selectableBasalRates)
     }
     
     func testMaxBolusGuardrailInsideLimits() {
@@ -218,6 +233,12 @@ class GuardrailTests: XCTestCase {
         let guardrail = Guardrail.maximumBolus(supportedBolusVolumes: supportedBolusVolumes)
         XCTAssertEqual(guardrail.absoluteBounds.range(withUnit: .internationalUnit()), 0.05...30.0)
         XCTAssertEqual(guardrail.recommendedBounds.range(withUnit: .internationalUnit()), 1.0...20.0.nextDown)
+    }
+    
+    func testSelectableBolusVolumes() {
+        let supportedBolusVolumes = [0.0, 0.05, 1.0, 2.0, 30.nextUp]
+        let selectableBolusVolumes = Guardrail.selectableBolusVolumes(supportedBolusVolumes: supportedBolusVolumes)
+        XCTAssertEqual([0.05, 1.0, 2.0], selectableBolusVolumes)
     }
 }
 

--- a/LoopKitTests/GuardrailTests.swift
+++ b/LoopKitTests/GuardrailTests.swift
@@ -189,14 +189,14 @@ class GuardrailTests: XCTestCase {
         let supportedBasalRates = [0, 0.05, 1.0]
         let scheduledBasalRange = 0.05...0.78125
         let lowestCarbRatio = 10.0
-        let selectableBasalRates = Guardrail.selectableBasalRates(supportedBasalRates: supportedBasalRates, scheduledBasalRange: scheduledBasalRange, lowestCarbRatio: lowestCarbRatio)
+        let selectableBasalRates = Guardrail.selectableMaxBasalRates(supportedBasalRates: supportedBasalRates, scheduledBasalRange: scheduledBasalRange, lowestCarbRatio: lowestCarbRatio)
         XCTAssertEqual([1.0], selectableBasalRates)
     }
     
     func testSelectableBasalRatesGuardrailNoScheduledBasalRates() {
         let supportedBasalRates = [0, 0.05, 1.0]
         let lowestCarbRatio = 10.0
-        let selectableBasalRates = Guardrail.selectableBasalRates(supportedBasalRates: supportedBasalRates, scheduledBasalRange: nil, lowestCarbRatio: lowestCarbRatio)
+        let selectableBasalRates = Guardrail.selectableMaxBasalRates(supportedBasalRates: supportedBasalRates, scheduledBasalRange: nil, lowestCarbRatio: lowestCarbRatio)
         XCTAssertEqual([0.05, 1.0], selectableBasalRates)
     }
     

--- a/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
@@ -17,6 +17,7 @@ public struct DeliveryLimitsEditor: View {
     let selectableBasalRates: [Double]
     let scheduledBasalRange: ClosedRange<Double>?
     let supportedBolusVolumes: [Double]
+    let selectableBolusVolumes: [Double]
     let save: (_ deliveryLimits: DeliveryLimits) -> Void
     let mode: PresentationMode
     
@@ -42,16 +43,10 @@ public struct DeliveryLimitsEditor: View {
         self._value = State(initialValue: value)
         self.initialValue = value
         self.supportedBasalRates = supportedBasalRates
-        let basalGuardrail = Guardrail.maximumBasalRate(supportedBasalRates: supportedBasalRates, scheduledBasalRange: scheduledBasalRange, lowestCarbRatio: lowestCarbRatio)
-        if let maximumScheduledBasalRate = scheduledBasalRange?.upperBound {
-            self.selectableBasalRates = Array(supportedBasalRates.drop(while: { $0 < maximumScheduledBasalRate }))
-                .filter { basalGuardrail.absoluteBounds.contains(HKQuantity(unit: .internationalUnitsPerHour, doubleValue: $0)) }
-        } else {
-            self.selectableBasalRates = supportedBasalRates
-                .filter { basalGuardrail.absoluteBounds.contains(HKQuantity(unit: .internationalUnitsPerHour, doubleValue: $0)) }
-        }
+        self.selectableBasalRates = Guardrail.selectableBasalRates(supportedBasalRates: supportedBasalRates, scheduledBasalRange: scheduledBasalRange, lowestCarbRatio: lowestCarbRatio)
         self.scheduledBasalRange = scheduledBasalRange
         self.supportedBolusVolumes = supportedBolusVolumes
+        self.selectableBolusVolumes = Guardrail.selectableBolusVolumes(supportedBolusVolumes: supportedBolusVolumes)
         self.save = save
         self.mode = mode
         self.lowestCarbRatio = lowestCarbRatio
@@ -234,7 +229,7 @@ public struct DeliveryLimitsEditor: View {
                         ),
                         unit: .internationalUnit(),
                         guardrail: self.maximumBolusGuardrail,
-                        selectableValues: self.supportedBolusVolumes,
+                        selectableValues: self.selectableBolusVolumes,
                         usageContext: .independent
                     )
                     .accessibility(identifier: "max_bolus_picker")

--- a/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
@@ -43,7 +43,7 @@ public struct DeliveryLimitsEditor: View {
         self._value = State(initialValue: value)
         self.initialValue = value
         self.supportedBasalRates = supportedBasalRates
-        self.selectableBasalRates = Guardrail.selectableBasalRates(supportedBasalRates: supportedBasalRates, scheduledBasalRange: scheduledBasalRange, lowestCarbRatio: lowestCarbRatio)
+        self.selectableBasalRates = Guardrail.selectableMaxBasalRates(supportedBasalRates: supportedBasalRates, scheduledBasalRange: scheduledBasalRange, lowestCarbRatio: lowestCarbRatio)
         self.scheduledBasalRange = scheduledBasalRange
         self.supportedBolusVolumes = supportedBolusVolumes
         self.selectableBolusVolumes = Guardrail.selectableBolusVolumes(supportedBolusVolumes: supportedBolusVolumes)

--- a/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
@@ -14,7 +14,7 @@ import LoopKit
 public struct DeliveryLimitsEditor: View {
     let initialValue: DeliveryLimits
     let supportedBasalRates: [Double]
-    let selectableBasalRates: [Double]
+    let selectableMaxBasalRates: [Double]
     let scheduledBasalRange: ClosedRange<Double>?
     let supportedBolusVolumes: [Double]
     let selectableBolusVolumes: [Double]
@@ -43,7 +43,7 @@ public struct DeliveryLimitsEditor: View {
         self._value = State(initialValue: value)
         self.initialValue = value
         self.supportedBasalRates = supportedBasalRates
-        self.selectableBasalRates = Guardrail.selectableMaxBasalRates(supportedBasalRates: supportedBasalRates, scheduledBasalRange: scheduledBasalRange, lowestCarbRatio: lowestCarbRatio)
+        self.selectableMaxBasalRates = Guardrail.selectableMaxBasalRates(supportedBasalRates: supportedBasalRates, scheduledBasalRange: scheduledBasalRange, lowestCarbRatio: lowestCarbRatio)
         self.scheduledBasalRange = scheduledBasalRange
         self.supportedBolusVolumes = supportedBolusVolumes
         self.selectableBolusVolumes = Guardrail.selectableBolusVolumes(supportedBolusVolumes: supportedBolusVolumes)
@@ -179,7 +179,7 @@ public struct DeliveryLimitsEditor: View {
                         ),
                         unit: .internationalUnitsPerHour,
                         guardrail: self.maximumBasalRateGuardrail,
-                        selectableValues: self.selectableBasalRates,
+                        selectableValues: self.selectableMaxBasalRates,
                         usageContext: .independent
                     )
                     .accessibility(identifier: "max_basal_picker")

--- a/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
@@ -264,7 +264,7 @@ public struct DeliveryLimitsEditor: View {
         let crossedThresholds = self.crossedThresholds
         return Group {
             if !crossedThresholds.isEmpty && (userDidTap || mode == .settings) {
-                DeliveryLimitsGuardrailWarning(crossedThresholds: crossedThresholds)
+                DeliveryLimitsGuardrailWarning(crossedThresholds: crossedThresholds, value: value)
             }
         }
     }
@@ -321,8 +321,8 @@ public struct DeliveryLimitsEditor: View {
 
 
 struct DeliveryLimitsGuardrailWarning: View {
-    var crossedThresholds: [DeliveryLimits.Setting: SafetyClassification.Threshold]
-
+    let crossedThresholds: [DeliveryLimits.Setting: SafetyClassification.Threshold]
+    let value: DeliveryLimits
     var body: some View {
         switch crossedThresholds.count {
         case 0:
@@ -336,7 +336,11 @@ struct DeliveryLimitsGuardrailWarning: View {
                 case .minimum, .belowRecommended:
                     // ANNA TODO: Ask MLee about this one
                     title = Text("Low Maximum Basal Rate", comment: "Title text for low maximum basal rate warning")
-                    caption = Text("A setting of 0 U/hr means Loop will not automatically administer insulin.", comment: "Caption text for low maximum basal rate warning")
+                    if value.maximumBasalRate?.doubleValue(for: .internationalUnitsPerHour) == 0 {
+                        caption = Text("A setting of 0 U/hr means Loop will not automatically administer insulin.", comment: "Caption text for low maximum basal rate warning")
+                    } else {
+                        caption = Text(TherapySetting.deliveryLimits.guardrailCaptionForLowValue)
+                    }
                 case .aboveRecommended, .maximum:
                     title = Text("High Maximum Basal Rate", comment: "Title text for high maximum basal rate warning")
                     caption = Text(TherapySetting.deliveryLimits.guardrailCaptionForHighValue)
@@ -345,7 +349,11 @@ struct DeliveryLimitsGuardrailWarning: View {
                 switch threshold {
                 case .minimum, .belowRecommended:
                     title = Text("Low Maximum Bolus", comment: "Title text for low maximum bolus warning")
-                    caption = Text("A setting of 0 U means you will not be able to bolus.", comment: "Caption text for zero maximum bolus setting warning")
+                    if value.maximumBolus?.doubleValue(for: .internationalUnit()) == 0 {
+                        caption = Text("A setting of 0 U means you will not be able to bolus.", comment: "Caption text for zero maximum bolus setting warning")
+                    } else {
+                        caption = Text(TherapySetting.deliveryLimits.guardrailCaptionForLowValue)
+                    }
                 case .aboveRecommended, .maximum:
                     title = Text("High Maximum Bolus", comment: "Title text for high maximum bolus warning")
                     caption = nil


### PR DESCRIPTION
This fixes the warning text to show the default low value warning if the value isn't equal 0.  
While testing this I also found & fixed some corner-case bugs related to guardrails ([LOOP-1732](https://tidepool.atlassian.net/browse/LOOP-1732))
[LOOP-2430](https://tidepool.atlassian.net/browse/LOOP-2430)