### PR TITLE
LOOP-1287 Prefer instance identifiers to allow reuse of DeviceManager types

### DIFF
--- a/LoopKit/DeviceManager/DeviceManager.swift
+++ b/LoopKit/DeviceManager/DeviceManager.swift
@@ -27,12 +27,9 @@ public protocol DeviceManagerDelegate: AlertPresenter {
 public protocol DeviceManager: CustomDebugStringConvertible, AlertResponder, AlertSoundVendor {
     typealias RawStateValue = [String: Any]
 
-    /// The identifier of the manager. This should be unique
-    static var managerIdentifier: String { get }
-
-    /// A title describing this type of manager
-    static var localizedTitle: String { get }
-
+    /// A unique identifier for this manager
+    var managerIdentifier: String { get }
+    
     /// A title describing this manager
     var localizedTitle: String { get }
 
@@ -49,16 +46,4 @@ public protocol DeviceManager: CustomDebugStringConvertible, AlertResponder, Ale
 
     /// The current, serializable state of the manager
     var rawState: RawStateValue { get }
-}
-
-
-public extension DeviceManager {
-    var localizedTitle: String {
-        return type(of: self).localizedTitle
-    }
-    
-    /// Represents a per-device-manager-Type identifier that can uniquely identify a class of this type.
-    var managerIdentifier: String {
-        return Self.managerIdentifier
-    }
 }

--- a/MockKit/MockCGMDataSource.swift
+++ b/MockKit/MockCGMDataSource.swift
@@ -51,7 +51,7 @@ public struct MockCGMDataSource {
     }
 
     static let device = HKDevice(
-        name: MockCGMManager.managerIdentifier,
+        name: "MockCGMManager",
         manufacturer: nil,
         model: nil,
         hardwareVersion: nil,

--- a/MockKit/MockCGMManager.swift
+++ b/MockKit/MockCGMManager.swift
@@ -254,7 +254,16 @@ extension MockCGMLifecycleProgress: RawRepresentable {
 public final class MockCGMManager: TestingCGMManager {
     
     public static let managerIdentifier = "MockCGMManager"
+
+    public var managerIdentifier: String {
+        return MockCGMManager.managerIdentifier
+    }
+    
     public static let localizedTitle = "CGM Simulator"
+    
+    public var localizedTitle: String {
+        return MockCGMManager.localizedTitle
+    }
 
     public struct MockAlert {
         public let sound: Alert.Sound

--- a/MockKit/MockPumpManager.swift
+++ b/MockKit/MockPumpManager.swift
@@ -42,8 +42,17 @@ public enum MockPumpManagerError: LocalizedError {
 public final class MockPumpManager: TestingPumpManager {
 
     public static let managerIdentifier = "MockPumpManager"
+
+    public var managerIdentifier: String {
+        return MockPumpManager.managerIdentifier
+    }
+    
     public static let localizedTitle = "Insulin Pump Simulator"
     
+    public var localizedTitle: String {
+        return MockPumpManager.localizedTitle
+    }
+
     private static let device = HKDevice(
         name: MockPumpManager.managerIdentifier,
         manufacturer: nil,


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-1287

DashPumpManager is being subclassed to provide a new demo pumpmanager that uses a mock sdk.