### PR TITLE
LOOP-3870: Fix/workaround iOS 15 issue with SwiftUI Pickers

### DIFF
--- a/LoopKitUI/Views/FractionalQuantityPicker.swift
+++ b/LoopKitUI/Views/FractionalQuantityPicker.swift
@@ -134,6 +134,7 @@ public struct FractionalQuantityPicker: View {
             .padding(.leading, usageContext == .independent ? unitLabelWidth + spacing : 0)
             .padding(.trailing, spacing + separatorWidth + spacing)
             .clipped()
+            .compositingGroup()
 
             QuantityPicker(
                 value: $fraction.withUnit(unit),
@@ -147,6 +148,7 @@ public struct FractionalQuantityPicker: View {
             .frame(width: availableWidth / 3.5)
             .padding(.trailing, spacing + unitLabelWidth)
             .clipped()
+            .compositingGroup()
         }
     }
 

--- a/LoopKitUI/Views/GlucoseRangePicker.swift
+++ b/LoopKitUI/Views/GlucoseRangePicker.swift
@@ -111,6 +111,7 @@ public struct GlucoseRangePicker: View {
             .padding(.leading, usageContext == .independent ? unitLabelWidth : 0)
             .padding(.trailing, spacing + separatorWidth + spacing)
             .clipped()
+            .compositingGroup()
             .accessibility(identifier: "min_glucose_picker")
 
             GlucoseValuePicker(
@@ -124,6 +125,7 @@ public struct GlucoseRangePicker: View {
             .frame(width: availableWidth / 3.5)
             .padding(.trailing, unitLabelWidth)
             .clipped()
+            .compositingGroup()
             .accessibility(identifier: "max_glucose_picker")
         }
     }

--- a/LoopKitUI/Views/QuantityScheduleEditor.swift
+++ b/LoopKitUI/Views/QuantityScheduleEditor.swift
@@ -69,6 +69,7 @@ struct QuantityScheduleEditor<ActionAreaContent: View>: View {
                     // Ensure overlaid unit label is not clipped
                     .padding(.trailing, unitLabelWidth + unitLabelSpacing)
                     .clipped()
+                    .compositingGroup()
                 } else {
                     FractionalQuantityPicker(
                         value: item.value.animation(),

--- a/LoopKitUI/Views/ScheduleItemPicker.swift
+++ b/LoopKitUI/Views/ScheduleItemPicker.swift
@@ -38,6 +38,7 @@ struct ScheduleItemPicker<Value, ValuePicker: View>: View {
                     )
                     .frame(width: geometry.size.width / 3)
                     .clipped()
+                    .compositingGroup()
                     .accessibility(identifier: "time_picker")
 
                     self.valuePicker(/* availableWidth: */ 2/3 * geometry.size.width)

--- a/LoopKitUI/Views/Settings Editors/SuspendThresholdEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/SuspendThresholdEditor.swift
@@ -111,6 +111,7 @@ public struct SuspendThresholdEditor: View {
                             // Prevent the picker from expanding the card's width on small devices
                             .frame(maxWidth: UIScreen.main.bounds.width - 48)
                             .clipped()
+                            .compositingGroup()
                         }
                     )
                 }


### PR DESCRIPTION
Followed the advice from https://stackoverflow.com/questions/62462747/swiftui-picker-view-touch-scroll-able-area-is-still-out-of-frame-even-after-us/62603630#62603630 as pointed to by
https://developer.apple.com/forums/thread/687986?answerId=685001022#685001022

(Note: I've tested this on iOS 15.0.2 and iOS 14.8 on actual devices, and it seems to work fine.  However, I did notice that on iOS 15 _simulators_, while it looks to fix the tap target problem, the simulators seem to have some odd rendering issues (Xcode 13, Simulator version 13).)

Also, while I can basically understand why this fixes/works around the problem, I have yet to find a root cause reason for why this code is needed on iOS 15 but not 14. 🤷‍♂️ 

https://tidepool.atlassian.net/browse/LOOP-3870