### PR TITLE
[LOOP-3913] Fix Critical Event Log Export failure

### DIFF
--- a/LoopKit/DeviceManager/PumpManagerStatus.swift
+++ b/LoopKit/DeviceManager/PumpManagerStatus.swift
@@ -98,7 +98,7 @@ extension PumpManagerStatus: Codable {
         self.pumpBatteryChargeRemaining = try container.decodeIfPresent(Double.self, forKey: .pumpBatteryChargeRemaining)
         self.basalDeliveryState = try container.decodeIfPresent(BasalDeliveryState.self, forKey: .basalDeliveryState)
         self.bolusState = try container.decode(BolusState.self, forKey: .bolusState)
-        self.insulinType = try container.decode(InsulinType.self, forKey: .insulinType)
+        self.insulinType = try container.decodeIfPresent(InsulinType.self, forKey: .insulinType)
         self.deliveryIsUncertain = try container.decode(Bool.self, forKey: .deliveryIsUncertain)
     }
 
@@ -109,7 +109,7 @@ extension PumpManagerStatus: Codable {
         try container.encodeIfPresent(pumpBatteryChargeRemaining, forKey: .pumpBatteryChargeRemaining)
         try container.encodeIfPresent(basalDeliveryState, forKey: .basalDeliveryState)
         try container.encode(bolusState, forKey: .bolusState)
-        try container.encode(insulinType, forKey: .insulinType)
+        try container.encodeIfPresent(insulinType, forKey: .insulinType)
         try container.encode(deliveryIsUncertain, forKey: .deliveryIsUncertain)
     }
 

--- a/LoopKitTests/PumpManagerStatusTests.swift
+++ b/LoopKitTests/PumpManagerStatusTests.swift
@@ -47,8 +47,39 @@ class PumpManagerStatusCodableTests: XCTestCase {
     "softwareVersion" : "2.3.4",
     "udiDeviceIdentifier" : "U0D1I2"
   },
-  "insulinType\" : 0,
+  "insulinType" : 0,
   "pumpBatteryChargeRemaining" : 0.75,
+  "timeZone" : {
+    "identifier" : "America/Los_Angeles"
+  }
+}
+"""
+        )
+    }
+
+    func testCodableRequiredOnly() throws {
+        let device = HKDevice(name: nil,
+                              manufacturer: nil,
+                              model: nil,
+                              hardwareVersion: nil,
+                              firmwareVersion: nil,
+                              softwareVersion: nil,
+                              localIdentifier: nil,
+                              udiDeviceIdentifier: "U0D1I2")
+        try assertPumpManagerStatusCodable(PumpManagerStatus(timeZone: TimeZone(identifier: "America/Los_Angeles")!,
+                                                             device: device,
+                                                             pumpBatteryChargeRemaining: nil,
+                                                             basalDeliveryState: nil,
+                                                             bolusState: .noBolus,
+                                                             insulinType: nil,
+                                                             deliveryIsUncertain: true),
+                                           encodesJSON: """
+{
+  "bolusState" : "noBolus",
+  "deliveryIsUncertain" : true,
+  "device" : {
+    "udiDeviceIdentifier" : "U0D1I2"
+  },
   "timeZone" : {
     "identifier" : "America/Los_Angeles"
   }


### PR DESCRIPTION
- https://tidepool.atlassian.net/browse/LOOP-3913
- Only encode/decode PumpManagerStatus.insulinType if present