### PR TITLE
[COASTAL-102] Set max bolus limit

### DIFF
--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -703,6 +703,7 @@
 		A9E675F5227140DD00E25293 /* HealthKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9E675F4227140DD00E25293 /* HealthKit.framework */; };
 		A9FD046F24E310D00040F203 /* HKObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9FD046E24E310D00040F203 /* HKObject.swift */; };
 		A9FD047024E310DD0040F203 /* HKObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9FD046E24E310D00040F203 /* HKObject.swift */; };
+		B40C43912707408400F5D86C /* DeliveryLimits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC64C7D24BF6EBC004A63A1 /* DeliveryLimits.swift */; };
 		B40D07CA251BD89D00C1C6D7 /* DateAndDurationSteppableTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B40D07C8251BD89D00C1C6D7 /* DateAndDurationSteppableTableViewCell.xib */; };
 		B40D07CB251BD89D00C1C6D7 /* DateAndDurationSteppableTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40D07C9251BD89D00C1C6D7 /* DateAndDurationSteppableTableViewCell.swift */; };
 		B4102D3224ABB068005D460B /* DeviceLifecycleProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4102D3124ABB068005D460B /* DeviceLifecycleProgress.swift */; };
@@ -4185,6 +4186,7 @@
 				A9498D7F23386C3300DAA9B9 /* GlucoseThreshold.swift in Sources */,
 				A9E675D522713F4700E25293 /* WalshInsulinModel.swift in Sources */,
 				A9E675D622713F4700E25293 /* GlucoseEffectVelocity.swift in Sources */,
+				B40C43912707408400F5D86C /* DeliveryLimits.swift in Sources */,
 				A9E675D722713F4700E25293 /* PumpEvent+CoreDataClass.swift in Sources */,
 				A9E675D822713F4700E25293 /* UpdateSource.swift in Sources */,
 				A9E675D922713F4700E25293 /* Reservoir+CoreDataProperties.swift in Sources */,

--- a/LoopKit/DeviceManager/PumpManager.swift
+++ b/LoopKit/DeviceManager/PumpManager.swift
@@ -182,6 +182,16 @@ public protocol PumpManager: DeviceManager {
     ///   - completion: A closure called after the command is complete
     ///   - result: A BasalRateSchedule or an error describing why the command failed
     func syncBasalRateSchedule(items scheduleItems: [RepeatingScheduleValue<Double>], completion: @escaping (_ result: Result<BasalRateSchedule, Error>) -> Void)
+
+    typealias SyncDeliveryLimits = (_ deliveryLimits: DeliveryLimits, _ completion: @escaping (_ result: Result<DeliveryLimits, Error>) -> Void) -> Void
+
+    /// Sync the delivery limits for basal rate and bolus
+    ///
+    /// - Parameters:
+    ///   - deliveryLimits: The delivery limits
+    ///   - completion: A closure called after the command is complete
+    ///   - result: The delivery limits set or an error describing why the command failed
+    func syncDeliveryLimits(limits deliveryLimits: DeliveryLimits, completion: @escaping (_ result: Result<DeliveryLimits, Error>) -> Void)
 }
 
 

