### PR TITLE
[LOOP-3021] CGM manager should handle its deletion to allow for any needed cleanup

### DIFF
--- a/LoopKit/DeviceManager/CGMManager.swift
+++ b/LoopKit/DeviceManager/CGMManager.swift
@@ -22,7 +22,7 @@ public enum CGMReadingResult {
 public struct CGMManagerStatus {
     // Return false if no sensor active, or in a state where no future data is expected without user intervention
     public var hasValidSensorSession: Bool
-    
+
     public init(hasValidSensorSession: Bool) {
         self.hasValidSensorSession = hasValidSensorSession
     }
@@ -115,7 +115,7 @@ public protocol CGMManager: DeviceManager {
     /// Requests that the manager completes its deletion process
     ///
     /// - Parameter completion: Action to take after the CGM manager is deleted
-    func deleteCGMManager(completion: @escaping () -> Void)
+    func delete(completion: @escaping () -> Void)
 }
 
 
@@ -144,7 +144,7 @@ public extension CGMManager {
     }
 
     /// Override this default behaviour if the CGM Manager needs to complete tasks before being deleted
-    func deleteCGMManager(completion: @escaping () -> Void) {
+    func delete(completion: @escaping () -> Void) {
         notifyDelegateOfDeletion(completion: completion)
     }
 }

--- a/LoopKit/DeviceManager/CGMManager.swift
+++ b/LoopKit/DeviceManager/CGMManager.swift
@@ -111,6 +111,11 @@ public protocol CGMManager: DeviceManager {
     ///
     /// - Parameter observer: The observing object
     func removeStatusObserver(_ observer: CGMManagerStatusObserver)
+
+    /// Requests that the manager completes its deletion process
+    ///
+    /// - Parameter completion: Action to take after the CGM manager is deleted
+    func deleteCGMManager(completion: @escaping () -> Void)
 }
 
 
@@ -136,5 +141,10 @@ public extension CGMManager {
 
     func removeStatusObserver(_ observer: CGMManagerStatusObserver) {
         // optional since a CGM manager may not support status observers
+    }
+
+    /// Override this default behaviour if the CGM Manager needs to complete tasks before being deleted
+    func deleteCGMManager(completion: @escaping () -> Void) {
+        notifyDelegateOfDeletion(completion: completion)
     }
 }


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-3021

I checked DIY, and those CGM managers do not conduct any additional deletion tasks besides calling `notifyDelegateOfDeletion`.