### PR TITLE
[LOOP-3170] build view in init instead of in body

### DIFF
--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -414,10 +414,25 @@ struct SectionWithTapToEdit<Header, Content, NavigationDestination>: View where 
     let title: String
     let descriptiveText: String
     let destination: (_ goBack: @escaping () -> Void) -> NavigationDestination
-    let content: () -> Content
+    let content: Content
 
     @State var isActive: Bool = false
-    
+
+    init(isEnabled: Bool,
+         header: Header,
+         title: String,
+         descriptiveText: String,
+         destination: @escaping (@escaping () -> Void) -> NavigationDestination,
+         @ViewBuilder content: () -> Content)
+    {
+        self.isEnabled = isEnabled
+        self.header = header
+        self.title = title
+        self.descriptiveText = descriptiveText
+        self.destination = destination
+        self.content = content()
+    }
+
     private func onFinish() {
         // Dispatching here fixes an issue on iOS 14.2 where schedule editors do not dismiss. It does not fix iOS 14.0 and 14.1
         DispatchQueue.main.async {
@@ -444,7 +459,7 @@ struct SectionWithTapToEdit<Header, Content, NavigationDestination>: View where 
                 }
                 Spacer()
             }
-            content()
+            content
         }
         .contentShape(Rectangle()) // make the whole card tappable
         .highPriorityGesture(

--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -423,7 +423,7 @@ struct SectionWithTapToEdit<Header, Content, NavigationDestination>: View where 
          title: String,
          descriptiveText: String,
          destination: @escaping (@escaping () -> Void) -> NavigationDestination,
-         @ViewBuilder content: () -> Content)
+         content: () -> Content)
     {
         self.isEnabled = isEnabled
         self.header = header


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-3170

I wish I could include a clear explanation as to why this change is needed, but alas I don't fully understand the issue. 

When investigating, I narrowed down the problem to a closure containing `ForEach` as the content for `SectionWithTapToEdit`, which affects the:
- `CorrectionRangeScheduleEditor`
- `BasalRateScheduleEditor`
- `CarbRatioScheduleEditor`
- `InsulinSensitivityScheduleEditor` 

navigation when the user taps `Cancel` or `Save`. I was able to reproduce in the iPod 7th Gen simulator running 14.2.

As you see in the fix, the closure is now called in the `init` instead of in the `body`. This works as expected when the view updates.