### PR TITLE
LOOP-2479, LOOP-2480: Make sure max basal rate guardrail absolute bounds don't cross

### DIFF
--- a/Extensions/Guardrail+Settings.swift
+++ b/Extensions/Guardrail+Settings.swift
@@ -121,7 +121,7 @@ public extension Guardrail where Value == HKQuantity {
             recommendedLowerBound = (recommendedLowScheduledBasalScaleFactor * highestScheduledBasalRate).matchingOrTruncatedValue(from: supportedBasalRates, withinDecimalPlaces: decimalPlaces)
             recommendedUpperBound = (recommendedHighScheduledBasalScaleFactor * highestScheduledBasalRate).matchingOrTruncatedValue(from: supportedBasalRates, withinDecimalPlaces: decimalPlaces)
             
-            let absoluteBounds = highestScheduledBasalRate...absoluteUpperBound
+            let absoluteBounds = highestScheduledBasalRate...max(absoluteUpperBound, highestScheduledBasalRate)
             let recommendedBounds = (recommendedLowerBound...recommendedUpperBound).clamped(to: absoluteBounds)
             return Guardrail(
                 absoluteBounds: absoluteBounds,

--- a/Extensions/Guardrail+Settings.swift
+++ b/Extensions/Guardrail+Settings.swift
@@ -121,7 +121,7 @@ public extension Guardrail where Value == HKQuantity {
             recommendedLowerBound = (recommendedLowScheduledBasalScaleFactor * highestScheduledBasalRate).matchingOrTruncatedValue(from: supportedBasalRates, withinDecimalPlaces: decimalPlaces)
             recommendedUpperBound = (recommendedHighScheduledBasalScaleFactor * highestScheduledBasalRate).matchingOrTruncatedValue(from: supportedBasalRates, withinDecimalPlaces: decimalPlaces)
             
-            let absoluteBounds = highestScheduledBasalRate...max(absoluteUpperBound, highestScheduledBasalRate)
+            let absoluteBounds = highestScheduledBasalRate...max(absoluteUpperBound, recommendedUpperBound)
             let recommendedBounds = (recommendedLowerBound...recommendedUpperBound).clamped(to: absoluteBounds)
             return Guardrail(
                 absoluteBounds: absoluteBounds,

--- a/LoopKit/TherapySettings.swift
+++ b/LoopKit/TherapySettings.swift
@@ -107,7 +107,7 @@ extension TherapySettings {
             glucoseTargetRangeSchedule: glucoseTargetRangeSchedule,
             preMealTargetRange: DoubleRange(minValue: 80.0, maxValue: 90.0),
             workoutTargetRange: DoubleRange(minValue: 140.0, maxValue: 160.0),
-            maximumBasalRatePerHour: 5,
+            maximumBasalRatePerHour: 1,
             maximumBolus: 10,
             suspendThreshold: GlucoseThreshold(unit: .milligramsPerDeciliter, value: 75),
             insulinSensitivitySchedule: insulinSensitivitySchedule,

--- a/LoopKitTests/GuardrailTests.swift
+++ b/LoopKitTests/GuardrailTests.swift
@@ -163,8 +163,8 @@ class GuardrailTests: XCTestCase {
         let scheduledBasalRange = 0.05...0.78125
         let lowestCarbRatio = 150.0
         let guardrail = Guardrail.maximumBasalRate(supportedBasalRates: supportedBasalRates, scheduledBasalRange: scheduledBasalRange, lowestCarbRatio: lowestCarbRatio)
-        XCTAssertEqual(guardrail.absoluteBounds.range(withUnit: .internationalUnitsPerHour), 0.78125...0.78125)
-        XCTAssertEqual(guardrail.recommendedBounds.range(withUnit: .internationalUnitsPerHour), 0.78125...0.78125)
+        XCTAssertEqual(guardrail.absoluteBounds.range(withUnit: .internationalUnitsPerHour), 0.78125...5.0)
+        XCTAssertEqual(guardrail.recommendedBounds.range(withUnit: .internationalUnitsPerHour), 1.6...5.0)
     }
     
     func testMaxBasalRateGuardrailHigherCarbRatioClampsRecommendedBounds() {
@@ -172,8 +172,8 @@ class GuardrailTests: XCTestCase {
         let scheduledBasalRange = 0.05...0.78125
         let lowestCarbRatio = 15.0
         let guardrail = Guardrail.maximumBasalRate(supportedBasalRates: supportedBasalRates, scheduledBasalRange: scheduledBasalRange, lowestCarbRatio: lowestCarbRatio)
-        XCTAssertEqual(guardrail.absoluteBounds.range(withUnit: .internationalUnitsPerHour), 0.78125...4.65)
-        XCTAssertEqual(guardrail.recommendedBounds.range(withUnit: .internationalUnitsPerHour), 1.6...4.65)
+        XCTAssertEqual(guardrail.absoluteBounds.range(withUnit: .internationalUnitsPerHour), 0.78125...5.0)
+        XCTAssertEqual(guardrail.recommendedBounds.range(withUnit: .internationalUnitsPerHour), 1.6...5.0)
     }
     
     func testMaxBasalRateGuardrailNoCarbRatio() {

--- a/LoopKitTests/GuardrailTests.swift
+++ b/LoopKitTests/GuardrailTests.swift
@@ -158,6 +158,15 @@ class GuardrailTests: XCTestCase {
         XCTAssertEqual(guardrail.recommendedBounds.range(withUnit: .internationalUnitsPerHour), 1.6...5.0)
     }
     
+    func testMaxBasalRateGuardrailHighCarbRatio() {
+        let supportedBasalRates = (1...600).map { Double($0) / 20 }
+        let scheduledBasalRange = 0.05...0.78125
+        let lowestCarbRatio = 150.0
+        let guardrail = Guardrail.maximumBasalRate(supportedBasalRates: supportedBasalRates, scheduledBasalRange: scheduledBasalRange, lowestCarbRatio: lowestCarbRatio)
+        XCTAssertEqual(guardrail.absoluteBounds.range(withUnit: .internationalUnitsPerHour), 0.78125...0.78125)
+        XCTAssertEqual(guardrail.recommendedBounds.range(withUnit: .internationalUnitsPerHour), 0.78125...0.78125)
+    }
+    
     func testMaxBasalRateGuardrailHigherCarbRatioClampsRecommendedBounds() {
         let supportedBasalRates = (1...600).map { Double($0) / 20 }
         let scheduledBasalRange = 0.05...0.78125

--- a/LoopKitUI/Views/FractionalQuantityPicker.swift
+++ b/LoopKitUI/Views/FractionalQuantityPicker.swift
@@ -66,14 +66,14 @@ public struct FractionalQuantityPicker: View {
         self._whole = Binding(
             get: { doubleValue.wrappedValue.whole },
             set: { newWholeValue in
-                let newFractionValue = Self.matchingFraction(for: doubleValue.wrappedValue.fraction, from: fractionalValuesByWhole[newWholeValue]!)
+                let newFractionValue = Self.matchingFraction(for: doubleValue.wrappedValue.fraction, from: fractionalValuesByWhole[newWholeValue] ?? [0.0])
                 let newDoubleValue = newWholeValue + newFractionValue
                 let maxValue = guardrail.absoluteBounds.upperBound.doubleValue(for: unit)
                 doubleValue.wrappedValue = min(newDoubleValue, maxValue)
             }
         )
         self._fraction = Binding(
-            get: { doubleValue.wrappedValue.fraction.roundedToNearest(of: fractionalValuesByWhole[doubleValue.wrappedValue.whole]!) },
+            get: { doubleValue.wrappedValue.fraction.roundedToNearest(of: fractionalValuesByWhole[doubleValue.wrappedValue.whole] ?? [0.0]) },
             set: { newFractionValue in
                 let newDoubleValue = doubleValue.wrappedValue.whole + newFractionValue
                 let minValue = guardrail.absoluteBounds.lowerBound.doubleValue(for: unit)
@@ -138,7 +138,7 @@ public struct FractionalQuantityPicker: View {
             QuantityPicker(
                 value: $fraction.withUnit(unit),
                 unit: unit,
-                selectableValues: fractionalValuesByWhole[whole]!,
+                selectableValues: fractionalValuesByWhole[whole] ?? [0.0],
                 formatter: fractionalFormatter,
                 colorForValue: colorForFraction
             )
@@ -153,7 +153,7 @@ public struct FractionalQuantityPicker: View {
     private func colorForWhole(_ whole: Double) -> Color {
         assert(whole.whole == whole)
 
-        let fractionIfWholeSelected = Self.matchingFraction(for: fraction, from: fractionalValuesByWhole[whole]!)
+        let fractionIfWholeSelected = Self.matchingFraction(for: fraction, from: fractionalValuesByWhole[whole] ?? [0.0])
         let valueIfWholeSelected = whole + fractionIfWholeSelected
         let quantityIfWholeSelected = HKQuantity(unit: unit, doubleValue: valueIfWholeSelected)
         return guardrail.color(for: quantityIfWholeSelected, guidanceColors: guidanceColors)
@@ -169,7 +169,7 @@ public struct FractionalQuantityPicker: View {
 
     private var fractionalFormatter: NumberFormatter {
         // Mutate the shared instance to avoid extra allocations.
-        Self.fractionalFormatter.minimumFractionDigits = fractionalValuesByWhole[whole]!
+        Self.fractionalFormatter.minimumFractionDigits = (fractionalValuesByWhole[whole] ?? [0.0])
             .lazy
             .map { Decimal($0) }
             .deltaScale(boundedBy: Self.maximumSupportedPrecision)


### PR DESCRIPTION
Adjusts max basal guardrail with  new rule that the max basal rate absolute bounds is:

> Maximum:  Greater of { 70 / Lowest Carb Ratio (in the user’s carb ratio schedule) } or High Warning (i.e., Highest Scheduled Basal Rate x 6.4)

See the updated Done Criteria in [LOOP-1732](https://tidepool.atlassian.net/browse/LOOP-1732)

[LOOP-2479](https://tidepool.atlassian.net/browse/LOOP-2479)
Should also address [LOOP-2480](https://tidepool.atlassian.net/browse/LOOP-2480)