### PR TITLE
[LOOP-3375] Onboarding service integration

### DIFF
--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -549,7 +549,7 @@
 		A9498D8023386C3300DAA9B9 /* RemoteDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D7523386C3300DAA9B9 /* RemoteDataService.swift */; };
 		A9498D8223386C3300DAA9B9 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D7623386C3300DAA9B9 /* Service.swift */; };
 		A9498D8423386C3300DAA9B9 /* DiagnosticLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D7723386C3300DAA9B9 /* DiagnosticLog.swift */; };
-		A9498D8823386CAF00DAA9B9 /* ServiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D8623386CAF00DAA9B9 /* ServiceViewController.swift */; };
+		A9498D8823386CAF00DAA9B9 /* ServiceNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D8623386CAF00DAA9B9 /* ServiceNavigationController.swift */; };
 		A9498D8B23386CC700DAA9B9 /* ServiceUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D8A23386CC700DAA9B9 /* ServiceUI.swift */; };
 		A9498D8D23386CD800DAA9B9 /* MockService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D8C23386CD700DAA9B9 /* MockService.swift */; };
 		A9498D8F23386CE800DAA9B9 /* MockServiceTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9498D8E23386CE800DAA9B9 /* MockServiceTableViewController.swift */; };
@@ -1468,7 +1468,7 @@
 		A9498D7523386C3300DAA9B9 /* RemoteDataService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteDataService.swift; sourceTree = "<group>"; };
 		A9498D7623386C3300DAA9B9 /* Service.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
 		A9498D7723386C3300DAA9B9 /* DiagnosticLog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiagnosticLog.swift; sourceTree = "<group>"; };
-		A9498D8623386CAF00DAA9B9 /* ServiceViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServiceViewController.swift; sourceTree = "<group>"; };
+		A9498D8623386CAF00DAA9B9 /* ServiceNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServiceNavigationController.swift; sourceTree = "<group>"; };
 		A9498D8A23386CC700DAA9B9 /* ServiceUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServiceUI.swift; sourceTree = "<group>"; };
 		A9498D8C23386CD700DAA9B9 /* MockService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockService.swift; sourceTree = "<group>"; };
 		A9498D8E23386CE800DAA9B9 /* MockServiceTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockServiceTableViewController.swift; sourceTree = "<group>"; };
@@ -1845,7 +1845,7 @@
 				895FE08C22011F4800FCF18A /* OverrideSelectionViewController.swift */,
 				898E6E6F2241EDB70019E459 /* PercentageTextFieldTableViewController.swift */,
 				43FB60E620DCBC55002B996B /* RadioSelectionTableViewController.swift */,
-				A9498D8623386CAF00DAA9B9 /* ServiceViewController.swift */,
+				A9498D8623386CAF00DAA9B9 /* ServiceNavigationController.swift */,
 				892A5D992231E0E3008961AB /* SettingsNavigationViewController.swift */,
 				43FB60E420DCBA02002B996B /* SetupTableViewController.swift */,
 				43D8FE0C1C7290530073BE78 /* SingleValueScheduleTableViewController.swift */,
@@ -3493,7 +3493,7 @@
 				89653C822473592600E1BAA5 /* CarbRatioScheduleEditor.swift in Sources */,
 				1D1FCE2B24BE704A000300A8 /* TherapySetting+Settings.swift in Sources */,
 				4369F08F208859E6000E3E45 /* PaddedTextField.swift in Sources */,
-				A9498D8823386CAF00DAA9B9 /* ServiceViewController.swift in Sources */,
+				A9498D8823386CAF00DAA9B9 /* ServiceNavigationController.swift in Sources */,
 				892A5D9E2231E122008961AB /* StateColorPalette.swift in Sources */,
 				895FE08022011F0C00FCF18A /* EmojiDataSource.swift in Sources */,
 				432CF86920D76B320066B889 /* SetupButton.swift in Sources */,

--- a/LoopKitUI/CGMManagerUI.swift
+++ b/LoopKitUI/CGMManagerUI.swift
@@ -33,23 +33,26 @@ public protocol CGMStatusIndicator {
     func glucoseRangeCategory(for glucose: GlucoseSampleValue) -> GlucoseRangeCategory?
 }
 
