### PR TITLE
[LOOP-3170] added delay to dispatch

### DIFF
--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -489,7 +489,8 @@ struct SectionWithTapToEdit<Header, Content, NavigationDestination>: View where 
 
     private func onFinish() {
         // Dispatching here fixes an issue on iOS 14.2 where schedule editors do not dismiss. It does not fix iOS 14.0 and 14.1
-        DispatchQueue.main.async {
+        // Added a delay, since recently a similar issue was encountered in a plugin where a delay was also needed. Still uncertain why.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             self.isActive = false
         }
     }


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-3170

Added a delay, since recently a similar issue was encountered in the Dexcom plugin where a delay was also needed. Still uncertain why.