### PR TITLE
Fix typo in calling super method for viewWillDisappear

### DIFF
--- a/LoopKitUI/View Controllers/DismissibleHostingController.swift
+++ b/LoopKitUI/View Controllers/DismissibleHostingController.swift
@@ -72,7 +72,7 @@ public class DismissibleHostingController: UIHostingController<AnyView> {
     }
 
     public override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+        super.viewWillDisappear(animated)
         onDisappear()
     }
 }


### PR DESCRIPTION
Typo was causing issues with views jumping down as they were obscured by a new view being pushed onto a nav stack.