### PR TITLE
[LOOP-2399] Allowing observers of the CGMManagerStatus didUpdate

### DIFF
--- a/LoopKit/DeviceManager/CGMManager.swift
+++ b/LoopKit/DeviceManager/CGMManager.swift
@@ -29,8 +29,8 @@ public struct CGMManagerStatus {
     }
 }
 
-public protocol CGMManagerStatusObserver: class {
-    /// Notifies observes of changes in CGMManagerStatus
+public protocol CGMManagerStatusObserver: AnyObject {
+    /// Notifies observers of changes in CGMManagerStatus
     ///
     /// - Parameter manager: The manager instance
     /// - Parameter status: The new, updated status. Status includes properties associated with the manager, transmitter, or sensor,

--- a/LoopKit/DeviceManager/CGMManager.swift
+++ b/LoopKit/DeviceManager/CGMManager.swift
@@ -130,4 +130,12 @@ public extension CGMManager {
             completion()
         }
     }
+    
+    func addStatusObserver(_ observer: CGMManagerStatusObserver, queue: DispatchQueue) {
+        // optional since a CGM manager may not support status observers
+    }
+
+    func removeStatusObserver(_ observer: CGMManagerStatusObserver) {
+        // optional since a CGM manager may not support status observers
+    }
 }

--- a/LoopKit/DeviceManager/CGMManager.swift
+++ b/LoopKit/DeviceManager/CGMManager.swift
@@ -29,7 +29,16 @@ public struct CGMManagerStatus {
     }
 }
 
-public protocol CGMManagerDelegate: DeviceManagerDelegate {
+public protocol CGMManagerStatusObserver: class {
+    /// Notifies observes of changes in CGMManagerStatus
+    ///
+    /// - Parameter manager: The manager instance
+    /// - Parameter status: The new, updated status. Status includes properties associated with the manager, transmitter, or sensor,
+    ///                     that are not part of an individual sensor reading.
+    func cgmManager(_ manager: CGMManager, didUpdate status: CGMManagerStatus)
+}
+
+public protocol CGMManagerDelegate: DeviceManagerDelegate, CGMManagerStatusObserver {
     /// Asks the delegate for a date with which to filter incoming glucose data
     ///
     /// - Parameter manager: The manager instance
@@ -58,13 +67,6 @@ public protocol CGMManagerDelegate: DeviceManagerDelegate {
     /// - Parameter manager: The manager instance
     /// - Returns: The unique prefix for the credential store
     func credentialStoragePrefix(for manager: CGMManager) -> String
-    
-    /// Notifies the delegate of a change in status
-    ///
-    /// - Parameter manager: The manager instance
-    /// - Parameter status: The new, updated status. Status includes properties associated with the manager, transmitter, or sensor,
-    ///                     that are not part of an individual sensor reading.
-    func cgmManager(_ manager: CGMManager, didUpdate status: CGMManagerStatus)
 }
 
 
@@ -86,14 +88,30 @@ public protocol CGMManager: DeviceManager {
     /// The representation of the device for use in HealthKit
     var device: HKDevice? { get }
 
-    /// The current status of the cgm
-    var cgmStatus: CGMManagerStatus { get }
+    /// The current status of the cgm manager
+    var cgmManagerStatus: CGMManagerStatus { get }
 
     /// Performs a manual fetch of glucose data from the device, if necessary
     ///
     /// - Parameters:
     ///   - completion: A closure called when operation has completed
     func fetchNewDataIfNeeded(_ completion: @escaping (CGMReadingResult) -> Void) -> Void
+
+    /// Adds an observer of changes in CGMManagerStatus
+    ///
+    /// Observers are held by weak reference.
+    ///
+    /// - Parameters:
+    ///   - observer: The observing object
+    ///   - queue: The queue on which the observer methods should be called
+    func addStatusObserver(_ observer: CGMManagerStatusObserver, queue: DispatchQueue)
+
+    /// Removes an observer of changes in CGMManagerStatus
+    ///
+    /// Since observers are held weakly, calling this method is not required when the observer is deallocated
+    ///
+    /// - Parameter observer: The observing object
+    func removeStatusObserver(_ observer: CGMManagerStatusObserver)
 }
 
 

--- a/MockKit/MockCGMManager.swift
+++ b/MockKit/MockCGMManager.swift
@@ -291,9 +291,7 @@ public final class MockCGMManager: TestingCGMManager {
 
     public var mockSensorState: MockCGMState {
         didSet {
-            delegate.notify { (delegate) in
-                delegate?.cgmManagerDidUpdateState(self)
-            }
+            self.notifyStatusObservers(cgmManagerStatus: self.cgmManagerStatus)
         }
     }
 
@@ -335,10 +333,7 @@ public final class MockCGMManager: TestingCGMManager {
 
     public var dataSource: MockCGMDataSource {
         didSet {
-            delegate.notify { (delegate) in
-                delegate?.cgmManagerDidUpdateState(self)
-                self.notifyStatusObservers(cgmManagerStatus: self.cgmManagerStatus)
-            }
+            self.notifyStatusObservers(cgmManagerStatus: self.cgmManagerStatus)
         }
     }
 
@@ -360,6 +355,7 @@ public final class MockCGMManager: TestingCGMManager {
     
     private func notifyStatusObservers(cgmManagerStatus: CGMManagerStatus) {
         delegate.notify { delegate in
+            delegate?.cgmManagerDidUpdateState(self)
             delegate?.cgmManager(self, didUpdate: self.cgmManagerStatus)
         }
         statusObservers.forEach { observer in
@@ -578,9 +574,6 @@ extension MockCGMManager {
             // restore signal loss status highlight
             issueSignalLossAlert()
         }
-
-        // trigger display of the status highlight
-        sendCGMReadingResult(.noData)
     }
     
     private func registerBackgroundTask() {


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-2399

Allowing observers of the CGMManagerStatus didUpdate. This follows the pattern in the pump manager for notifying updates to its status.