+public typealias CGMManagerViewController = (UIViewController & CGMManagerOnboarding & CompletionNotifying)
+
 public protocol CGMManagerUI: CGMManager, DeviceManagerUI, DisplayGlucoseUnitObserver, CGMStatusIndicator {
     /// Create and onboard a new CGM manager.
     ///
     /// - Parameters:
     ///     - bluetoothProvider: The provider of Bluetooth functionality.
+    ///     - displayGlucoseUnitObservable: The glucose units to use for display.
     ///     - colorPalette: Color palette to use for any UI.
     /// - Returns: Either a conforming view controller to create and onboard the CGM manager or a newly created and onboarded CGM manager.
-    static func setupViewController(bluetoothProvider: BluetoothProvider, colorPalette: LoopUIColorPalette) -> SetupUIResult<UIViewController & CGMManagerCreateNotifying & CGMManagerOnboardNotifying & CompletionNotifying, CGMManagerUI>
+    static func setupViewController(bluetoothProvider: BluetoothProvider, displayGlucoseUnitObservable: DisplayGlucoseUnitObservable, colorPalette: LoopUIColorPalette) -> SetupUIResult<CGMManagerViewController, CGMManagerUI>
 
     /// Configure settings for an existing CGM manager.
     ///
     /// - Parameters:
-    ///     - displayGlucoseUnitObservable: The glucose units to use for display.
     ///     - bluetoothProvider: The provider of Bluetooth functionality.
+    ///     - displayGlucoseUnitObservable: The glucose units to use for display.
     ///     - colorPalette: Color palette to use for any UI.
     /// - Returns: A view controller to configure an existing CGM manager.
-    func settingsViewController(for displayGlucoseUnitObservable: DisplayGlucoseUnitObservable, bluetoothProvider: BluetoothProvider, colorPalette: LoopUIColorPalette) -> (UIViewController & CGMManagerOnboardNotifying & CompletionNotifying)
+    func settingsViewController(bluetoothProvider: BluetoothProvider, displayGlucoseUnitObservable: DisplayGlucoseUnitObservable, colorPalette: LoopUIColorPalette) -> CGMManagerViewController
 }
 
 extension CGMManagerUI {
@@ -63,28 +66,21 @@ extension CGMManagerUI {
     }
 }
 
