### PR TITLE
LOOP-1732: Follow up done criteria change: exactly 100 is not a warning

### DIFF
--- a/Extensions/Guardrail+Settings.swift
+++ b/Extensions/Guardrail+Settings.swift
@@ -23,7 +23,7 @@ public extension Guardrail where Value == HKQuantity {
         .min()!
     }
 
-    static let correctionRange = Guardrail(absoluteBounds: 87...180, recommendedBounds: 101...115, unit: .milligramsPerDeciliter)
+    static let correctionRange = Guardrail(absoluteBounds: 87...180, recommendedBounds: 100...115, unit: .milligramsPerDeciliter)
 
     static func minCorrectionRangeValue(suspendThreshold: GlucoseThreshold?) -> HKQuantity {
         return [
@@ -37,7 +37,9 @@ public extension Guardrail where Value == HKQuantity {
     fileprivate static func workoutCorrectionRange(correctionRangeScheduleRange: ClosedRange<HKQuantity>,
                                                    suspendThreshold: GlucoseThreshold?) -> Guardrail<HKQuantity> {
         // Static "unconstrained" constant values before applying constraints
-        let workoutCorrectionRange = Guardrail(absoluteBounds: 85...250, recommendedBounds: 101...180, unit: .milligramsPerDeciliter)
+        let workoutCorrectionRange = Guardrail(absoluteBounds: 85...250,
+                                               recommendedBounds: correctionRange.recommendedBounds.lowerBound.doubleValue(for: .milligramsPerDeciliter)...180,
+                                               unit: .milligramsPerDeciliter)
         
         let absoluteLowerBound = [
             workoutCorrectionRange.absoluteBounds.lowerBound,

--- a/LoopKitTests/GuardrailTests.swift
+++ b/LoopKitTests/GuardrailTests.swift
@@ -60,6 +60,22 @@ class GuardrailTests: XCTestCase {
         }
     }
     
+    func testCorrectionRange() {
+        let guardrail = Guardrail.correctionRange
+        let expectedAndTest: [(SafetyClassification, Double)] = [
+            (SafetyClassification.withinRecommendedRange, 100),
+            (SafetyClassification.withinRecommendedRange, 115),
+            (SafetyClassification.outsideRecommendedRange(.belowRecommended), 100.nextDown),
+            (SafetyClassification.outsideRecommendedRange(.aboveRecommended), 115.nextUp),
+            (SafetyClassification.outsideRecommendedRange(.maximum), 180),
+            (SafetyClassification.outsideRecommendedRange(.minimum), 87),
+        ]
+        
+        for test in expectedAndTest {
+            XCTAssertEqual(test.0, guardrail.classification(for: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: test.1)), "for \(test.1)")
+        }
+    }
+    
     func testWorkoutCorrectionRange() {
         let correctionRangeInputs = [ 70...80, 70...85, 70...90 ]
         let suspendThresholdInputs: [Double?] = [ nil, 81, 91 ]


### PR DESCRIPTION
This is to address the change to the **Done** criteria (see [this comment](https://tidepool.atlassian.net/browse/LOOP-1732?focusedCommentId=32153))

https://tidepool.atlassian.net/browse/LOOP-1732