### PR TITLE
LOOP-3099: Enable ability to auto-focus the TextField in LabeledNumberInput

### DIFF
--- a/LoopKitUI/Views/DismissibleKeyboardTextField.swift
+++ b/LoopKitUI/Views/DismissibleKeyboardTextField.swift
@@ -21,6 +21,7 @@ public struct DismissibleKeyboardTextField: UIViewRepresentable {
     var shouldBecomeFirstResponder: Bool
     var maxLength: Int?
     var doneButtonColor: UIColor
+    var isDismissible: Bool
 
     public init(
         text: Binding<String>,
@@ -33,7 +34,8 @@ public struct DismissibleKeyboardTextField: UIViewRepresentable {
         autocorrectionType: UITextAutocorrectionType = .default,
         shouldBecomeFirstResponder: Bool = false,
         maxLength: Int? = nil,
-        doneButtonColor: UIColor = .blue
+        doneButtonColor: UIColor = .blue,
+        isDismissible: Bool = true
     ) {
         self._text = text
         self.placeholder = placeholder
@@ -46,11 +48,12 @@ public struct DismissibleKeyboardTextField: UIViewRepresentable {
         self.shouldBecomeFirstResponder = shouldBecomeFirstResponder
         self.maxLength = maxLength
         self.doneButtonColor = doneButtonColor
+        self.isDismissible = isDismissible
     }
 
     public func makeUIView(context: Context) -> UITextField {
         let textField = UITextField()
-        textField.inputAccessoryView = makeDoneToolbar(for: textField)
+        textField.inputAccessoryView = isDismissible ? makeDoneToolbar(for: textField) : nil
         textField.addTarget(context.coordinator, action: #selector(Coordinator.textChanged), for: .editingChanged)
         textField.addTarget(context.coordinator, action: #selector(Coordinator.editingDidBegin), for: .editingDidBegin)
         textField.delegate = context.coordinator

--- a/LoopKitUI/Views/LabeledNumberInput.swift
+++ b/LoopKitUI/Views/LabeledNumberInput.swift
@@ -10,10 +10,11 @@ import SwiftUI
 
 public struct LabeledNumberInput: View {
     @Binding var value: Double?
-    let font: Font
+    let font: UIFont
     let label: String
     let placeholder: String
     let allowFractions: Bool
+    let shouldBecomeFirstResponder: Bool
     
     private var numberFormatter: NumberFormatter {
         let numberFormatter = NumberFormatter()
@@ -38,23 +39,28 @@ public struct LabeledNumberInput: View {
         )
     }
     
-    public init(value: Binding<Double?>, font: Font = .largeTitle, label: String, placeholder: String? = nil, allowFractions: Bool = false) {
+    public init(value: Binding<Double?>, font: UIFont = .preferredFont(forTextStyle: .largeTitle), label: String, placeholder: String? = nil, allowFractions: Bool = false, shouldBecomeFirstResponder: Bool = false) {
         _value = value
         self.font = font
         self.label = label
         self.placeholder = placeholder ?? LocalizedString("Value", comment: "Placeholder text until value is entered")
         self.allowFractions = allowFractions
+        self.shouldBecomeFirstResponder = shouldBecomeFirstResponder
     }
         
     public var body: some View {
         GeometryReader { geometry in
             HStack(alignment: .bottom, spacing: 5) {
-                TextField(self.placeholder, text: self.valueString)
-                    .font(font)
-                    .multilineTextAlignment(.trailing)
-                    .keyboardType(self.allowFractions ? .decimalPad : .numberPad)
-                    .frame(width: geometry.size.width/2, alignment: .trailing)
-                    .accessibility(label: Text(String(format: LocalizedString("Enter %1$@ value", comment: "Format string for accessibility label for value entry. (1: value label)"), label)))
+                DismissibleKeyboardTextField(
+                    text: valueString,
+                    placeholder: placeholder,
+                    font: font,
+                    textAlignment: .right,
+                    keyboardType: allowFractions ? .decimalPad : .numberPad,
+                    shouldBecomeFirstResponder: true,
+                    isDismissible: false
+                )
+                .accessibility(label: Text(String(format: LocalizedString("Enter %1$@ value", comment: "Format string for accessibility label for value entry. (1: value label)"), label)))
                 Text(self.label)
                     .font(.footnote)
                     .multilineTextAlignment(.leading)


### PR DESCRIPTION
This is from [design review feedback](https://tidepool.atlassian.net/browse/LOOP-3099?focusedCommentId=35511) on LOOP-3099.  Apparently you can't auto-focus a TextField in SwiftUI, but we have `DismissibleTextField` for that, so use it.
