### PR TITLE
LOOP-3661: Use ForEach form that supports modifiable content

### DIFF
--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -215,7 +215,7 @@ extension TherapySettingsView {
             if let items = self.viewModel.glucoseTargetRangeSchedule(for: glucoseUnit)?.items
             {
                 SectionDivider()
-                ForEach(items.indices) { index in
+                ForEach(items.indices, id: \.self) { index in
                     if index > 0 {
                         SettingsDivider()
                     }
@@ -266,7 +266,7 @@ extension TherapySettingsView {
         card(for: .basalRate) {
             if let items = viewModel.therapySettings.basalRateSchedule?.items, let supportedBasalRates = viewModel.pumpSupportedIncrements?()?.basalRates {
                 SectionDivider()
-                ForEach(items.indices) { index in
+                ForEach(items.indices, id: \.self) { index in
                     if index > 0 {
                         SettingsDivider()
                     }
@@ -355,7 +355,7 @@ extension TherapySettingsView {
         card(for: .carbRatio) {
             if let items = viewModel.therapySettings.carbRatioSchedule?.items {
                 SectionDivider()
-                ForEach(items.indices) { index in
+                ForEach(items.indices, id: \.self) { index in
                     if index > 0 {
                         SettingsDivider()
                     }
@@ -372,7 +372,7 @@ extension TherapySettingsView {
         card(for: .insulinSensitivity) {
             if let items = viewModel.insulinSensitivitySchedule(for: glucoseUnit)?.items {
                 SectionDivider()
-                ForEach(items.indices) { index in
+                ForEach(items.indices, id: \.self) { index in
                     if index > 0 {
                         SettingsDivider()
                     }


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-3661

(Side note: this was the simplest change, not needing to make `RepeatingScheduleValue<>` conform to `Identifiable`.
Also: I took a quick look through all other uses of `ForEach` in the code, they all either did this or was working on non-modifiable arrays.)
(Side side note: This is all giving me deja vu...I could've sworn I had this problem when I first worked on this screen... hmm...looks like this _may_ have been introduced by https://github.com/tidepool-org/LoopKit/pull/364)

See https://developer.apple.com/documentation/swiftui/foreach and https://stackoverflow.com/questions/59060673/swiftui-foreach-index-out-of-range-error-when-removing-row/62796050#62796050