### PR TITLE
Use Publisher for observing `didBecomeActiveNotification`

### DIFF
--- a/LoopKitUI/View Controllers/ChartsTableViewController.swift
+++ b/LoopKitUI/View Controllers/ChartsTableViewController.swift
@@ -37,15 +37,14 @@ open class ChartsTableViewController: UITableViewController, UIGestureRecognizer
         gestureRecognizer.addTarget(self, action: #selector(handlePan(_:)))
         charts.gestureRecognizer = gestureRecognizer
         
-        NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: nil) { [weak self] _ in
-            guard let self = self else { return }
-            
-            if self.visible {
-                DispatchQueue.main.async {
-                    self.reloadData()
+        NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification, object: nil)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                if self?.visible == true {
+                    self?.reloadData()
                 }
             }
-        }
+            .store(in: &cancellables)
     }
 
     open override func didReceiveMemoryWarning() {


### PR DESCRIPTION
I was observing somewhat odd behavior when implementing [LOOP-3871](https://tidepool.atlassian.net/browse/LOOP-3871) and kept seeing [LOOP-3931](https://tidepool.atlassian.net/browse/LOOP-3931) (see https://github.com/tidepool-org/Loop/pull/473).  This ensures that the observer created is properly destroyed.