### PR TITLE
onboarding therapy settings information screen now handle both

### DIFF
--- a/LoopKitUI/Extensions/QuantityFormatter+Guardrails.swift
+++ b/LoopKitUI/Extensions/QuantityFormatter+Guardrails.swift
@@ -23,4 +23,26 @@ extension HKQuantity {
                mgdLFormatter.string(from: self, for: .milligramsPerDeciliter)!,
                mmolLFormatter.string(from: self, for: .millimolesPerLiter)!)
     }
+
+    public func stringForGlucoseUnit(_ glucoseUnit: HKUnit) -> String {
+        if glucoseUnit == HKUnit.milligramsPerDeciliter {
+            return mgdLFormatter.string(from: self, for: .milligramsPerDeciliter)!
+        } else {
+            return mmolLFormatter.string(from: self, for: .millimolesPerLiter)!
+        }
+    }
+}
+
+extension ClosedRange where Bound == HKQuantity {
+    public func stringForGlucoseUnit(_ glucoseUnit: HKUnit) -> String {
+        let formatter: QuantityFormatter
+        if glucoseUnit == HKUnit.milligramsPerDeciliter {
+            formatter = mgdLFormatter
+        } else {
+            formatter = mmolLFormatter
+        }
+        return String(format: "%1$@-%2$@",
+                      formatter.string(from: self.lowerBound, for: glucoseUnit, includeUnit: false)!,
+                      formatter.string(from: self.upperBound, for: glucoseUnit, includeUnit: true)!)
+    }
 }

--- a/LoopKitUI/Views/Information Screens/CorrectionRangeInformationView.swift
+++ b/LoopKitUI/Views/Information Screens/CorrectionRangeInformationView.swift
@@ -7,14 +7,20 @@
 //
 
 import SwiftUI
+import HealthKit
 import LoopKit
 
 public struct CorrectionRangeInformationView: View {
     var onExit: (() -> Void)?
     var mode: SettingsPresentationMode
-    
+
+    @EnvironmentObject private var displayGlucoseUnitObserverable: DisplayGlucoseUnitObservable
     @Environment(\.presentationMode) var presentationMode
     @Environment(\.appName) var appName
+
+    private var displayGlucoseUnit: HKUnit {
+        displayGlucoseUnitObserverable.displayGlucoseUnit
+    }
 
     public init(onExit: (() -> Void)? = nil, mode: SettingsPresentationMode = .acceptanceFlow) {
         self.onExit = onExit
@@ -32,8 +38,10 @@ public struct CorrectionRangeInformationView: View {
     }
     
     private var text: some View {
-        VStack(alignment: .leading, spacing: 25) {
-            Text(LocalizedString("If you've used a CGM before, you're likely familiar with target range as a wide range of values you'd like for your glucose notification alerts, such as 70-180 mg/dL or 90-200 mg/dL.", comment: "Information about target range"))
+        let glucoseRangeLower: ClosedRange<HKQuantity> = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 70)...HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 180)
+        let glucoseRangeUpper: ClosedRange<HKQuantity> = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 90)...HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 200)
+        return VStack(alignment: .leading, spacing: 25) {
+            Text(String(format: LocalizedString("If you've used a CGM before, you're likely familiar with target range as a wide range of values you'd like for your glucose notification alerts, such as %1$@ or %2$@.", comment: "Information about target range (1: target range lower range (70-180 mg/dL), 2: target upper range (90-200 mg/dL))"), glucoseRangeLower.stringForGlucoseUnit(displayGlucoseUnit), glucoseRangeUpper.stringForGlucoseUnit(displayGlucoseUnit)))
             Text(LocalizedString("A Correction Range is different. This will be a narrower range.", comment: "Information about differences between target range and correction range"))
             .bold()
             Text(String(format: LocalizedString("For this range, choose the specific glucose value (or range of values) that you want %1$@ to aim for in adjusting your basal insulin.", comment: "Information about correction range format (1: app name)"), appName))
@@ -47,12 +55,14 @@ struct CorrectionRangeInformationView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             CorrectionRangeInformationView()
+                .environmentObject(DisplayGlucoseUnitObservable(displayGlucoseUnit: .milligramsPerDeciliter))
         }
         .colorScheme(.light)
         .previewDevice(PreviewDevice(rawValue: "iPhone SE 2"))
         .previewDisplayName("SE light")
         NavigationView {
             CorrectionRangeInformationView()
+                .environmentObject(DisplayGlucoseUnitObservable(displayGlucoseUnit: .millimolesPerLiter))
         }
         .preferredColorScheme(.dark)
         .colorScheme(.dark)

