### PR TITLE
LOOP-2458 Fix slow status bar update

### DIFF
--- a/LoopKit/CarbKit/CarbStore.swift
+++ b/LoopKit/CarbKit/CarbStore.swift
@@ -1183,7 +1183,7 @@ extension CarbStore {
             var queryError: Error?
 
             guard limit > 0 else {
-                completion(.success(queryAnchor, queryCreatedResult, queryUpdatedResult, queryDeletedResult))
+                completion(.success(queryAnchor, [], [], []))
                 return
             }
 

--- a/LoopKit/DeviceManager/DeviceLog/DeviceLog.xcdatamodeld/DeviceCommsLog.xcdatamodel/contents
+++ b/LoopKit/DeviceManager/DeviceLog/DeviceLog.xcdatamodeld/DeviceCommsLog.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="16119" systemVersion="19G2021" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17511" systemVersion="20C69" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Entry" representedClassName=".DeviceLogEntry" syncable="YES">
         <attribute name="deviceIdentifier" optional="YES" attributeType="String"/>
         <attribute name="managerIdentifier" attributeType="String"/>
@@ -10,8 +10,11 @@
         <fetchIndex name="byTimestampIndex">
             <fetchIndexElement property="timestamp" type="Binary" order="ascending"/>
         </fetchIndex>
+        <fetchIndex name="byModificationCounter">
+            <fetchIndexElement property="modificationCounter" type="Binary" order="ascending"/>
+        </fetchIndex>
     </entity>
     <elements>
-        <element name="Entry" positionX="-36" positionY="9" width="128" height="133"/>
+        <element name="Entry" positionX="-36" positionY="9" width="128" height="119"/>
     </elements>
 </model>

--- a/LoopKit/DosingDecisionStore.swift
+++ b/LoopKit/DosingDecisionStore.swift
@@ -121,7 +121,7 @@ extension DosingDecisionStore {
             var queryError: Error?
 
             guard limit > 0 else {
-                completion(.success(queryAnchor, queryResult))
+                completion(.success(queryAnchor, []))
                 return
             }
 

--- a/LoopKit/GlucoseKit/GlucoseStore.swift
+++ b/LoopKit/GlucoseKit/GlucoseStore.swift
@@ -703,7 +703,7 @@ extension GlucoseStore {
             var queryError: Error?
 
             guard limit > 0 else {
-                completion(.success(queryAnchor, queryResult))
+                completion(.success(queryAnchor, []))
                 return
             }
 

--- a/LoopKit/InsulinKit/DoseStore.swift
+++ b/LoopKit/InsulinKit/DoseStore.swift
@@ -1433,7 +1433,7 @@ extension DoseStore {
         var queryError: Error?
 
         guard limit > 0 else {
-            completion(.success(queryAnchor, queryResult))
+            completion(.success(queryAnchor, []))
             return
         }
 
@@ -1473,7 +1473,7 @@ extension DoseStore {
         var queryError: Error?
 
         guard limit > 0 else {
-            completion(.success(queryAnchor, queryResult))
+            completion(.success(queryAnchor, []))
             return
         }
 

--- a/LoopKit/Persistence/Model.xcdatamodeld/Modelv3.xcdatamodel/contents
+++ b/LoopKit/Persistence/Model.xcdatamodeld/Modelv3.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17192" systemVersion="19H2" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17511" systemVersion="20C69" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="CachedCarbObject" representedClassName=".CachedCarbObject" syncable="YES">
         <attribute name="absorptionTime" optional="YES" attributeType="Double" usesScalarValueType="NO"/>
         <attribute name="addedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -17,6 +17,9 @@
         <attribute name="userDeletedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="userUpdatedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="uuid" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <fetchIndex name="byAnchorKey">
+            <fetchIndexElement property="anchorKey" type="Binary" order="ascending"/>
+        </fetchIndex>
     </entity>
     <entity name="CachedGlucoseObject" representedClassName=".CachedGlucoseObject" syncable="YES">
         <attribute name="isDisplayOnly" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
@@ -40,6 +43,9 @@
         </fetchIndex>
         <fetchIndex name="bySyncIdentifierIndex">
             <fetchIndexElement property="syncIdentifier" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byModificationCounter">
+            <fetchIndexElement property="modificationCounter" type="Binary" order="ascending"/>
         </fetchIndex>
         <uniquenessConstraints>
             <uniquenessConstraint>
@@ -88,6 +94,9 @@
         <fetchIndex name="byDateIndex">
             <fetchIndexElement property="date" type="Binary" order="ascending"/>
         </fetchIndex>
+        <fetchIndex name="byModificationCounter">
+            <fetchIndexElement property="modificationCounter" type="Binary" order="ascending"/>
+        </fetchIndex>
     </entity>
     <entity name="PumpEvent" representedClassName=".PumpEvent" syncable="YES">
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
@@ -115,6 +124,9 @@
         <fetchIndex name="byMutable">
             <fetchIndexElement property="mutable" type="Binary" order="ascending"/>
         </fetchIndex>
+        <fetchIndex name="byModificationCounter">
+            <fetchIndexElement property="modificationCounter" type="Binary" order="ascending"/>
+        </fetchIndex>
         <uniquenessConstraints>
             <uniquenessConstraint>
                 <constraint value="raw"/>
@@ -134,14 +146,17 @@
         <attribute name="data" attributeType="Binary"/>
         <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="modificationCounter" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <fetchIndex name="byModificationCounter">
+            <fetchIndexElement property="modificationCounter" type="Binary" order="ascending"/>
+        </fetchIndex>
     </entity>
     <elements>
-        <element name="CachedCarbObject" positionX="-63" positionY="72" width="128" height="283"/>
-        <element name="CachedGlucoseObject" positionX="-63" positionY="99" width="128" height="193"/>
+        <element name="CachedCarbObject" positionX="-63" positionY="72" width="128" height="269"/>
+        <element name="CachedGlucoseObject" positionX="-63" positionY="99" width="128" height="179"/>
         <element name="CachedInsulinDeliveryObject" positionX="-63" positionY="108" width="128" height="208"/>
-        <element name="DosingDecisionObject" positionX="-63" positionY="126" width="128" height="88"/>
-        <element name="PumpEvent" positionX="-63" positionY="18" width="128" height="238"/>
+        <element name="DosingDecisionObject" positionX="-63" positionY="126" width="128" height="74"/>
+        <element name="PumpEvent" positionX="-63" positionY="18" width="128" height="224"/>
         <element name="Reservoir" positionX="-63" positionY="-18" width="128" height="105"/>
-        <element name="SettingsObject" positionX="-63" positionY="126" width="128" height="88"/>
+        <element name="SettingsObject" positionX="-63" positionY="126" width="128" height="74"/>
     </elements>
 </model>


### PR DESCRIPTION
- https://tidepool.atlassian.net/browse/LOOP-2458
- Add modificationCounter/anchorKey indices to prevent slow data access
- Move settings data decoding from data access queue into utility queue
- Clearly return empty array when store query limit is <= 0