### PR TITLE
[LOOP-2491] Return to originally supported orientations

### DIFF
--- a/LoopKitUI/Extensions/OrientationLock.swift
+++ b/LoopKitUI/Extensions/OrientationLock.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 public protocol DeviceOrientationController: AnyObject {
     var supportedInterfaceOrientations: UIInterfaceOrientationMask { get set }
+    func setOriginallySupportedInferfaceOrientations()
 }
 
 /// A class whose lifetime defines the application's supported interface orientations.
@@ -18,20 +19,21 @@ public protocol DeviceOrientationController: AnyObject {
 /// Use the `supportedInterfaceOrientations` modifier on a SwiftUI view to lock its orientation.
 /// To function, `OrientationLock.deviceOrientationController` must be assigned prior to use.
 public final class OrientationLock {
-    private let originalSupportedInterfaceOrientations: UIInterfaceOrientationMask
-
     /// The global controller for device orientation.
     /// The property must be assigned prior to instantiating any OrientationLock.
     public static weak var deviceOrientationController: DeviceOrientationController?
 
     fileprivate init(_ supportedInterfaceOrientations: UIInterfaceOrientationMask) {
-        assert(Self.deviceOrientationController != nil, "OrientationLock.deviceOrientationController must be assigned prior to constructing an OrientationLock")
-        originalSupportedInterfaceOrientations = Self.deviceOrientationController?.supportedInterfaceOrientations ?? .allButUpsideDown
-        Self.deviceOrientationController?.supportedInterfaceOrientations = supportedInterfaceOrientations
-    }
+        guard let deviceOrientationController = Self.deviceOrientationController else {
+            assertionFailure("OrientationLock.deviceOrientationController must be assigned prior to constructing an OrientationLock")
+            return
+        }
 
-    deinit {
-        Self.deviceOrientationController?.supportedInterfaceOrientations = originalSupportedInterfaceOrientations
+        deviceOrientationController.supportedInterfaceOrientations = supportedInterfaceOrientations
+    }
+    
+    func setOriginallySupportedInferfaceOrientations() {
+        Self.deviceOrientationController?.setOriginallySupportedInferfaceOrientations()
     }
 }
 
@@ -53,5 +55,8 @@ private struct OrientationLocked<Content: View>: View {
         self.content = content
     }
 
-    var body: some View { content }
+    var body: some View {
+        content
+            .onDisappear { orientationLock.setOriginallySupportedInferfaceOrientations() }
+    }
 }

--- a/LoopKitUI/Extensions/OrientationLock.swift
+++ b/LoopKitUI/Extensions/OrientationLock.swift
@@ -14,8 +14,6 @@ public protocol DeviceOrientationController: AnyObject {
     func setOriginallySupportedInferfaceOrientations()
 }
 
-/// A class whose lifetime defines the application's supported interface orientations.
-///
 /// Use the `supportedInterfaceOrientations` modifier on a SwiftUI view to lock its orientation.
 /// To function, `OrientationLock.deviceOrientationController` must be assigned prior to use.
 public final class OrientationLock {
@@ -55,6 +53,7 @@ private struct OrientationLocked<Content: View>: View {
         self.content = content
     }
 
+    // when view disappears, it reverts to the originally support orientations
     var body: some View {
         content
             .onDisappear { orientationLock.setOriginallySupportedInferfaceOrientations() }


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-2491

Since this object is instantiated within a view body, a new instance is created with each view refresh. Thus it cannot use deinit to set originally supported orientations. Instead just have the `deviceOrientationController` set the originally supported orientations when the view disappears.