-public protocol CGMManagerCreateDelegate: AnyObject {
-    /// Informs the delegate that the specified cgm manager was created.
+public protocol CGMManagerOnboardingDelegate: AnyObject {
+    /// Informs the delegate that the specified CGM manager was created.
     ///
     /// - Parameters:
-    ///     - cgmManager: The cgm manager created.
-    func cgmManagerCreateNotifying(didCreateCGMManager cgmManager: CGMManagerUI)
-}
+    ///     - cgmManager: The CGM manager created.
+    func cgmManagerOnboarding(didCreateCGMManager cgmManager: CGMManagerUI)
 
-public protocol CGMManagerCreateNotifying {
-    /// Delegate to notify about cgm manager creation.
-    var cgmManagerCreateDelegate: CGMManagerCreateDelegate? { get set }
-}
-
-public protocol CGMManagerOnboardDelegate: AnyObject {
-    /// Informs the delegate that the specified cgm manager was onboarded.
+    /// Informs the delegate that the specified CGM manager was onboarded.
     ///
     /// - Parameters:
-    ///     - cgmManager: The cgm manager onboarded.
-    func cgmManagerOnboardNotifying(didOnboardCGMManager cgmManager: CGMManagerUI)
+    ///     - cgmManager: The CGM manager onboarded.
+    func cgmManagerOnboarding(didOnboardCGMManager cgmManager: CGMManagerUI)
 }
 
-public protocol CGMManagerOnboardNotifying {
-    /// Delegate to notify about cgm manager onboarding.
-    var cgmManagerOnboardDelegate: CGMManagerOnboardDelegate? { get set }
+public protocol CGMManagerOnboarding {
+    /// Delegate to notify about CGM manager onboarding.
+    var cgmManagerOnboardingDelegate: CGMManagerOnboardingDelegate? { get set }
 }

--- a/LoopKitUI/OnboardingUI.swift
+++ b/LoopKitUI/OnboardingUI.swift
@@ -60,6 +60,8 @@ public protocol HealthStoreAuthorizationProvider: AnyObject {
     func authorizeHealthStore(_ completion: @escaping (HealthStoreAuthorization) -> Void)
 }
 
+public typealias OnboardingResult = SetupUIResult
+
 public protocol CGMManagerProvider: AnyObject {
     /// The active CGM manager.
     var activeCGMManager: CGMManager? { get }
@@ -67,12 +69,12 @@ public protocol CGMManagerProvider: AnyObject {
     /// The descriptor list of available CGM managers.
     var availableCGMManagers: [CGMManagerDescriptor] { get }
 
-    /// Setup the CGM manager with the specified identifier.
+    /// Onboard the CGM manager with the specified identifier.
     ///
     /// - Parameters:
-    ///     - identifier: The identifier of the CGM manager to setup.
-    /// - Returns: Either a conforming view controller to create and setup the CGM manager, a newly created and setup CGM manager, or an error.
-    func setupCGMManager(withIdentifier identifier: String) -> Result<SetupUIResult<UIViewController & CGMManagerCreateNotifying & CGMManagerOnboardNotifying & CompletionNotifying, CGMManager>, Error>
+    ///     - identifier: The identifier of the CGM manager to onboard.
+    /// - Returns: Either a conforming view controller to onboard the CGM manager, a newly onboarded CGM manager, or an error.
+    func onboardCGMManager(withIdentifier identifier: String) -> Result<OnboardingResult<CGMManagerViewController, CGMManager>, Error>
 }
 
 public protocol PumpManagerProvider: AnyObject {
@@ -82,12 +84,12 @@ public protocol PumpManagerProvider: AnyObject {
     /// The descriptor list of available pump managers.
     var availablePumpManagers: [PumpManagerDescriptor] { get }
 
-    /// Setup the pump manager with the specified identifier.
+    /// Onboard the pump manager with the specified identifier.
     ///
     /// - Parameters:
-    ///     - identifier: The identifier of the pump manager to setup.
-    /// - Returns: Either a conforming view controller to create and setup the pump manager, a newly created and setup pump manager, or an error.
-    func setupPumpManager(withIdentifier identifier: String, initialSettings settings: PumpManagerSetupSettings) -> Result<SetupUIResult<UIViewController & PumpManagerCreateNotifying & PumpManagerOnboardNotifying & CompletionNotifying, PumpManager>, Error>
+    ///     - identifier: The identifier of the pump manager to onboard.
+    /// - Returns: Either a conforming view controller to onboard the pump manager, a newly onboarded pump manager, or an error.
+    func onboardPumpManager(withIdentifier identifier: String, initialSettings settings: PumpManagerSetupSettings) -> Result<OnboardingResult<PumpManagerViewController, PumpManager>, Error>
 }
 
 public protocol ServiceProvider: AnyObject {
@@ -97,16 +99,16 @@ public protocol ServiceProvider: AnyObject {
     /// The descriptor list of available services.
     var availableServices: [ServiceDescriptor] { get }
 
-    /// Setup the setup with the specified identifier.
+    /// Onboard the service with the specified identifier.
     ///
     /// - Parameters:
-    ///     - identifier: The identifier of the setup to setup.
-    /// - Returns: Either a conforming view controller to create and setup the service, a newly created and setup service, or an error.
-    func setupService(withIdentifier identifier: String) -> Result<SetupUIResult<UIViewController & ServiceCreateNotifying & ServiceOnboardNotifying & CompletionNotifying, Service>, Error>
+    ///     - identifier: The identifier of the service to onboard.
+    /// - Returns: Either a conforming view controller to onboard the service, a newly onboarded service, or an error.
+    func onboardService(withIdentifier identifier: String) -> Result<OnboardingResult<ServiceViewController, Service>, Error>
 }
 
 public protocol OnboardingProvider: NotificationAuthorizationProvider, HealthStoreAuthorizationProvider, BluetoothProvider, CGMManagerProvider, PumpManagerProvider, ServiceProvider {
-    var allowSkipOnboarding: Bool { get }   // NOTE: SKIP ONBOARDING - DEBUG AND TEST ONLY
+    var allowDebugFeatures: Bool { get }   // NOTE: DEBUG FEATURES - DEBUG AND TEST ONLY
 }
 
 public protocol OnboardingDelegate: AnyObject {
@@ -132,7 +134,7 @@ public protocol OnboardingDelegate: AnyObject {
     func onboarding(_ onboarding: OnboardingUI, hasNewDosingEnabled dosingEnabled: Bool)
 }
 
-public typealias OnboardingViewController = (CGMManagerCreateNotifying & CGMManagerOnboardNotifying & PumpManagerCreateNotifying & PumpManagerOnboardNotifying & ServiceCreateNotifying & ServiceOnboardNotifying & CompletionNotifying)
+public typealias OnboardingViewController = (UIViewController & CGMManagerOnboarding & PumpManagerOnboarding & ServiceOnboarding & CompletionNotifying)
 
 public protocol OnboardingUI: AnyObject {
     typealias RawState = [String: Any]
@@ -167,7 +169,5 @@ public protocol OnboardingUI: AnyObject {
     ///   - displayGlucoseUnitObservable: The glucose unit to use for display.
     ///   - colorPalette: The colors to use in any UI,
     /// - Returns: A view controller to create and configure a new onboarding.
-    func onboardingViewController(onboardingProvider: OnboardingProvider,
-                                  displayGlucoseUnitObservable: DisplayGlucoseUnitObservable,
-                                  colorPalette: LoopUIColorPalette) -> (UIViewController & OnboardingViewController)
+    func onboardingViewController(onboardingProvider: OnboardingProvider, displayGlucoseUnitObservable: DisplayGlucoseUnitObservable, colorPalette: LoopUIColorPalette) -> OnboardingViewController
 }

--- a/LoopKitUI/PumpManagerUI.swift
+++ b/LoopKitUI/PumpManagerUI.swift
@@ -31,6 +31,8 @@ public struct PumpManagerSetupSettings {
     }
 }
 
+public typealias PumpManagerViewController = (UIViewController & PumpManagerOnboarding & CompletionNotifying)
+
 public protocol PumpManagerUI: DeviceManagerUI, PumpManager, DeliveryLimitSettingsTableViewControllerSyncSource, BasalScheduleTableViewControllerSyncSource {
     /// Create and onboard a new pump manager.
     ///
@@ -39,7 +41,7 @@ public protocol PumpManagerUI: DeviceManagerUI, PumpManager, DeliveryLimitSettin
     ///     - bluetoothProvider: The provider of Bluetooth functionality.
     ///     - colorPalette: Color palette to use for any UI.
     /// - Returns: Either a conforming view controller to create and onboard the pump manager or a newly created and onboarded pump manager.
-    static func setupViewController(initialSettings settings: PumpManagerSetupSettings, bluetoothProvider: BluetoothProvider, colorPalette: LoopUIColorPalette) -> SetupUIResult<UIViewController & PumpManagerCreateNotifying & PumpManagerOnboardNotifying & CompletionNotifying, PumpManagerUI>
+    static func setupViewController(initialSettings settings: PumpManagerSetupSettings, bluetoothProvider: BluetoothProvider, colorPalette: LoopUIColorPalette) -> SetupUIResult<PumpManagerViewController, PumpManagerUI>
 
     /// Configure settings for an existing pump manager.
     ///
@@ -47,7 +49,7 @@ public protocol PumpManagerUI: DeviceManagerUI, PumpManager, DeliveryLimitSettin
     ///     - bluetoothProvider: The provider of Bluetooth functionality.
     ///     - colorPalette: Color palette to use for any UI.
     /// - Returns: A view controller to configure an existing pump manager.
-    func settingsViewController(bluetoothProvider: BluetoothProvider, colorPalette: LoopUIColorPalette) -> (UIViewController & PumpManagerOnboardNotifying & CompletionNotifying)
+    func settingsViewController(bluetoothProvider: BluetoothProvider, colorPalette: LoopUIColorPalette) -> PumpManagerViewController
 
     // View for recovering from delivery uncertainty
     func deliveryUncertaintyRecoveryViewController(colorPalette: LoopUIColorPalette) -> (UIViewController & CompletionNotifying)
@@ -59,28 +61,21 @@ public protocol PumpManagerUI: DeviceManagerUI, PumpManager, DeliveryLimitSettin
     static func createHUDView(rawValue: HUDProvider.HUDViewRawState) -> LevelHUDView?
 }
 
-public protocol PumpManagerCreateDelegate: AnyObject {
+public protocol PumpManagerOnboardingDelegate: AnyObject {
     /// Informs the delegate that the specified pump manager was created.
     ///
     /// - Parameters:
     ///     - pumpManager: The pump manager created.
-    func pumpManagerCreateNotifying(didCreatePumpManager pumpManager: PumpManagerUI)
-}
+    func pumpManagerOnboarding(didCreatePumpManager pumpManager: PumpManagerUI)
 
-public protocol PumpManagerCreateNotifying {
-    /// Delegate to notify about pump manager creation.
-    var pumpManagerCreateDelegate: PumpManagerCreateDelegate? { get set }
-}
-
-public protocol PumpManagerOnboardDelegate: AnyObject {
     /// Informs the delegate that the specified pump manager was onboarded.
     ///
     /// - Parameters:
     ///     - pumpManager: The pump manager onboarded.
-    func pumpManagerOnboardNotifying(didOnboardPumpManager pumpManager: PumpManagerUI, withFinalSettings settings: PumpManagerSetupSettings)
+    func pumpManagerOnboarding(didOnboardPumpManager pumpManager: PumpManagerUI, withFinalSettings settings: PumpManagerSetupSettings)
 }
 
-public protocol PumpManagerOnboardNotifying {
+public protocol PumpManagerOnboarding {
     /// Delegate to notify about pump manager onboarding.
-    var pumpManagerOnboardDelegate: PumpManagerOnboardDelegate? { get set }
+    var pumpManagerOnboardingDelegate: PumpManagerOnboardingDelegate? { get set }
 }

--- a/LoopKitUI/ServiceUI.swift
+++ b/LoopKitUI/ServiceUI.swift
@@ -19,6 +19,8 @@ public struct ServiceDescriptor {
     }
 }
 
+public typealias ServiceViewController = (UIViewController & ServiceOnboarding & CompletionNotifying)
+
 public protocol ServiceUI: Service {
     /// The image for this type of service.
     static var image: UIImage? { get }
@@ -28,42 +30,35 @@ public protocol ServiceUI: Service {
     /// - Parameters:
     ///     - colorPalette: Color palette to use for any UI.
     /// - Returns: Either a conforming view controller to create and onboard the service or a newly created and onboarded service.
-    static func setupViewController(colorPalette: LoopUIColorPalette) -> SetupUIResult<UIViewController & ServiceCreateNotifying & ServiceOnboardNotifying & CompletionNotifying, ServiceUI>
+    static func setupViewController(colorPalette: LoopUIColorPalette) -> SetupUIResult<ServiceViewController, ServiceUI>
 
     /// Configure settings for an existing service.
     ///
     /// - Parameters:
     ///     - colorPalette: Color palette to use for any UI.
     /// - Returns: A view controller to configure an existing service.
-    func settingsViewController(colorPalette: LoopUIColorPalette) -> (UIViewController & ServiceOnboardNotifying & CompletionNotifying)
+    func settingsViewController(colorPalette: LoopUIColorPalette) -> ServiceViewController
 }
 
 public extension ServiceUI {
     var image: UIImage? { return type(of: self).image }
 }
 
-public protocol ServiceCreateDelegate: AnyObject {
+public protocol ServiceOnboardingDelegate: AnyObject {
     /// Informs the delegate that the specified service was created.
     ///
     /// - Parameters:
     ///     - service: The service created.
-    func serviceCreateNotifying(didCreateService service: Service)
-}
+    func serviceOnboarding(didCreateService service: Service)
 
-public protocol ServiceCreateNotifying {
-    /// Delegate to notify about service creation.
-    var serviceCreateDelegate: ServiceCreateDelegate? { get set }
-}
-
-public protocol ServiceOnboardDelegate: AnyObject {
     /// Informs the delegate that the specified service was onboarded.
     ///
     /// - Parameters:
     ///     - service: The service onboarded.
-    func serviceOnboardNotifying(didOnboardService service: Service)
+    func serviceOnboarding(didOnboardService service: Service)
 }
 
-public protocol ServiceOnboardNotifying {
+public protocol ServiceOnboarding {
     /// Delegate to notify about service onboarding.
-    var serviceOnboardDelegate: ServiceOnboardDelegate? { get set }
+    var serviceOnboardingDelegate: ServiceOnboardingDelegate? { get set }
 }

--- a/LoopKitUI/View Controllers/ServiceNavigationController.swift
+++ b/LoopKitUI/View Controllers/ServiceNavigationController.swift
@@ -1,5 +1,5 @@
 //
-//  ServiceViewController.swift
+//  ServiceNavigationController.swift
 //  LoopKitUI
 //
 //  Created by Darin Krauss on 5/23/19.
@@ -8,17 +8,16 @@
 
 import LoopKit
 
-open class ServiceViewController: UINavigationController, ServiceCreateNotifying, ServiceOnboardNotifying, CompletionNotifying {
-    public weak var serviceCreateDelegate: ServiceCreateDelegate?
-    public weak var serviceOnboardDelegate: ServiceOnboardDelegate?
+open class ServiceNavigationController: UINavigationController, ServiceOnboarding, CompletionNotifying {
+    public weak var serviceOnboardingDelegate: ServiceOnboardingDelegate?
     public weak var completionDelegate: CompletionDelegate?
 
     public func notifyServiceCreated(_ service: Service) {
-        serviceCreateDelegate?.serviceCreateNotifying(didCreateService: service)
+        serviceOnboardingDelegate?.serviceOnboarding(didCreateService: service)
     }
 
     public func notifyServiceOnboarded(_ service: Service) {
-        serviceOnboardDelegate?.serviceOnboardNotifying(didOnboardService: service)
+        serviceOnboardingDelegate?.serviceOnboarding(didOnboardService: service)
     }
 
     public func notifyServiceCreatedAndOnboarded(_ service: ServiceUI) {

--- a/LoopKitUI/View Controllers/SettingsNavigationViewController.swift
+++ b/LoopKitUI/View Controllers/SettingsNavigationViewController.swift
@@ -18,22 +18,22 @@ open class SettingsNavigationViewController: UINavigationController, CompletionN
 
 }
 
-open class CGMManagerSettingsNavigationViewController: SettingsNavigationViewController, CGMManagerOnboardNotifying {
+open class CGMManagerSettingsNavigationViewController: SettingsNavigationViewController, CGMManagerOnboarding {
 
-    open weak var cgmManagerOnboardDelegate: CGMManagerOnboardDelegate?
+    open weak var cgmManagerOnboardingDelegate: CGMManagerOnboardingDelegate?
 
     open func notifySetup(cgmManager: CGMManagerUI) {
-        cgmManagerOnboardDelegate?.cgmManagerOnboardNotifying(didOnboardCGMManager: cgmManager)
+        cgmManagerOnboardingDelegate?.cgmManagerOnboarding(didOnboardCGMManager: cgmManager)
     }
 
 }
 
-open class PumpManagerSettingsNavigationViewController: SettingsNavigationViewController, PumpManagerOnboardNotifying {
+open class PumpManagerSettingsNavigationViewController: SettingsNavigationViewController, PumpManagerOnboarding {
 
-    open weak var pumpManagerOnboardDelegate: PumpManagerOnboardDelegate?
+    open weak var pumpManagerOnboardingDelegate: PumpManagerOnboardingDelegate?
 
     open func notifySetup(pumpManager: PumpManagerUI, withFinalSettings settings: PumpManagerSetupSettings) {
-        pumpManagerOnboardDelegate?.pumpManagerOnboardNotifying(didOnboardPumpManager: pumpManager, withFinalSettings: settings)
+        pumpManagerOnboardingDelegate?.pumpManagerOnboarding(didOnboardPumpManager: pumpManager, withFinalSettings: settings)
     }
 
 }

--- a/MockKitUI/MockCGMManager+UI.swift
+++ b/MockKitUI/MockCGMManager+UI.swift
@@ -18,11 +18,11 @@ extension MockCGMManager: CGMManagerUI {
 
     public var smallImage: UIImage? { return UIImage(named: "CGM Simulator", in: Bundle(for: MockCGMManagerSettingsViewController.self), compatibleWith: nil) }
 
-    public static func setupViewController(bluetoothProvider: BluetoothProvider, colorPalette: LoopUIColorPalette) -> SetupUIResult<UIViewController & CGMManagerCreateNotifying & CGMManagerOnboardNotifying & CompletionNotifying, CGMManagerUI> {
+    public static func setupViewController(bluetoothProvider: BluetoothProvider, displayGlucoseUnitObservable: DisplayGlucoseUnitObservable, colorPalette: LoopUIColorPalette) -> SetupUIResult<CGMManagerViewController, CGMManagerUI> {
         return .createdAndOnboarded(MockCGMManager())
     }
 
-    public func settingsViewController(for displayGlucoseUnitObservable: DisplayGlucoseUnitObservable, bluetoothProvider: BluetoothProvider, colorPalette: LoopUIColorPalette) -> (UIViewController & CGMManagerOnboardNotifying & CompletionNotifying) {
+    public func settingsViewController(bluetoothProvider: BluetoothProvider, displayGlucoseUnitObservable: DisplayGlucoseUnitObservable, colorPalette: LoopUIColorPalette) -> CGMManagerViewController {
         let settings = MockCGMManagerSettingsViewController(cgmManager: self, displayGlucoseUnitObservable: displayGlucoseUnitObservable)
         let nav = CGMManagerSettingsNavigationViewController(rootViewController: settings)
         return nav

--- a/MockKitUI/MockPumpManager+UI.swift
+++ b/MockKitUI/MockPumpManager+UI.swift
@@ -20,11 +20,18 @@ extension MockPumpManager: PumpManagerUI {
     
     public var smallImage: UIImage? { return UIImage(named: "Pump Simulator", in: Bundle(for: MockPumpManagerSettingsViewController.self), compatibleWith: nil) }
     
-    public static func setupViewController(initialSettings settings: PumpManagerSetupSettings, bluetoothProvider: BluetoothProvider, colorPalette: LoopUIColorPalette) -> SetupUIResult<UIViewController & PumpManagerCreateNotifying & PumpManagerOnboardNotifying & CompletionNotifying, PumpManagerUI> {
-        return .createdAndOnboarded(MockPumpManager())
+    public static func setupViewController(initialSettings settings: PumpManagerSetupSettings, bluetoothProvider: BluetoothProvider, colorPalette: LoopUIColorPalette) -> SetupUIResult<PumpManagerViewController, PumpManagerUI> {
+        let mockPumpManager = MockPumpManager()
+        if let maxBasalRateUnitsPerHour = settings.maxBasalRateUnitsPerHour {
+            mockPumpManager.setMaximumTempBasalRate(maxBasalRateUnitsPerHour)
+        }
+        if let basalSchedule = settings.basalSchedule {
+            mockPumpManager.syncBasalRateSchedule(items: basalSchedule.items, completion: { _ in })
+        }
+        return .createdAndOnboarded(mockPumpManager)
     }
 
-    public func settingsViewController(bluetoothProvider: BluetoothProvider, colorPalette: LoopUIColorPalette) -> (UIViewController & PumpManagerOnboardNotifying & CompletionNotifying) {
+    public func settingsViewController(bluetoothProvider: BluetoothProvider, colorPalette: LoopUIColorPalette) -> PumpManagerViewController {
         let settings = MockPumpManagerSettingsViewController(pumpManager: self)
         let nav = PumpManagerSettingsNavigationViewController(rootViewController: settings)
         return nav

--- a/MockKitUI/MockService+UI.swift
+++ b/MockKitUI/MockService+UI.swift
@@ -17,12 +17,12 @@ extension MockService: ServiceUI {
         return UIImage(systemName: "icloud.and.arrow.up")
     }
     
-    public static func setupViewController(colorPalette: LoopUIColorPalette) -> SetupUIResult<UIViewController & ServiceCreateNotifying & ServiceOnboardNotifying & CompletionNotifying, ServiceUI> {
-        return .userInteractionRequired(ServiceViewController(rootViewController: MockServiceTableViewController(service: MockService(), for: .create)))
+    public static func setupViewController(colorPalette: LoopUIColorPalette) -> SetupUIResult<ServiceViewController, ServiceUI> {
+        return .userInteractionRequired(ServiceNavigationController(rootViewController: MockServiceTableViewController(service: MockService(), for: .create)))
     }
 
-    public func settingsViewController(colorPalette: LoopUIColorPalette) -> (UIViewController & ServiceOnboardNotifying & CompletionNotifying) {
-      return ServiceViewController(rootViewController: MockServiceTableViewController(service: self, for: .update))
+    public func settingsViewController(colorPalette: LoopUIColorPalette) -> ServiceViewController {
+      return ServiceNavigationController(rootViewController: MockServiceTableViewController(service: self, for: .update))
     }
     
     public func supportMenuItem(supportInfoProvider: SupportInfoProvider, urlHandler: @escaping (URL) -> Void) -> AnyView? {

--- a/MockKitUI/View Controllers/MockPumpManagerSetupViewController.swift
+++ b/MockKitUI/View Controllers/MockPumpManagerSetupViewController.swift
@@ -12,7 +12,7 @@ import LoopKitUI
 import MockKit
 
 
-final class MockPumpManagerSetupViewController: UINavigationController, PumpManagerCreateNotifying, PumpManagerOnboardNotifying, CompletionNotifying {
+final class MockPumpManagerSetupViewController: UINavigationController, PumpManagerOnboarding, CompletionNotifying {
 
     static func instantiateFromStoryboard() -> MockPumpManagerSetupViewController {
         return UIStoryboard(name: "MockPumpManager", bundle: Bundle(for: MockPumpManagerSetupViewController.self)).instantiateInitialViewController() as! MockPumpManagerSetupViewController
@@ -26,9 +26,7 @@ final class MockPumpManagerSetupViewController: UINavigationController, PumpMana
 
     let pumpManager = MockPumpManager()
 
-    public weak var pumpManagerCreateDelegate: PumpManagerCreateDelegate?
-
-    public weak var pumpManagerOnboardDelegate: PumpManagerOnboardDelegate?
+    public weak var pumpManagerOnboardingDelegate: PumpManagerOnboardingDelegate?
 
     public weak var completionDelegate: CompletionDelegate?
 
@@ -47,12 +45,12 @@ final class MockPumpManagerSetupViewController: UINavigationController, PumpMana
     }
 
     func completeSetup() {
-        pumpManagerCreateDelegate?.pumpManagerCreateNotifying(didCreatePumpManager: pumpManager)
+        pumpManagerOnboardingDelegate?.pumpManagerOnboarding(didCreatePumpManager: pumpManager)
 
         let settings = PumpManagerSetupSettings(maxBasalRateUnitsPerHour: maxBasalRateUnitsPerHour,
-                                           maxBolusUnits: maxBolusUnits,
-                                           basalSchedule: basalSchedule)
-        pumpManagerOnboardDelegate?.pumpManagerOnboardNotifying(didOnboardPumpManager: pumpManager, withFinalSettings: settings)
+                                                maxBolusUnits: maxBolusUnits,
+                                                basalSchedule: basalSchedule)
+        pumpManagerOnboardingDelegate?.pumpManagerOnboarding(didOnboardPumpManager: pumpManager, withFinalSettings: settings)
         
         completionDelegate?.completionNotifyingDidComplete(self)
     }

--- a/MockKitUI/View Controllers/MockServiceTableViewController.swift
+++ b/MockKitUI/View Controllers/MockServiceTableViewController.swift
@@ -56,8 +56,8 @@ final class MockServiceTableViewController: UITableViewController {
         switch operation {
         case .create:
             service.completeCreate()
-            if let serviceViewController = navigationController as? ServiceViewController {
-                serviceViewController.notifyServiceCreatedAndOnboarded(service)
+            if let serviceNavigationController = navigationController as? ServiceNavigationController {
+                serviceNavigationController.notifyServiceCreatedAndOnboarded(service)
             }
         case .update:
             service.completeUpdate()
@@ -76,8 +76,8 @@ final class MockServiceTableViewController: UITableViewController {
     }
 
     private func notifyComplete() {
-        if let serviceViewController = navigationController as? ServiceViewController {
-            serviceViewController.notifyComplete()
+        if let serviceNavigationController = navigationController as? ServiceNavigationController {
+            serviceNavigationController.notifyComplete()
         }
     }
 


### PR DESCRIPTION
- https://tidepool.atlassian.net/browse/LOOP-3375
- Rename ServiceViewController to ServiceNavigationController to avoid naming collision
- Simplify CGMManager, PumpManager, and Service create and onboard delegates and notification
- Enhance Onboarding to support created, but not yet onboarded, states
- Rename Onboarding.allowSkipOnboarding to Onboarding.allowDebugFeatures to be more generalized
- Add DisplayGlucoseUnitObservable to CGMManager settingsViewController
- Update mocks to latest protocols
- Update MockPumpManager to utilize initial pump settings