### PR TITLE
LOOP-2122, LOOP-1998: iOS 14 Switch Therapy Setting navigation back to using NavigationLink

### DIFF
--- a/LoopKitUI/Views/Settings Editors/SuspendThresholdEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/SuspendThresholdEditor.swift
@@ -107,36 +107,32 @@ public struct SuspendThresholdEditor: View {
             actionButtonTitle: Text(mode.buttonText),
             actionButtonState: saveButtonState,
             cards: {
-                // TODO: Remove conditional when Swift 5.3 ships
-                // https://bugs.swift.org/browse/SR-11628
-                if true {
-                    Card {
-                        SettingDescription(text: description, informationalContent: { TherapySetting.suspendThreshold.helpScreen() })
-                        ExpandableSetting(
-                            isEditing: $isEditing,
-                            valueContent: {
-                                GuardrailConstrainedQuantityView(
-                                    value: value,
-                                    unit: unit,
-                                    guardrail: guardrail,
-                                    isEditing: isEditing,
-                                    // Workaround for strange animation behavior on appearance
-                                    forceDisableAnimations: true
-                                )
-                            },
-                            expandedContent: {
-                                GlucoseValuePicker(
-                                    value: self.$value.animation(),
-                                    unit: self.unit,
-                                    guardrail: self.guardrail,
-                                    bounds: self.guardrail.absoluteBounds.lowerBound...(self.maxValue ?? self.guardrail.absoluteBounds.upperBound)
-                                )
-                                // Prevent the picker from expanding the card's width on small devices
-                                .frame(maxWidth: UIScreen.main.bounds.width - 48)
-                                .clipped()
-                            }
-                        )
-                    }
+                Card {
+                    SettingDescription(text: description, informationalContent: { TherapySetting.suspendThreshold.helpScreen() })
+                    ExpandableSetting(
+                        isEditing: $isEditing,
+                        valueContent: {
+                            GuardrailConstrainedQuantityView(
+                                value: value,
+                                unit: unit,
+                                guardrail: guardrail,
+                                isEditing: isEditing,
+                                // Workaround for strange animation behavior on appearance
+                                forceDisableAnimations: true
+                            )
+                        },
+                        expandedContent: {
+                            GlucoseValuePicker(
+                                value: self.$value.animation(),
+                                unit: self.unit,
+                                guardrail: self.guardrail,
+                                bounds: self.guardrail.absoluteBounds.lowerBound...(self.maxValue ?? self.guardrail.absoluteBounds.upperBound)
+                            )
+                            // Prevent the picker from expanding the card's width on small devices
+                            .frame(maxWidth: UIScreen.main.bounds.width - 48)
+                            .clipped()
+                        }
+                    )
                 }
             },
             actionAreaContent: {

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -36,7 +36,7 @@ public struct TherapySettingsView: View, HorizontalSizeClassOverride {
     public var body: some View {
         switch viewModel.mode {
         case .acceptanceFlow: return AnyView(content)
-        case .settings: return AnyView(navigationViewWrappedContent)
+        case .settings: return AnyView(content)
         }
     }
     
@@ -428,12 +428,14 @@ struct SectionWithTapToEdit<Header, Content, NavigationDestination>: View where 
                 Text(title)
                     .bold()
                 Spacer()
-                ZStack(alignment: .leading) {
+                HStack {
                     DescriptiveText(label: descriptiveText)
                     if isEnabled {
+                        Spacer()
                         NavigationLink(destination: destination({ self.isActive = false }), isActive: $isActive) {
                             EmptyView()
                         }
+                        .frame(width: 15, alignment: .trailing)
                     }
                 }
                 Spacer()


### PR DESCRIPTION
This PR goes along with https://github.com/tidepool-org/Loop/pull/340.  It fixes some navigation and alignment issues with NavigationLink.