--- a/LoopKitUI/Views/Information Screens/CorrectionRangeOverrideInformationView.swift
+++ b/LoopKitUI/Views/Information Screens/CorrectionRangeOverrideInformationView.swift
@@ -68,18 +68,21 @@ struct CorrectionRangeOverrideInformationView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             CorrectionRangeOverrideInformationView(preset: .preMeal)
+                .environmentObject(DisplayGlucoseUnitObservable(displayGlucoseUnit: .milligramsPerDeciliter))
         }
         .colorScheme(.light)
         .previewDevice(PreviewDevice(rawValue: "iPhone SE 2"))
         .previewDisplayName("Pre-Meal SE light")
         NavigationView {
             CorrectionRangeOverrideInformationView(preset: .workout)
+                .environmentObject(DisplayGlucoseUnitObservable(displayGlucoseUnit: .milligramsPerDeciliter))
         }
         .colorScheme(.light)
         .previewDevice(PreviewDevice(rawValue: "iPhone SE 2"))
         .previewDisplayName("Workout SE light")
         NavigationView {
             CorrectionRangeOverrideInformationView(preset: .preMeal)
+                .environmentObject(DisplayGlucoseUnitObservable(displayGlucoseUnit: .millimolesPerLiter))
         }
         .preferredColorScheme(.dark)
         .colorScheme(.dark)
@@ -87,6 +90,7 @@ struct CorrectionRangeOverrideInformationView_Previews: PreviewProvider {
         .previewDisplayName("Pre-Meal 11 Pro dark")
         NavigationView {
             CorrectionRangeOverrideInformationView(preset: .workout)
+                .environmentObject(DisplayGlucoseUnitObservable(displayGlucoseUnit: .millimolesPerLiter))
         }
         .preferredColorScheme(.dark)
         .colorScheme(.dark)

--- a/LoopKitUI/Views/Information Screens/SuspendThresholdInformationView.swift
+++ b/LoopKitUI/Views/Information Screens/SuspendThresholdInformationView.swift
@@ -13,7 +13,6 @@ import LoopKit
 public struct SuspendThresholdInformationView: View {
     var onExit: (() -> Void)?
     var mode: SettingsPresentationMode
-    var preferredUnit: HKUnit = HKUnit.milligramsPerDeciliter
     
     @Environment(\.presentationMode) var presentationMode
     @Environment(\.appName) var appName
@@ -28,7 +27,6 @@ public struct SuspendThresholdInformationView: View {
     
     public var body: some View {
         GlucoseTherapySettingInformationView(therapySetting: .suspendThreshold,
-                                             preferredUnit: preferredUnit,
                                              onExit: onExit,
                                              mode: mode,
                                              appName: appName)
@@ -39,12 +37,14 @@ struct SuspendThresholdInformationView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             SuspendThresholdInformationView()
+                .environmentObject(DisplayGlucoseUnitObservable(displayGlucoseUnit: .milligramsPerDeciliter))
         }
         .colorScheme(.light)
         .previewDevice(PreviewDevice(rawValue: "iPhone SE 2"))
         .previewDisplayName("SE light")
         NavigationView {
             SuspendThresholdInformationView()
+                .environmentObject(DisplayGlucoseUnitObservable(displayGlucoseUnit: .millimolesPerLiter))
         }
         .preferredColorScheme(.dark)
         .colorScheme(.dark)


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-3014

Was looking for tickets to work on and decided to pick away at this one a bit. The glucose units will always be `mg/dL` until the allow healthkit form is moved to earlier on in the onboarding workflow.