--- a/LoopKit/DeviceManager/PumpManager.swift
+++ b/LoopKit/DeviceManager/PumpManager.swift
@@ -170,8 +170,6 @@ public protocol PumpManager: DeviceManager {
     ///   - error: An error describing why the command failed
     func resumeDelivery(completion: @escaping (_ error: Error?) -> Void)
     
-    typealias SyncSchedule = (_ items: [RepeatingScheduleValue<Double>], _ completion: @escaping (Result<BasalRateSchedule, Error>) -> Void) -> Void
-
     /// Sync the schedule of basal rates to the pump, annotating the result with the proper time zone.
     ///
     /// - Precondition:
@@ -183,9 +181,7 @@ public protocol PumpManager: DeviceManager {
     ///   - result: A BasalRateSchedule or an error describing why the command failed
     func syncBasalRateSchedule(items scheduleItems: [RepeatingScheduleValue<Double>], completion: @escaping (_ result: Result<BasalRateSchedule, Error>) -> Void)
 
-    typealias SyncDeliveryLimits = (_ deliveryLimits: DeliveryLimits, _ completion: @escaping (_ result: Result<DeliveryLimits, Error>) -> Void) -> Void
-
-    /// Sync the delivery limits for basal rate and bolus
+    /// Sync the delivery limits for basal rate and bolus. If the pump does not support setting max bolus or max basal rates, the completion should be called with success including the provided delivery limits.
     ///
     /// - Parameters:
     ///   - deliveryLimits: The delivery limits

--- a/LoopKitUI/PumpManagerUI.swift
+++ b/LoopKitUI/PumpManagerUI.swift
@@ -44,7 +44,12 @@ public protocol PumpStatusIndicator {
 
 public typealias PumpManagerViewController = (UIViewController & PumpManagerOnboarding & CompletionNotifying)
 
-public protocol PumpManagerUI: DeviceManagerUI, PumpStatusIndicator, PumpManager, DeliveryLimitSettingsTableViewControllerSyncSource, BasalScheduleTableViewControllerSyncSource {
+public typealias SyncSchedule = (_ items: [RepeatingScheduleValue<Double>], _ completion: @escaping (Result<BasalRateSchedule, Error>) -> Void) -> Void
+
+public typealias SyncDeliveryLimits = (_ deliveryLimits: DeliveryLimits, _ completion: @escaping (_ result: Result<DeliveryLimits, Error>) -> Void) -> Void
+
+public protocol PumpManagerUI: DeviceManagerUI, PumpStatusIndicator, PumpManager { //}, DeliveryLimitSettingsTableViewControllerSyncSource, BasalScheduleTableViewControllerSyncSource {
+
     /// Create and onboard a new pump manager.
     ///
     /// - Parameters:

--- a/LoopKitUI/PumpManagerUI.swift
+++ b/LoopKitUI/PumpManagerUI.swift
@@ -44,10 +44,6 @@ public protocol PumpStatusIndicator {
 
 public typealias PumpManagerViewController = (UIViewController & PumpManagerOnboarding & CompletionNotifying)
 
-public typealias SyncSchedule = (_ items: [RepeatingScheduleValue<Double>], _ completion: @escaping (Result<BasalRateSchedule, Error>) -> Void) -> Void
-
-public typealias SyncDeliveryLimits = (_ deliveryLimits: DeliveryLimits, _ completion: @escaping (_ result: Result<DeliveryLimits, Error>) -> Void) -> Void
-
 public protocol PumpManagerUI: DeviceManagerUI, PumpStatusIndicator, PumpManager { //}, DeliveryLimitSettingsTableViewControllerSyncSource, BasalScheduleTableViewControllerSyncSource {
 
     /// Create and onboard a new pump manager.

--- a/LoopKitUI/ViewModels/TherapySettingsViewModel.swift
+++ b/LoopKitUI/ViewModels/TherapySettingsViewModel.swift
@@ -11,6 +11,9 @@ import LoopKit
 import HealthKit
 import SwiftUI
 
+public typealias SyncSchedule = (_ items: [RepeatingScheduleValue<Double>], _ completion: @escaping (Swift.Result<BasalRateSchedule, Error>) -> Void) -> Void
+public typealias SyncDeliveryLimits = (_ deliveryLimits: DeliveryLimits, _ completion: @escaping (_ result: Swift.Result<DeliveryLimits, Error>) -> Void) -> Void
+
 public class TherapySettingsViewModel: ObservableObject {
     public typealias SaveCompletion = (TherapySetting, TherapySettings) -> Void
     

--- a/LoopKitUI/ViewModels/TherapySettingsViewModel.swift
+++ b/LoopKitUI/ViewModels/TherapySettingsViewModel.swift
@@ -20,12 +20,14 @@ public class TherapySettingsViewModel: ObservableObject {
     private let initialTherapySettings: TherapySettings
     let pumpSupportedIncrements: (() -> PumpSupportedIncrements?)?
     let syncPumpSchedule: (() -> PumpManager.SyncSchedule?)?
+    let syncDeliveryLimits: (() -> PumpManager.SyncDeliveryLimits?)?
     let sensitivityOverridesEnabled: Bool
     public var prescription: Prescription?
 
     public init(therapySettings: TherapySettings,
                 pumpSupportedIncrements: (() -> PumpSupportedIncrements?)? = nil,
                 syncPumpSchedule: (() -> PumpManager.SyncSchedule?)? = nil,
+                syncDeliveryLimits: (() -> PumpManager.SyncDeliveryLimits?)? = nil,
                 sensitivityOverridesEnabled: Bool = false,
                 prescription: Prescription? = nil,
                 didSave: SaveCompletion? = nil) {
@@ -33,6 +35,7 @@ public class TherapySettingsViewModel: ObservableObject {
         self.initialTherapySettings = therapySettings
         self.pumpSupportedIncrements = pumpSupportedIncrements
         self.syncPumpSchedule = syncPumpSchedule
+        self.syncDeliveryLimits = syncDeliveryLimits
         self.sensitivityOverridesEnabled = sensitivityOverridesEnabled
         self.prescription = prescription
         self.didSave = didSave

--- a/LoopKitUI/ViewModels/TherapySettingsViewModel.swift
+++ b/LoopKitUI/ViewModels/TherapySettingsViewModel.swift
@@ -19,15 +19,15 @@ public class TherapySettingsViewModel: ObservableObject {
 
     private let initialTherapySettings: TherapySettings
     let pumpSupportedIncrements: (() -> PumpSupportedIncrements?)?
-    let syncPumpSchedule: (() -> PumpManager.SyncSchedule?)?
-    let syncDeliveryLimits: (() -> PumpManager.SyncDeliveryLimits?)?
+    let syncPumpSchedule: (() -> SyncSchedule?)?
+    let syncDeliveryLimits: (() -> SyncDeliveryLimits?)?
     let sensitivityOverridesEnabled: Bool
     public var prescription: Prescription?
 
     public init(therapySettings: TherapySettings,
                 pumpSupportedIncrements: (() -> PumpSupportedIncrements?)? = nil,
-                syncPumpSchedule: (() -> PumpManager.SyncSchedule?)? = nil,
-                syncDeliveryLimits: (() -> PumpManager.SyncDeliveryLimits?)? = nil,
+                syncPumpSchedule: (() -> SyncSchedule?)? = nil,
+                syncDeliveryLimits: (() -> SyncDeliveryLimits?)? = nil,
                 sensitivityOverridesEnabled: Bool = false,
                 prescription: Prescription? = nil,
                 didSave: SaveCompletion? = nil) {

--- a/LoopKitUI/Views/Settings Editors/BasalRateScheduleEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/BasalRateScheduleEditor.swift
@@ -16,7 +16,7 @@ public struct BasalRateScheduleEditor: View {
     var supportedBasalRates: [Double]
     var guardrail: Guardrail<HKQuantity>
     var maximumScheduleEntryCount: Int
-    var syncSchedule: PumpManager.SyncSchedule?
+    var syncSchedule: SyncSchedule?
     var save: (BasalRateSchedule) -> Void
     let mode: SettingsPresentationMode
     @Environment(\.appName) private var appName
@@ -27,7 +27,7 @@ public struct BasalRateScheduleEditor: View {
         supportedBasalRates: [Double],
         maximumBasalRate: Double?,
         maximumScheduleEntryCount: Int,
-        syncSchedule: PumpManager.SyncSchedule?,
+        syncSchedule: SyncSchedule?,
         onSave save: @escaping (BasalRateSchedule) -> Void,
         mode: SettingsPresentationMode = .settings
     ) {

--- a/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
@@ -23,7 +23,7 @@ public struct DeliveryLimitsEditor: View {
     let scheduledBasalRange: ClosedRange<Double>?
     let supportedBolusVolumes: [Double]
     let selectableBolusVolumes: [Double]
-    let syncDeliveryLimits: PumpManager.SyncDeliveryLimits?
+    let syncDeliveryLimits: SyncDeliveryLimits?
     let save: (_ deliveryLimits: DeliveryLimits) -> Void
     let mode: SettingsPresentationMode
     
@@ -46,7 +46,7 @@ public struct DeliveryLimitsEditor: View {
         scheduledBasalRange: ClosedRange<Double>?,
         supportedBolusVolumes: [Double],
         lowestCarbRatio: Double?,
-        syncDeliveryLimits: PumpManager.SyncDeliveryLimits?,
+        syncDeliveryLimits: SyncDeliveryLimits?,
         onSave save: @escaping (_ deliveryLimits: DeliveryLimits) -> Void,
         mode: SettingsPresentationMode = .settings
     ) {

--- a/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/DeliveryLimitsEditor.swift
@@ -12,18 +12,26 @@ import LoopKit
 
 
 public struct DeliveryLimitsEditor: View {
+    fileprivate enum PresentedAlert {
+        case saveConfirmation(AlertContent)
+        case saveError(Error)
+    }
+
     let initialValue: DeliveryLimits
     let supportedBasalRates: [Double]
     let selectableMaxBasalRates: [Double]
     let scheduledBasalRange: ClosedRange<Double>?
     let supportedBolusVolumes: [Double]
     let selectableBolusVolumes: [Double]
+    let syncDeliveryLimits: PumpManager.SyncDeliveryLimits?
     let save: (_ deliveryLimits: DeliveryLimits) -> Void
     let mode: SettingsPresentationMode
     
     @State var value: DeliveryLimits
     @State private var userDidTap: Bool = false
     @State var settingBeingEdited: DeliveryLimits.Setting?
+    @State private var isSyncing = false
+    @State private var presentedAlert: PresentedAlert?
 
     @State var showingConfirmationAlert = false
     @Environment(\.dismissAction) var dismiss
@@ -38,6 +46,7 @@ public struct DeliveryLimitsEditor: View {
         scheduledBasalRange: ClosedRange<Double>?,
         supportedBolusVolumes: [Double],
         lowestCarbRatio: Double?,
+        syncDeliveryLimits: PumpManager.SyncDeliveryLimits?,
         onSave save: @escaping (_ deliveryLimits: DeliveryLimits) -> Void,
         mode: SettingsPresentationMode = .settings
     ) {
@@ -48,6 +57,7 @@ public struct DeliveryLimitsEditor: View {
         self.scheduledBasalRange = scheduledBasalRange
         self.supportedBolusVolumes = supportedBolusVolumes
         self.selectableBolusVolumes = Guardrail.selectableBolusVolumes(supportedBolusVolumes: supportedBolusVolumes)
+        self.syncDeliveryLimits = syncDeliveryLimits
         self.save = save
         self.mode = mode
         self.lowestCarbRatio = lowestCarbRatio
@@ -74,6 +84,7 @@ public struct DeliveryLimitsEditor: View {
             scheduledBasalRange: therapySettingsViewModel.therapySettings.basalRateSchedule?.valueRange(),
             supportedBolusVolumes: therapySettingsViewModel.pumpSupportedIncrements!()!.bolusVolumes,
             lowestCarbRatio: therapySettingsViewModel.therapySettings.carbRatioSchedule?.lowestValue(),
+            syncDeliveryLimits: therapySettingsViewModel.syncDeliveryLimits?(),
             onSave: { [weak therapySettingsViewModel] newLimits in
                 therapySettingsViewModel?.saveDeliveryLimits(limits: newLimits)
                 didSave?()
@@ -86,8 +97,10 @@ public struct DeliveryLimitsEditor: View {
         switch mode {
         case .acceptanceFlow:
             content
+                .disabled(isSyncing)
         case .settings:
             contentWithCancel
+                .disabled(isSyncing)
                 .navigationBarTitle("", displayMode: .inline)
         }
     }
@@ -127,11 +140,11 @@ public struct DeliveryLimitsEditor: View {
                 if self.crossedThresholds.isEmpty {
                     self.startSaving()
                 } else {
-                    self.showingConfirmationAlert = true
+                    self.presentedAlert = .saveConfirmation(confirmationAlertContent)
                 }
             }
         )
-        .alert(isPresented: $showingConfirmationAlert, content: confirmationAlert)
+        .alert(item: $presentedAlert, content: alert(for:))
         .simultaneousGesture(TapGesture().onEnded {
             withAnimation {
                 self.userDidTap = true
@@ -142,6 +155,10 @@ public struct DeliveryLimitsEditor: View {
     var saveButtonState: ConfigurationPageActionButtonState {
         guard value.maximumBasalRate != nil, value.maximumBolus != nil else {
             return .disabled
+        }
+
+        if isSyncing {
+            return .loading
         }
         
         if mode == .acceptanceFlow {
@@ -297,33 +314,86 @@ public struct DeliveryLimitsEditor: View {
         return crossedThresholds
     }
 
-    private func confirmationAlert() -> SwiftUI.Alert {
-        SwiftUI.Alert(
-            title: Text(LocalizedString("Save Delivery Limits?", comment: "Alert title for confirming delivery limits outside the recommended range")),
-            message: Text(TherapySetting.deliveryLimits.guardrailSaveWarningCaption),
-            primaryButton: .cancel(Text(LocalizedString("Go Back", comment: "Text for go back action on confirmation alert"))),
-            secondaryButton: .default(
-                Text(LocalizedString("Continue", comment: "Text for continue action on confirmation alert")),
-                action: startSaving
-            )
-        )
-    }
-
     private func startSaving() {
         guard mode == .settings else {
-            self.continueSaving()
+            self.continueSaving(savingMechanism: .synchronous { deliveryLimits in
+                save(deliveryLimits)
+            })
             return
         }
         authenticate(TherapySetting.deliveryLimits.authenticationChallengeDescription) {
             switch $0 {
-            case .success: self.continueSaving()
+            case .success: self.continueSaving(savingMechanism: .asynchronous { deliveryLimits, completion in
+                self.syncDeliveryLimits?(deliveryLimits) { result in
+                    switch result {
+                    case .success(let deliveryLimits):
+                        DispatchQueue.main.async {
+                            self.save(deliveryLimits)
+                        }
+                        completion(nil)
+                    case .failure(let error):
+                        completion(error)
+                    }
+                }
+            })
             case .failure: break
             }
         }
     }
     
-    private func continueSaving() {
-        self.save(self.value)
+    private func continueSaving(savingMechanism: SavingMechanism<DeliveryLimits>) {
+        switch savingMechanism {
+        case .synchronous(let save):
+            save(value)
+        case .asynchronous(let save):
+            withAnimation {
+                self.isSyncing = true
+            }
+
+            save(value) { error in
+                DispatchQueue.main.async {
+                    if let error = error {
+                        withAnimation {
+                            self.isSyncing = false
+                        }
+                        self.presentedAlert = .saveError(error)
+                    }
+                }
+            }
+        }
+    }
+
+    private func alert(for presentedAlert: PresentedAlert) -> SwiftUI.Alert {
+        switch presentedAlert {
+        case .saveConfirmation(let content):
+            return Alert(
+                title: content.title,
+                message: content.message,
+                primaryButton: .cancel(
+                    content.cancel ??
+                    Text(LocalizedString("Go Back", comment: "Button text to return to editing a schedule after from alert popup when some schedule values are outside the recommended range"))),
+                secondaryButton: .default(
+                    content.ok ??
+                    Text(LocalizedString("Continue", comment: "Button text to confirm saving from alert popup when some schedule values are outside the recommended range")),
+                    action: startSaving
+                )
+            )
+        case .saveError(let error):
+            return Alert(
+                title: Text(LocalizedString("Unable to Save", comment: "Alert title when error occurs while saving a schedule")),
+                message: Text(error.localizedDescription)
+            )
+        }
+    }
+
+    private var confirmationAlertContent: AlertContent {
+        AlertContent(
+            title: Text(LocalizedString("Save Delivery Limits?", comment: "Alert title for confirming delivery limits outside the recommended range")),
+            message: Text(TherapySetting.deliveryLimits.guardrailSaveWarningCaption),
+            cancel: Text(LocalizedString("Go Back", comment: "Text for go back action on confirmation alert")),
+            ok: Text(LocalizedString("Continue", comment: "Text for continue action on confirmation alert")
+            )
+        )
     }
 }
 
@@ -363,6 +433,17 @@ struct DeliveryLimitsGuardrailWarning: View {
                 thresholds: Array(crossedThresholds.values))
         default:
             preconditionFailure("Unreachable: only two delivery limit settings exist")
+        }
+    }
+}
+
+extension DeliveryLimitsEditor.PresentedAlert: Identifiable {
+    var id: Int {
+        switch self {
+        case .saveConfirmation:
+            return 0
+        case .saveError:
+            return 1
         }
     }
 }

--- a/MockKit/MockPumpManager.swift
+++ b/MockKit/MockPumpManager.swift
@@ -587,6 +587,12 @@ public final class MockPumpManager: TestingPumpManager {
             completion(.success(BasalRateSchedule(dailyItems: scheduleItems, timeZone: self.status.timeZone)!))
         }
     }
+
+    public func syncDeliveryLimits(limits deliveryLimits: DeliveryLimits, completion: @escaping (Result<DeliveryLimits, Error>) -> Void) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
+            completion(.success(deliveryLimits))
+        }
+    }
 }
 
 // MARK: - AlertResponder implementation

--- a/MockKitUI/MockPumpManager+UI.swift
+++ b/MockKitUI/MockPumpManager+UI.swift
@@ -58,57 +58,6 @@ extension MockPumpManager: PumpManagerUI {
     
 }
 
-// MARK: - DeliveryLimitSettingsTableViewControllerSyncSource
-extension MockPumpManager {
-    public func syncDeliveryLimitSettings(for viewController: DeliveryLimitSettingsTableViewController, completion: @escaping (DeliveryLimitSettingsResult) -> Void) {
-        guard let maximumBasalRatePerHour = viewController.maximumBasalRatePerHour,
-            let maximumBolus = viewController.maximumBolus else
-        {
-            completion(.failure(MockPumpManagerError.missingSettings))
-            return
-        }
-        completion(.success(maximumBasalRatePerHour: maximumBasalRatePerHour, maximumBolus: maximumBolus))
-    }
-
-    public func syncButtonTitle(for viewController: DeliveryLimitSettingsTableViewController) -> String {
-        return "Save to simulator"
-    }
-
-    public func syncButtonDetailText(for viewController: DeliveryLimitSettingsTableViewController) -> String? {
-        return nil
-    }
-
-    public func deliveryLimitSettingsTableViewControllerIsReadOnly(_ viewController: DeliveryLimitSettingsTableViewController) -> Bool {
-        return false
-    }
-}
-
-// MARK: - BasalScheduleTableViewControllerSyncSource
-extension MockPumpManager {
-    public func syncScheduleValues(for viewController: BasalScheduleTableViewController, completion: @escaping (SyncBasalScheduleResult<Double>) -> Void) {
-        syncBasalRateSchedule(items: viewController.scheduleItems) { result in
-            switch result {
-            case .success(let schedule):
-                completion(.success(scheduleItems: schedule.items, timeZone: schedule.timeZone))
-            case .failure(let error):
-                completion(.failure(error))
-            }
-        }
-    }
-
-    public func syncButtonTitle(for viewController: BasalScheduleTableViewController) -> String {
-        return "Save to simulator"
-    }
-
-    public func syncButtonDetailText(for viewController: BasalScheduleTableViewController) -> String? {
-        return nil
-    }
-
-    public func basalScheduleTableViewControllerIsReadOnly(_ viewController: BasalScheduleTableViewController) -> Bool {
-        return false
-    }
-}
-
 public enum MockPumpStatusBadge: DeviceStatusBadge {
     case timeSyncNeeded
     


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/COASTAL-102

There is a need to pass the delivery limits down to the pump when the user updates them in therapy settings.

The UX of the `DeliveryLimitsEditor` mirrors that of the `BasalRateScheduleEditor`.