### PR TITLE
[LOOP-3122] added dimmed state to lifecycle progress bar

### DIFF
--- a/LoopKit/DeviceManager/DeviceLifecycleProgress.swift
+++ b/LoopKit/DeviceManager/DeviceLifecycleProgress.swift
@@ -18,6 +18,7 @@ public protocol DeviceLifecycleProgress {
 
 public enum DeviceLifecycleProgressState: String, Codable {
     case critical
+    case dimmed
     case normalCGM
     case normalPump
     case warning


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-3122

The device lifecycle progress needs to support a dimmed state.