### PR TITLE
LOOP-2493: Fix tap gesture in prescription flow on iOS 14

### DIFF
--- a/LoopKitUI/Views/QuantityScheduleEditor.swift
+++ b/LoopKitUI/Views/QuantityScheduleEditor.swift
@@ -89,9 +89,11 @@ struct QuantityScheduleEditor<ActionAreaContent: View>: View {
             mode: mode,
             therapySettingType: settingType
         )
-        .onTapGesture {
-            self.userDidTap = true
-        }
+        .simultaneousGesture(TapGesture().onEnded {
+            withAnimation {
+                self.userDidTap = true
+            }
+        })
     }
 
     private var saveConfirmation: SaveConfirmation {

--- a/LoopKitUI/Views/ScheduleEditor.swift
+++ b/LoopKitUI/Views/ScheduleEditor.swift
@@ -168,14 +168,10 @@ struct ScheduleEditor<Value: Equatable, ValueContent: View, ValuePicker: View, A
             actionButtonTitle: Text(mode.buttonText),
             actionButtonState: saveButtonState,
             cards: {
-                // TODO: Remove conditional when Swift 5.3 ships
-                // https://bugs.swift.org/browse/SR-11628
-                if true {
-                    Card {
-                        SettingDescription(text: description, informationalContent: {self.therapySettingType.helpScreen()})
-                        Splat(Array(scheduleItems.enumerated()), id: \.element.startTime) { index, item in
-                            self.itemView(for: item, at: index)
-                        }
+                Card {
+                    SettingDescription(text: description, informationalContent: {self.therapySettingType.helpScreen()})
+                    Splat(Array(scheduleItems.enumerated()), id: \.element.startTime) { index, item in
+                        self.itemView(for: item, at: index)
                     }
                 }
             },

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeOverridesEditor.swift
@@ -139,9 +139,11 @@ public struct CorrectionRangeOverridesEditor: View {
         )
         .alert(isPresented: $showingConfirmationAlert, content: confirmationAlert)
         .navigationBarTitle("", displayMode: .inline)
-        .onTapGesture {
-            self.userDidTap = true
-        }
+        .simultaneousGesture(TapGesture().onEnded {
+            withAnimation {
+                self.userDidTap = true
+            }
+        })
     }
 
     private func card(for preset: CorrectionRangeOverrides.Preset) -> Card {

--- a/LoopKitUI/Views/Settings Editors/CorrectionRangeScheduleEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/CorrectionRangeScheduleEditor.swift
@@ -92,9 +92,11 @@ public struct CorrectionRangeScheduleEditor: View {
             mode: mode,
             therapySettingType: .glucoseTargetRange
         )
-        .onTapGesture {
-            self.userDidTap = true
-        }
+        .simultaneousGesture(TapGesture().onEnded {
+            withAnimation {
+                self.userDidTap = true
+            }
+        })
     }
 
     var defaultFirstScheduleItemValue: DoubleRange {

--- a/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
@@ -129,9 +129,11 @@ public struct DeliveryLimitsEditor: View {
         )
         .alert(isPresented: $showingConfirmationAlert, content: confirmationAlert)
         .navigationBarTitle("", displayMode: .inline)
-        .onTapGesture {
-            self.userDidTap = true
-        }
+        .simultaneousGesture(TapGesture().onEnded {
+            withAnimation {
+                self.userDidTap = true
+            }
+        })
     }
 
     var saveButtonState: ConfigurationPageActionButtonState {

--- a/LoopKitUI/Views/Settings Editors/SuspendThresholdEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/SuspendThresholdEditor.swift
@@ -110,36 +110,32 @@ public struct SuspendThresholdEditor: View {
             actionButtonTitle: Text(mode.buttonText),
             actionButtonState: saveButtonState,
             cards: {
-                // TODO: Remove conditional when Swift 5.3 ships
-                // https://bugs.swift.org/browse/SR-11628
-                if true {
-                    Card {
-                        SettingDescription(text: description, informationalContent: { TherapySetting.suspendThreshold.helpScreen() })
-                        ExpandableSetting(
-                            isEditing: $isEditing,
-                            valueContent: {
-                                GuardrailConstrainedQuantityView(
-                                    value: value,
-                                    unit: unit,
-                                    guardrail: guardrail,
-                                    isEditing: isEditing,
-                                    // Workaround for strange animation behavior on appearance
-                                    forceDisableAnimations: true
-                                )
-                            },
-                            expandedContent: {
-                                GlucoseValuePicker(
-                                    value: self.$value.animation(),
-                                    unit: self.unit,
-                                    guardrail: self.guardrail,
-                                    bounds: self.guardrail.absoluteBounds.lowerBound...(self.maxValue ?? self.guardrail.absoluteBounds.upperBound)
-                                )
-                                // Prevent the picker from expanding the card's width on small devices
-                                .frame(maxWidth: UIScreen.main.bounds.width - 48)
-                                .clipped()
-                            }
-                        )
-                    }
+                Card {
+                    SettingDescription(text: description, informationalContent: { TherapySetting.suspendThreshold.helpScreen() })
+                    ExpandableSetting(
+                        isEditing: $isEditing,
+                        valueContent: {
+                            GuardrailConstrainedQuantityView(
+                                value: value,
+                                unit: unit,
+                                guardrail: guardrail,
+                                isEditing: isEditing,
+                                // Workaround for strange animation behavior on appearance
+                                forceDisableAnimations: true
+                            )
+                        },
+                        expandedContent: {
+                            GlucoseValuePicker(
+                                value: self.$value.animation(),
+                                unit: self.unit,
+                                guardrail: self.guardrail,
+                                bounds: self.guardrail.absoluteBounds.lowerBound...(self.maxValue ?? self.guardrail.absoluteBounds.upperBound)
+                            )
+                            // Prevent the picker from expanding the card's width on small devices
+                            .frame(maxWidth: UIScreen.main.bounds.width - 48)
+                            .clipped()
+                        }
+                    )
                 }
             },
             actionAreaContent: {
@@ -158,9 +154,11 @@ public struct SuspendThresholdEditor: View {
         )
         .alert(isPresented: $showingConfirmationAlert, content: confirmationAlert)
         .navigationBarTitle("", displayMode: .inline)
-        .onTapGesture {
-            self.userDidTap = true
-        }
+        .simultaneousGesture(TapGesture().onEnded {
+            withAnimation {
+                self.userDidTap = true
+            }
+        })
     }
 
     var description: Text {

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -435,12 +435,14 @@ struct SectionWithTapToEdit<Header, Content, NavigationDestination>: View where 
                 Text(title)
                     .bold()
                 Spacer()
-                ZStack(alignment: .leading) {
+                HStack {
                     DescriptiveText(label: descriptiveText)
                     if isEnabled {
+                        Spacer()
                         NavigationLink(destination: destination(onFinish), isActive: $isActive) {
                             EmptyView()
                         }
+                        .frame(width: 10, alignment: .trailing)
                     }
                 }
                 Spacer()


### PR DESCRIPTION
Use  `.simultaneousGesture()` to ensure tap gesture goes to subview as well as parent.

TBH I'm not sure why this _worked_ on iOS 13.  I thought that gestures, once consumed, didn't pass to subviews.  Maybe it was a bug that was fixed.

Also has 2 tiny bonus commits that I'm hoping to sneak in that are very minor...

[LOOP-2493](https://tidepool.atlassian.net/browse/LOOP-2493)