### PR TITLE
LOOP-2988: no inset grouped list style for compact size classes

### DIFF
--- a/LoopKitUI/Extensions/View+InsetGroupedListStyle.swift
+++ b/LoopKitUI/Extensions/View+InsetGroupedListStyle.swift
@@ -21,8 +21,16 @@ fileprivate struct CustomInsetGroupedListStyle: ViewModifier, HorizontalSizeClas
 
     @ViewBuilder func body(content: Content) -> some View {
         if #available(iOSApplicationExtension 14.0, *) {
-            content
-                .listStyle(InsetGroupedListStyle())
+            // For compact sizes (e.g. iPod Touch), don't inset, in order to more efficiently utilize limited real estate
+            if horizontalOverride == .compact {
+                content
+                    .listStyle(GroupedListStyle())
+                    .environment(\.horizontalSizeClass, horizontalOverride)
+            } else {
+                content
+                    .listStyle(InsetGroupedListStyle())
+                    .environment(\.horizontalSizeClass, horizontalOverride)
+            }
         } else {
             // Fallback on earlier versions
             content

--- a/LoopKitUI/Views/SectionHeader.swift
+++ b/LoopKitUI/Views/SectionHeader.swift
@@ -39,13 +39,14 @@ public struct SectionHeader: View {
     }
 }
 
+fileprivate struct HorizontalSizeClassOverrideHelper: HorizontalSizeClassOverride {}
 public extension SectionHeader.Style {
     
-    static let `default`: SectionHeader.Style  = {
+    static let `default`: SectionHeader.Style = {
         if #available(iOSApplicationExtension 14.0, *) {
             return .regular
         } else {
-            return .tight
+            return HorizontalSizeClassOverrideHelper().horizontalOverride == .compact ? .regular : .tight
         }
     }()
 }


### PR DESCRIPTION
"compact size classes" are iPod Touches, for example.
Also fixes, on iOS 13, the Section header margin which also needs adjusting in compact sizes

https://tidepool.atlassian.net/browse/LOOP-2988