### PR TITLE
LOOP-3932: Fix memory leak when deleting CGM manager

### DIFF
--- a/LoopKit/WeakSynchronizedSet.swift
+++ b/LoopKit/WeakSynchronizedSet.swift
@@ -62,9 +62,7 @@ public class WeakSynchronizedSet<Element> {
     /// - Returns: A reference to the instance for easy chaining
     @discardableResult public func cleanupDeallocatedElements() -> Self {
         elements.mutate { (storage) in
-            for (id, element) in storage where element.element == nil {
-                storage.removeValue(forKey: id)
-            }
+            storage = storage.compactMapValues { $0.element == nil ? nil : $0 }
         }
         return self
     }


### PR DESCRIPTION
Xcode's memory graph revealed a memory leak in `WeakSynchronizedSet`.  Calling `removeValue(forKey:)` on a Swift dictionary apparently doesn't (immediately?) free up the memory associated with the entry in the set, but `compactMapValues` will. (Note the `Value` pointed to is apparently freed, as far as I can tell, but the memory allocated by the Swift Dictionary to point at it isn't.  Since this creates a new Dictionary the memory is freed.)