### PR TITLE
[LOOP-3837] Do not persist UUID if write to HealthKit fails in GlucoseStore

### DIFF
--- a/LoopKit/GlucoseKit/GlucoseStore.swift
+++ b/LoopKit/GlucoseKit/GlucoseStore.swift
@@ -97,8 +97,8 @@ public final class GlucoseStore: HealthKitSampleStore {
 
     public var healthKitStorageDelay: TimeInterval = 0
     
-    // If HealthKit sharing is denied, a `nil` here will prevent later storage there
-    var healthKitStorageDelayIfAuthorized: TimeInterval? { sharingDenied ? nil : healthKitStorageDelay }
+    // If HealthKit sharing is not authorized, `nil` will prevent later storage
+    var healthKitStorageDelayIfAuthorized: TimeInterval? { sharingAuthorized ? healthKitStorageDelay : nil }
     
     static let healthKitQueryAnchorMetadataKey = "com.loopkit.GlucoseStore.hkQueryAnchor"
 
@@ -196,7 +196,7 @@ public final class GlucoseStore: HealthKitSampleStore {
                 }
             }
 
-            if error != nil {
+            guard error == nil else {
                 completion(false)
                 return
             }
@@ -348,12 +348,10 @@ extension GlucoseStore {
                     }
 
                     error = self.cacheStore.save()
-                    if error != nil {
+                    guard error == nil else {
                         return
                     }
 
-                    // Note: because we cannot guarantee that we are allowed to store samples in HealthKit, we
-                    // don't update the UUID in StoredGlucoseSample here anymore.
                     storedSamples = objects.map { StoredGlucoseSample(managedObject: $0) }
                 } catch let coreDataError {
                     error = coreDataError
@@ -372,25 +370,26 @@ extension GlucoseStore {
     
     private func saveSamplesToHealthKit() {
         dispatchPrecondition(condition: .onQueue(queue))
-        var error: Error? = nil
+        var error: Error?
         
         cacheStore.managedObjectContext.performAndWait {
-            let request: NSFetchRequest<CachedGlucoseObject> = CachedGlucoseObject.fetchRequest()
-            request.predicate = NSPredicate(format: "healthKitEligibleDate <= %@", Date() as NSDate)
             do {
-                let stored = try self.cacheStore.managedObjectContext.fetch(request)
-                guard !stored.isEmpty else {
+                let request: NSFetchRequest<CachedGlucoseObject> = CachedGlucoseObject.fetchRequest()
+                request.predicate = NSPredicate(format: "healthKitEligibleDate <= %@", Date() as NSDate)
+                request.sortDescriptors = [NSSortDescriptor(key: "modificationCounter", ascending: true)]   // Maintains modificationCounter order
+
+                let objects = try self.cacheStore.managedObjectContext.fetch(request)
+                guard !objects.isEmpty else {
                     return
                 }
                 
-                if stored.contains(where: { $0.uuid != nil }) {
+                if objects.contains(where: { $0.uuid != nil }) {
                     self.log.error("Found CachedGlucoseObjects with non-nil uuid. Should never happen, but HealthKit should be able to resolve it.")
-                    // Note the UUIDs will be overwritten below...HealthKit should resolve this by "replacing" these items since the syncIdentifiers match
+                    // Note: UUIDs will be overwritten below, but since the syncIdentifiers will match then HealthKit can resolve correctly via replacement
                 }
                     
-                let quantitySamples = stored.map { $0.quantitySample }
+                let quantitySamples = objects.map { $0.quantitySample }
                 
-                // Save objects to HealthKit, log any errors, but do not fail
                 let dispatchGroup = DispatchGroup()
                 dispatchGroup.enter()
                 self.healthStore.save(quantitySamples) { (_, healthKitError) in
@@ -398,26 +397,30 @@ extension GlucoseStore {
                     dispatchGroup.leave()
                 }
                 dispatchGroup.wait()
-                
-                let zipped = zip(quantitySamples, stored).map { ($0, $1) }
-                // Update Core Data with the changes, log any errors, but do not fail
-                zipped.forEach { quantitySample, object in
+
+                guard error == nil else {
+                    return
+                }
+
+                for (object, quantitySample) in zip(objects, quantitySamples) {
                     object.uuid = quantitySample.uuid
                     object.healthKitEligibleDate = nil
+                    object.updateModificationCounter()  // Maintains modificationCounter order
                 }
-                if let e = self.cacheStore.save() {
-                    self.log.error("Error updating CachedGlucoseObjects after saving HealthKit objects: %@", String(describing: error))
-                    stored.forEach { $0.uuid = nil }
-                    throw e
+
+                error = self.cacheStore.save()
+                guard error == nil else {
+                    return
                 }
                 
-                self.log.default("Stored %d eligible glucose samples to HealthKit", stored.count)
-            } catch let e {
-                error = e
+                self.log.default("Stored %d eligible glucose samples to HealthKit", objects.count)
+            } catch let coreDataError {
+                error = coreDataError
             }
         }
+
         if let error = error {
-            self.log.error("Error saving HealthKit objects: %@", String(describing: error))
+            self.log.error("Error saving samples to HealthKit: %{public}@", String(describing: error))
         }
     }
 

--- a/LoopKit/GlucoseKit/GlucoseStore.swift
+++ b/LoopKit/GlucoseKit/GlucoseStore.swift
@@ -398,6 +398,7 @@ extension GlucoseStore {
                 }
                 dispatchGroup.wait()
 
+                // If there is an error writing to HealthKit, then do not persist uuids and retry later
                 guard error == nil else {
                     return
                 }

--- a/LoopKit/HealthKitSampleStore.swift
+++ b/LoopKit/HealthKitSampleStore.swift
@@ -392,6 +392,11 @@ extension HealthKitSampleStore {
 // MARK: - HKHealthStore helpers
 extension HealthKitSampleStore {
     
+    /// True if the user has explicitly authorized access to any required share types
+    public var sharingAuthorized: Bool {
+        return healthStore.authorizationStatus(for: sampleType) == .sharingAuthorized
+    }
+
     /// True if the user has explicitly denied access to any required share types
     public var sharingDenied: Bool {
         return healthStore.authorizationStatus(for: sampleType) == .sharingDenied

--- a/LoopKitHostedTests/CoreDataMigrationTests.swift
+++ b/LoopKitHostedTests/CoreDataMigrationTests.swift
@@ -45,7 +45,7 @@ class CoreDataV1MigrationTests: XCTestCase {
             }
             e.fulfill()
         }
-        wait(for: [e], timeout: 3.0)
+        wait(for: [e], timeout: 10.0)
         if let error = error { throw error }        
         var entries: [CachedCarbObject]!
         let e0 = expectation(description: "\(#function): fetch")

--- a/LoopKitHostedTests/GlucoseStoreTests.swift
+++ b/LoopKitHostedTests/GlucoseStoreTests.swift
@@ -52,6 +52,7 @@ class GlucoseStoreTests: PersistenceControllerTestCase, GlucoseStoreDelegate {
         semaphore.wait()
 
         healthStore = HKHealthStoreMock()
+        healthStore.authorizationStatus = .sharingAuthorized
         glucoseStore = GlucoseStore(healthStore: healthStore,
                                     cacheStore: cacheStore,
                                     cacheLength: .hours(1),
@@ -191,10 +192,13 @@ class GlucoseStoreTests: PersistenceControllerTestCase, GlucoseStoreDelegate {
             case .success(let samples):
                 XCTAssertEqual(samples.count, 3)
                 XCTAssertNotNil(samples[0].uuid)
+                XCTAssertNil(samples[0].healthKitEligibleDate)
                 assertEqualSamples(samples[0], self.sample1)
                 XCTAssertNotNil(samples[1].uuid)
+                XCTAssertNil(samples[1].healthKitEligibleDate)
                 assertEqualSamples(samples[1], self.sample3)
                 XCTAssertNotNil(samples[2].uuid)
+                XCTAssertNil(samples[2].healthKitEligibleDate)
                 assertEqualSamples(samples[2], self.sample2)
             }
             getGlucoseSamples1Completion.fulfill()
@@ -209,6 +213,7 @@ class GlucoseStoreTests: PersistenceControllerTestCase, GlucoseStoreDelegate {
             case .success(let samples):
                 XCTAssertEqual(samples.count, 1)
                 XCTAssertNotNil(samples[0].uuid)
+                XCTAssertNil(samples[0].healthKitEligibleDate)
                 assertEqualSamples(samples[0], self.sample3)
             }
             getGlucoseSamples2Completion.fulfill()
@@ -239,8 +244,6 @@ class GlucoseStoreTests: PersistenceControllerTestCase, GlucoseStoreDelegate {
 
     func testGetGlucoseSamplesDelayedHealthKitStorage() {
         glucoseStore.healthKitStorageDelay = .minutes(5)
-        // Note error should not cause failure
-        healthStore.saveError = Error.arbitrary
         var hkobjects = [HKObject]()
         healthStore.setSaveHandler { o, _, _ in hkobjects = o }
         let addGlucoseSamplesCompletion = expectation(description: "addGlucoseSamples")
@@ -264,10 +267,13 @@ class GlucoseStoreTests: PersistenceControllerTestCase, GlucoseStoreDelegate {
                 XCTAssertEqual(samples.count, 3)
                 // HealthKit storage is deferred, so the second 2 UUIDs are nil
                 XCTAssertNotNil(samples[0].uuid)
+                XCTAssertNil(samples[0].healthKitEligibleDate)
                 assertEqualSamples(samples[0], self.sample1)
                 XCTAssertNil(samples[1].uuid)
+                XCTAssertNotNil(samples[1].healthKitEligibleDate)
                 assertEqualSamples(samples[1], self.sample3)
                 XCTAssertNil(samples[2].uuid)
+                XCTAssertNotNil(samples[2].healthKitEligibleDate)
                 assertEqualSamples(samples[2], self.sample2)
             }
             getGlucoseSamples1Completion.fulfill()
@@ -277,10 +283,48 @@ class GlucoseStoreTests: PersistenceControllerTestCase, GlucoseStoreDelegate {
         XCTAssertEqual([sample1.quantitySample.description], hkobjects.map { $0.description })
     }
     
-    func testGetGlucoseSamplesDeniedHealthKitStorage() {
-        glucoseStore.healthKitStorageDelay = .minutes(5)
-        // Note error should not cause failure
+    func testGetGlucoseSamplesErrorHealthKitStorage() {
         healthStore.saveError = Error.arbitrary
+        var hkobjects = [HKObject]()
+        healthStore.setSaveHandler { o, _, _ in hkobjects = o }
+        let addGlucoseSamplesCompletion = expectation(description: "addGlucoseSamples")
+        glucoseStore.addGlucoseSamples([sample1, sample2, sample3]) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("Unexpected failure: \(error)")
+            case .success(let samples):
+                XCTAssertEqual(samples.count, 3)
+            }
+            addGlucoseSamplesCompletion.fulfill()
+        }
+        waitForExpectations(timeout: 10)
+
+        let getGlucoseSamples1Completion = expectation(description: "getGlucoseSamples1")
+        glucoseStore.getGlucoseSamples() { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("Unexpected failure: \(error)")
+            case .success(let samples):
+                XCTAssertEqual(samples.count, 3)
+                // HealthKit storage is deferred, so the second 2 UUIDs are nil
+                XCTAssertNil(samples[0].uuid)
+                XCTAssertNotNil(samples[0].healthKitEligibleDate)
+                assertEqualSamples(samples[0], self.sample1)
+                XCTAssertNil(samples[1].uuid)
+                XCTAssertNotNil(samples[1].healthKitEligibleDate)
+                assertEqualSamples(samples[1], self.sample3)
+                XCTAssertNil(samples[2].uuid)
+                XCTAssertNotNil(samples[2].healthKitEligibleDate)
+                assertEqualSamples(samples[2], self.sample2)
+            }
+            getGlucoseSamples1Completion.fulfill()
+        }
+        waitForExpectations(timeout: 10)
+
+        XCTAssertEqual(3, hkobjects.count)
+    }
+
+    func testGetGlucoseSamplesDeniedHealthKitStorage() {
         healthStore.authorizationStatus = .sharingDenied
         var hkobjects = [HKObject]()
         healthStore.setSaveHandler { o, _, _ in hkobjects = o }
@@ -305,10 +349,13 @@ class GlucoseStoreTests: PersistenceControllerTestCase, GlucoseStoreDelegate {
                 XCTAssertEqual(samples.count, 3)
                 // HealthKit storage is denied, so all UUIDs are nil
                 XCTAssertNil(samples[0].uuid)
+                XCTAssertNil(samples[0].healthKitEligibleDate)
                 assertEqualSamples(samples[0], self.sample1)
                 XCTAssertNil(samples[1].uuid)
+                XCTAssertNil(samples[1].healthKitEligibleDate)
                 assertEqualSamples(samples[1], self.sample3)
                 XCTAssertNil(samples[2].uuid)
+                XCTAssertNil(samples[2].healthKitEligibleDate)
                 assertEqualSamples(samples[2], self.sample2)
             }
             getGlucoseSamples1Completion.fulfill()
@@ -377,10 +424,13 @@ class GlucoseStoreTests: PersistenceControllerTestCase, GlucoseStoreDelegate {
             case .success(let samples):
                 XCTAssertEqual(samples.count, 3)
                 XCTAssertNotNil(samples[0].uuid)
+                XCTAssertNil(samples[0].healthKitEligibleDate)
                 assertEqualSamples(samples[0], self.sample1)
                 XCTAssertNotNil(samples[1].uuid)
+                XCTAssertNil(samples[1].healthKitEligibleDate)
                 assertEqualSamples(samples[1], self.sample3)
                 XCTAssertNil(samples[2].uuid)
+                XCTAssertNil(samples[2].healthKitEligibleDate)
                 assertEqualSamples(samples[2], self.sample2)
             }
             getGlucoseSamples1Completion.fulfill()
@@ -436,10 +486,13 @@ class GlucoseStoreTests: PersistenceControllerTestCase, GlucoseStoreDelegate {
                 XCTAssertEqual(samples.count, 3)
                 // Note: the HealthKit UUID is no longer updated before being returned as a result of addGlucoseSamples.
                 XCTAssertNil(samples[0].uuid)
+                XCTAssertNotNil(samples[0].healthKitEligibleDate)
                 assertEqualSamples(samples[0], self.sample1)
                 XCTAssertNil(samples[1].uuid)
+                XCTAssertNotNil(samples[1].healthKitEligibleDate)
                 assertEqualSamples(samples[1], self.sample2)
                 XCTAssertNil(samples[2].uuid)
+                XCTAssertNotNil(samples[2].healthKitEligibleDate)
                 assertEqualSamples(samples[2], self.sample3)
             }
             addGlucoseSamples1Completion.fulfill()
@@ -454,10 +507,13 @@ class GlucoseStoreTests: PersistenceControllerTestCase, GlucoseStoreDelegate {
             case .success(let samples):
                 XCTAssertEqual(samples.count, 3)
                 XCTAssertNotNil(samples[0].uuid)
+                XCTAssertNil(samples[0].healthKitEligibleDate)
                 assertEqualSamples(samples[0], self.sample1)
                 XCTAssertNotNil(samples[1].uuid)
+                XCTAssertNil(samples[1].healthKitEligibleDate)
                 assertEqualSamples(samples[1], self.sample3)
                 XCTAssertNotNil(samples[2].uuid)
+                XCTAssertNil(samples[2].healthKitEligibleDate)
                 assertEqualSamples(samples[2], self.sample2)
             }
             getGlucoseSamples1Completion.fulfill()
@@ -484,10 +540,13 @@ class GlucoseStoreTests: PersistenceControllerTestCase, GlucoseStoreDelegate {
             case .success(let samples):
                 XCTAssertEqual(samples.count, 3)
                 XCTAssertNotNil(samples[0].uuid)
+                XCTAssertNil(samples[0].healthKitEligibleDate)
                 assertEqualSamples(samples[0], self.sample1)
                 XCTAssertNotNil(samples[1].uuid)
+                XCTAssertNil(samples[1].healthKitEligibleDate)
                 assertEqualSamples(samples[1], self.sample3)
                 XCTAssertNotNil(samples[2].uuid)
+                XCTAssertNil(samples[2].healthKitEligibleDate)
                 assertEqualSamples(samples[2], self.sample2)
             }
             getGlucoseSamples2Completion.fulfill()

--- a/LoopKitTests/GlucoseStoreTests.swift
+++ b/LoopKitTests/GlucoseStoreTests.swift
@@ -396,9 +396,9 @@ class GlucoseStoreCriticalEventLogExportTests: PersistenceControllerTestCase {
                                          progress: progress))
         XCTAssertEqual(outputStream.string, """
             [
-            {"healthKitEligibleDate":"2100-01-02T03:08:00.000Z","isDisplayOnly":false,"modificationCounter":1,"provenanceIdentifier":"com.apple.dt.xctest.tool","startDate":"2100-01-02T03:08:00.000Z","syncIdentifier":"18CF3948-0B3D-4B12-8BFE-14986B0E6784","syncVersion":1,"unitString":"mg/dL","value":111,"wasUserEntered":false},
-            {"healthKitEligibleDate":"2100-01-02T03:04:00.000Z","isDisplayOnly":false,"modificationCounter":3,"provenanceIdentifier":"com.apple.dt.xctest.tool","startDate":"2100-01-02T03:04:00.000Z","syncIdentifier":"2B03D96C-6F5D-4140-99CD-80C3E64D6010","syncVersion":3,"trend":3,"unitString":"mg/dL","value":113,"wasUserEntered":false},
-            {"healthKitEligibleDate":"2100-01-02T03:06:00.000Z","isDisplayOnly":false,"modificationCounter":4,"provenanceIdentifier":"com.apple.dt.xctest.tool","startDate":"2100-01-02T03:06:00.000Z","syncIdentifier":"FF1C4F01-3558-4FB2-957E-FA1522C4735E","syncVersion":4,"trend":3,"unitString":"mg/dL","value":114,"wasUserEntered":false}
+            {"isDisplayOnly":false,"modificationCounter":1,"provenanceIdentifier":"com.apple.dt.xctest.tool","startDate":"2100-01-02T03:08:00.000Z","syncIdentifier":"18CF3948-0B3D-4B12-8BFE-14986B0E6784","syncVersion":1,"unitString":"mg/dL","value":111,"wasUserEntered":false},
+            {"isDisplayOnly":false,"modificationCounter":3,"provenanceIdentifier":"com.apple.dt.xctest.tool","startDate":"2100-01-02T03:04:00.000Z","syncIdentifier":"2B03D96C-6F5D-4140-99CD-80C3E64D6010","syncVersion":3,"trend":3,"unitString":"mg/dL","value":113,"wasUserEntered":false},
+            {"isDisplayOnly":false,"modificationCounter":4,"provenanceIdentifier":"com.apple.dt.xctest.tool","startDate":"2100-01-02T03:06:00.000Z","syncIdentifier":"FF1C4F01-3558-4FB2-957E-FA1522C4735E","syncVersion":4,"trend":3,"unitString":"mg/dL","value":114,"wasUserEntered":false}
             ]
             """
         )

--- a/MockKit/MockGlucoseProvider.swift
+++ b/MockKit/MockGlucoseProvider.swift
@@ -59,7 +59,7 @@ struct MockGlucoseProvider {
                     return []
                 }
             }
-            let result: CGMReadingResult = allSamples.isEmpty ? .noData : .newData(allSamples)
+            let result: CGMReadingResult = allSamples.isEmpty ? .noData : .newData(allSamples.reversed())
             completion(result)
         }
     }
@@ -107,7 +107,7 @@ extension MockGlucoseProvider {
         return MockGlucoseProvider { date, completion in
             let timeOffset = date.timeIntervalSince1970 - referenceDate.timeIntervalSince1970
             func sine(_ t: TimeInterval) -> Double {
-                return baseGlucoseValue + amplitudeValue * sin(2 * .pi / period * t)
+                return Double(baseGlucoseValue + amplitudeValue * sin(2 * .pi / period * t)).rounded()
             }
             let glucoseValue = sine(timeOffset)
             func trend() -> GlucoseTrend? {


### PR DESCRIPTION
- https://tidepool.atlassian.net/browse/LOOP-3837
- Fix GlucoseStore.saveSamplesToHealthKit to NOT persist UUID for failed writes to HealthKit
- Fix GlucoseStore.saveSamplesToHealthKit to maintain modificationCounter order
- Update GlucoseStore.saveSamplesToHealthKit for consistency
- Only allow HealthKit storage of glucose samples if authorized
- Add HealthKitSampleStore.sharingAuthorized
- Update MockGlucoseProvider to provide samples in ascending startTime order
- Update MockGlucoseProvider to round mg/dL values to whole number
- Update tests