### PR TITLE
LOOP-3973: Introducing `interruptionLevel` as a replacement for `Alert.isCritical`

### DIFF
--- a/LoopKit/Alert.swift
+++ b/LoopKit/Alert.swift
@@ -33,20 +33,29 @@ public struct Alert: Equatable {
         /// Delay triggering the alert by `repeatInterval`, and repeat at that interval until cancelled or unscheduled.
         case repeating(repeatInterval: TimeInterval)
     }
+    /// The interruption level of the alert.  Note that these follow the same definitiions as defined by https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel
+    /// Handlers will determine how that is manifested.
+    public enum InterruptionLevel: String {
+        /// The system presents the notification immediately, lights up the screen, and can play a sound.  These alerts may be deferred if the user chooses.
+        case active
+        /// The system presents the notification immediately, lights up the screen, and can play a sound.  These alerts may not be deferred.
+        case timeSensitive
+        /// The system makes every attempt at alerting the user, including (possibly) ignoring the mute switch, or the user's notification settings.
+        case critical
+    }
     /// Content of the alert, either for foreground or background alerts
     public struct Content: Equatable  {
         public let title: String
         public let body: String
-        /// Should this alert be deemed "critical" for the User?  Handlers will determine how that is manifested.
-        public let isCritical: Bool
+        public let interruptionLevel: InterruptionLevel
         // TODO: when we have more complicated actions.  For now, all we have is "acknowledge".
 //        let actions: [UserAlertAction]
         public let acknowledgeActionButtonLabel: String
-        public init(title: String, body: String, acknowledgeActionButtonLabel: String, isCritical: Bool = false) {
+        public init(title: String, body: String, acknowledgeActionButtonLabel: String, interruptionLevel: InterruptionLevel = .active) {
             self.title = title
             self.body = body
             self.acknowledgeActionButtonLabel = acknowledgeActionButtonLabel
-            self.isCritical = isCritical
+            self.interruptionLevel = interruptionLevel
         }
     }
     public struct Identifier: Equatable, Hashable {
@@ -117,6 +126,7 @@ public protocol AlertSoundVendor {
 extension Alert: Codable { }
 extension Alert.Content: Codable { }
 extension Alert.Identifier: Codable { }
+extension Alert.InterruptionLevel: Codable { }
 // These Codable implementations of enums with associated values cannot be synthesized (yet) in Swift.
 // The code below follows a pattern described by https://medium.com/@hllmandel/codable-enum-with-associated-values-swift-4-e7d75d6f4370
 extension Alert.Trigger: Codable {

--- a/LoopKit/Alert.swift
+++ b/LoopKit/Alert.swift
@@ -47,15 +47,13 @@ public struct Alert: Equatable {
     public struct Content: Equatable  {
         public let title: String
         public let body: String
-        public let interruptionLevel: InterruptionLevel
         // TODO: when we have more complicated actions.  For now, all we have is "acknowledge".
 //        let actions: [UserAlertAction]
         public let acknowledgeActionButtonLabel: String
-        public init(title: String, body: String, acknowledgeActionButtonLabel: String, interruptionLevel: InterruptionLevel = .active) {
+        public init(title: String, body: String, acknowledgeActionButtonLabel: String) {
             self.title = title
             self.body = body
             self.acknowledgeActionButtonLabel = acknowledgeActionButtonLabel
-            self.interruptionLevel = interruptionLevel
         }
     }
     public struct Identifier: Equatable, Hashable {
@@ -82,6 +80,8 @@ public struct Alert: Equatable {
     public let backgroundContent: Content?
     /// Trigger for the alert.
     public let trigger: Trigger
+    /// Interruption level for the alert.  See `InterruptionLevel` above.
+    public let interruptionLevel: InterruptionLevel
 
     /// An alert's "identifier" is a tuple of `managerIdentifier` and `alertIdentifier`.  It's purpose is to uniquely identify an alert so we can
     /// find which device issued it, and send acknowledgment of that alert to the proper device manager.
@@ -95,11 +95,13 @@ public struct Alert: Equatable {
     }
     public let sound: Sound?
     
-    public init(identifier: Identifier, foregroundContent: Content?, backgroundContent: Content?, trigger: Trigger, sound: Sound? = nil) {
+    public init(identifier: Identifier, foregroundContent: Content?, backgroundContent: Content?, trigger: Trigger,
+                interruptionLevel: InterruptionLevel = .timeSensitive, sound: Sound? = nil) {
         self.identifier = identifier
         self.foregroundContent = foregroundContent
         self.backgroundContent = backgroundContent
         self.trigger = trigger
+        self.interruptionLevel = interruptionLevel
         self.sound = sound
     }
 }

--- a/LoopKit/Alert.swift
+++ b/LoopKit/Alert.swift
@@ -33,7 +33,7 @@ public struct Alert: Equatable {
         /// Delay triggering the alert by `repeatInterval`, and repeat at that interval until cancelled or unscheduled.
         case repeating(repeatInterval: TimeInterval)
     }
-    /// The interruption level of the alert.  Note that these follow the same definitiions as defined by https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel
+    /// The interruption level of the alert.  Note that these follow the same definitions as defined by https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel
     /// Handlers will determine how that is manifested.
     public enum InterruptionLevel: String {
         /// The system presents the notification immediately, lights up the screen, and can play a sound.  These alerts may be deferred if the user chooses.

--- a/LoopKitTests/AlertTests.swift
+++ b/LoopKitTests/AlertTests.swift
@@ -11,8 +11,8 @@ import XCTest
 
 class AlertTests: XCTestCase {
     let identifier = Alert.Identifier(managerIdentifier: "managerIdentifier1", alertIdentifier: "alertIdentifier1")
-    let foregroundContent = Alert.Content(title: "title1", body: "body1", acknowledgeActionButtonLabel: "acknowledgeActionButtonLabel1", isCritical: false)
-    let backgroundContent = Alert.Content(title: "title2", body: "body2", acknowledgeActionButtonLabel: "acknowledgeActionButtonLabel2", isCritical: false)
+    let foregroundContent = Alert.Content(title: "title1", body: "body1", acknowledgeActionButtonLabel: "acknowledgeActionButtonLabel1", interruptionLevel: .timeSensitive)
+    let backgroundContent = Alert.Content(title: "title2", body: "body2", acknowledgeActionButtonLabel: "acknowledgeActionButtonLabel2", interruptionLevel: .active)
 
     func testIdentifierValue() {
         XCTAssertEqual("managerIdentifier1.alertIdentifier1", identifier.value)
@@ -21,76 +21,76 @@ class AlertTests: XCTestCase {
     func testAlertImmediateEncodable() {
         let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
         let str = try? alert.encodeToString()
-    XCTAssertEqual("{\"trigger\":\"immediate\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}", str)
+    XCTAssertEqual("{\"trigger\":\"immediate\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"title\":\"title1\",\"interruptionLevel\":\"timeSensitive\"},\"backgroundContent\":{\"body\":\"body2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"title\":\"title2\",\"interruptionLevel\":\"active\"}}", str)
     }
     
     func testAlertDelayedEncodable() {
         let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 1.0))
         let str = try? alert.encodeToString()
-    XCTAssertEqual("{\"trigger\":{\"delayed\":{\"delayInterval\":1}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}", str)
+    XCTAssertEqual("{\"trigger\":{\"delayed\":{\"delayInterval\":1}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"title\":\"title1\",\"interruptionLevel\":\"timeSensitive\"},\"backgroundContent\":{\"body\":\"body2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"title\":\"title2\",\"interruptionLevel\":\"active\"}}", str)
     }
     
     func testAlertRepeatingEncodable() {
         let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .repeating(repeatInterval: 2.0))
         let str = try? alert.encodeToString()
-    XCTAssertEqual("{\"trigger\":{\"repeating\":{\"repeatInterval\":2}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}", str)
+    XCTAssertEqual("{\"trigger\":{\"repeating\":{\"repeatInterval\":2}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"title\":\"title1\",\"interruptionLevel\":\"timeSensitive\"},\"backgroundContent\":{\"body\":\"body2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"title\":\"title2\",\"interruptionLevel\":\"active\"}}", str)
     }
     
     func testAlertSilentSoundEncodable() {
         let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .silence)
         let str = try? alert.encodeToString()
-        XCTAssertEqual("{\"trigger\":\"immediate\",\"sound\":\"silence\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}", str)
+        XCTAssertEqual("{\"trigger\":\"immediate\",\"sound\":\"silence\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"title\":\"title1\",\"interruptionLevel\":\"timeSensitive\"},\"backgroundContent\":{\"body\":\"body2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"title\":\"title2\",\"interruptionLevel\":\"active\"}}", str)
     }
 
     func testAlertVibrateSoundEncodable() {
         let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .vibrate)
         let str = try? alert.encodeToString()
-        XCTAssertEqual("{\"trigger\":\"immediate\",\"sound\":\"vibrate\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}", str)
+        XCTAssertEqual("{\"trigger\":\"immediate\",\"sound\":\"vibrate\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"title\":\"title1\",\"interruptionLevel\":\"timeSensitive\"},\"backgroundContent\":{\"body\":\"body2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"title\":\"title2\",\"interruptionLevel\":\"active\"}}", str)
     }
 
     func testAlertSoundEncodable() {
         let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .sound(name: "soundName"))
         let str = try? alert.encodeToString()
-        XCTAssertEqual("{\"trigger\":\"immediate\",\"sound\":{\"sound\":{\"name\":\"soundName\"}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}", str)
+        XCTAssertEqual("{\"trigger\":\"immediate\",\"sound\":{\"sound\":{\"name\":\"soundName\"}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"title\":\"title1\",\"interruptionLevel\":\"timeSensitive\"},\"backgroundContent\":{\"body\":\"body2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"title\":\"title2\",\"interruptionLevel\":\"active\"}}", str)
     }
 
     func testAlertImmediateDecodable() {
-        let str = "{\"trigger\":\"immediate\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
+        let str = "{\"trigger\":\"immediate\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"interruptionLevel\":\"timeSensitive\",\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"interruptionLevel\":\"active\",\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
         let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
         let alert = try? Alert.decode(from: str)
         XCTAssertEqual(expected, alert)
     }
 
     func testAlertDelayedDecodable() {
-        let str = "{\"trigger\":{\"delayed\":{\"delayInterval\":1}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
+        let str = "{\"trigger\":{\"delayed\":{\"delayInterval\":1}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"interruptionLevel\":\"timeSensitive\",\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"interruptionLevel\":\"active\",\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
         let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 1.0))
         let alert = try? Alert.decode(from: str)
         XCTAssertEqual(expected, alert)
     }
 
     func testAlertRepeatingDecodable() {
-        let str = "{\"trigger\":{\"repeating\":{\"repeatInterval\":2}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
+        let str = "{\"trigger\":{\"repeating\":{\"repeatInterval\":2}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"interruptionLevel\":\"timeSensitive\",\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"interruptionLevel\":\"active\",\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
         let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .repeating(repeatInterval: 2.0))
         let alert = try? Alert.decode(from: str)
         XCTAssertEqual(expected, alert)
     }
 
     func testAlertSilentSoundDecodable() {
-        let str = "{\"trigger\":\"immediate\",\"sound\":\"silence\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
+        let str = "{\"trigger\":\"immediate\",\"sound\":\"silence\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"interruptionLevel\":\"timeSensitive\",\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"interruptionLevel\":\"active\",\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
         let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .silence)
         let alert = try? Alert.decode(from: str)
         XCTAssertEqual(expected, alert)
     }
 
     func testAlertVibrateSoundDecodable() {
-        let str = "{\"trigger\":\"immediate\",\"sound\":\"vibrate\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
+        let str = "{\"trigger\":\"immediate\",\"sound\":\"vibrate\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"interruptionLevel\":\"timeSensitive\",\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"interruptionLevel\":\"active\",\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
         let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .vibrate)
         let alert = try? Alert.decode(from: str)
         XCTAssertEqual(expected, alert)
     }
 
     func testAlertSoundDecodable() {
-        let str = "{\"trigger\":\"immediate\",\"sound\":{\"sound\":{\"name\":\"soundName\"}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"isCritical\":false,\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"isCritical\":false,\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
+        let str = "{\"trigger\":\"immediate\",\"sound\":{\"sound\":{\"name\":\"soundName\"}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"interruptionLevel\":\"timeSensitive\",\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"interruptionLevel\":\"active\",\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
         let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .sound(name: "soundName"))
         let alert = try? Alert.decode(from: str)
         XCTAssertEqual(expected, alert)

--- a/LoopKitTests/AlertTests.swift
+++ b/LoopKitTests/AlertTests.swift
@@ -11,8 +11,8 @@ import XCTest
 
 class AlertTests: XCTestCase {
     let identifier = Alert.Identifier(managerIdentifier: "managerIdentifier1", alertIdentifier: "alertIdentifier1")
-    let foregroundContent = Alert.Content(title: "title1", body: "body1", acknowledgeActionButtonLabel: "acknowledgeActionButtonLabel1", interruptionLevel: .timeSensitive)
-    let backgroundContent = Alert.Content(title: "title2", body: "body2", acknowledgeActionButtonLabel: "acknowledgeActionButtonLabel2", interruptionLevel: .active)
+    let foregroundContent = Alert.Content(title: "title1", body: "body1", acknowledgeActionButtonLabel: "acknowledgeActionButtonLabel1")
+    let backgroundContent = Alert.Content(title: "title2", body: "body2", acknowledgeActionButtonLabel: "acknowledgeActionButtonLabel2")
 
     func testIdentifierValue() {
         XCTAssertEqual("managerIdentifier1.alertIdentifier1", identifier.value)
@@ -21,76 +21,76 @@ class AlertTests: XCTestCase {
     func testAlertImmediateEncodable() {
         let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
         let str = try? alert.encodeToString()
-    XCTAssertEqual("{\"trigger\":\"immediate\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"title\":\"title1\",\"interruptionLevel\":\"timeSensitive\"},\"backgroundContent\":{\"body\":\"body2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"title\":\"title2\",\"interruptionLevel\":\"active\"}}", str)
+    XCTAssertEqual("{\"trigger\":\"immediate\",\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"body\":\"body1\"},\"backgroundContent\":{\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"body\":\"body2\"}}", str)
     }
     
     func testAlertDelayedEncodable() {
         let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 1.0))
         let str = try? alert.encodeToString()
-    XCTAssertEqual("{\"trigger\":{\"delayed\":{\"delayInterval\":1}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"title\":\"title1\",\"interruptionLevel\":\"timeSensitive\"},\"backgroundContent\":{\"body\":\"body2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"title\":\"title2\",\"interruptionLevel\":\"active\"}}", str)
+    XCTAssertEqual("{\"trigger\":{\"delayed\":{\"delayInterval\":1}},\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"body\":\"body1\"},\"backgroundContent\":{\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"body\":\"body2\"}}", str)
     }
     
     func testAlertRepeatingEncodable() {
         let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .repeating(repeatInterval: 2.0))
         let str = try? alert.encodeToString()
-    XCTAssertEqual("{\"trigger\":{\"repeating\":{\"repeatInterval\":2}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"title\":\"title1\",\"interruptionLevel\":\"timeSensitive\"},\"backgroundContent\":{\"body\":\"body2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"title\":\"title2\",\"interruptionLevel\":\"active\"}}", str)
+    XCTAssertEqual("{\"trigger\":{\"repeating\":{\"repeatInterval\":2}},\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"body\":\"body1\"},\"backgroundContent\":{\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"body\":\"body2\"}}", str)
     }
     
     func testAlertSilentSoundEncodable() {
         let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .silence)
         let str = try? alert.encodeToString()
-        XCTAssertEqual("{\"trigger\":\"immediate\",\"sound\":\"silence\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"title\":\"title1\",\"interruptionLevel\":\"timeSensitive\"},\"backgroundContent\":{\"body\":\"body2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"title\":\"title2\",\"interruptionLevel\":\"active\"}}", str)
+        XCTAssertEqual("{\"trigger\":\"immediate\",\"interruptionLevel\":\"timeSensitive\",\"sound\":\"silence\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"body\":\"body1\"},\"backgroundContent\":{\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"body\":\"body2\"}}", str)
     }
 
     func testAlertVibrateSoundEncodable() {
         let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .vibrate)
         let str = try? alert.encodeToString()
-        XCTAssertEqual("{\"trigger\":\"immediate\",\"sound\":\"vibrate\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"title\":\"title1\",\"interruptionLevel\":\"timeSensitive\"},\"backgroundContent\":{\"body\":\"body2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"title\":\"title2\",\"interruptionLevel\":\"active\"}}", str)
+        XCTAssertEqual("{\"trigger\":\"immediate\",\"interruptionLevel\":\"timeSensitive\",\"sound\":\"vibrate\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"body\":\"body1\"},\"backgroundContent\":{\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"body\":\"body2\"}}", str)
     }
 
     func testAlertSoundEncodable() {
         let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .sound(name: "soundName"))
         let str = try? alert.encodeToString()
-        XCTAssertEqual("{\"trigger\":\"immediate\",\"sound\":{\"sound\":{\"name\":\"soundName\"}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"title\":\"title1\",\"interruptionLevel\":\"timeSensitive\"},\"backgroundContent\":{\"body\":\"body2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"title\":\"title2\",\"interruptionLevel\":\"active\"}}", str)
+        XCTAssertEqual("{\"trigger\":\"immediate\",\"interruptionLevel\":\"timeSensitive\",\"sound\":{\"sound\":{\"name\":\"soundName\"}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"body\":\"body1\"},\"backgroundContent\":{\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"body\":\"body2\"}}", str)
     }
 
     func testAlertImmediateDecodable() {
-        let str = "{\"trigger\":\"immediate\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"interruptionLevel\":\"timeSensitive\",\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"interruptionLevel\":\"active\",\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
+        let str = "{\"trigger\":\"immediate\",\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
         let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
         let alert = try? Alert.decode(from: str)
         XCTAssertEqual(expected, alert)
     }
 
     func testAlertDelayedDecodable() {
-        let str = "{\"trigger\":{\"delayed\":{\"delayInterval\":1}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"interruptionLevel\":\"timeSensitive\",\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"interruptionLevel\":\"active\",\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
+        let str = "{\"trigger\":{\"delayed\":{\"delayInterval\":1}},\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
         let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 1.0))
         let alert = try? Alert.decode(from: str)
         XCTAssertEqual(expected, alert)
     }
 
     func testAlertRepeatingDecodable() {
-        let str = "{\"trigger\":{\"repeating\":{\"repeatInterval\":2}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"interruptionLevel\":\"timeSensitive\",\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"interruptionLevel\":\"active\",\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
+        let str = "{\"trigger\":{\"repeating\":{\"repeatInterval\":2}},\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
         let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .repeating(repeatInterval: 2.0))
         let alert = try? Alert.decode(from: str)
         XCTAssertEqual(expected, alert)
     }
 
     func testAlertSilentSoundDecodable() {
-        let str = "{\"trigger\":\"immediate\",\"sound\":\"silence\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"interruptionLevel\":\"timeSensitive\",\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"interruptionLevel\":\"active\",\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
+        let str = "{\"trigger\":\"immediate\",\"sound\":\"silence\",\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
         let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .silence)
         let alert = try? Alert.decode(from: str)
         XCTAssertEqual(expected, alert)
     }
 
     func testAlertVibrateSoundDecodable() {
-        let str = "{\"trigger\":\"immediate\",\"sound\":\"vibrate\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"interruptionLevel\":\"timeSensitive\",\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"interruptionLevel\":\"active\",\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
+        let str = "{\"trigger\":\"immediate\",\"sound\":\"vibrate\",\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
         let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .vibrate)
         let alert = try? Alert.decode(from: str)
         XCTAssertEqual(expected, alert)
     }
 
     func testAlertSoundDecodable() {
-        let str = "{\"trigger\":\"immediate\",\"sound\":{\"sound\":{\"name\":\"soundName\"}},\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"interruptionLevel\":\"timeSensitive\",\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"interruptionLevel\":\"active\",\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
+        let str = "{\"trigger\":\"immediate\",\"sound\":{\"sound\":{\"name\":\"soundName\"}},\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
         let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .sound(name: "soundName"))
         let alert = try? Alert.decode(from: str)
         XCTAssertEqual(expected, alert)

--- a/MockKit/MockCGMManager.swift
+++ b/MockKit/MockCGMManager.swift
@@ -319,8 +319,8 @@ public final class MockCGMManager: TestingCGMManager {
                                             foregroundContent: Alert.Content(title: "Alert: FG Title", body: "Alert: Foreground Body", acknowledgeActionButtonLabel: "FG OK"),
                                             backgroundContent: Alert.Content(title: "Alert: BG Title", body: "Alert: Background Body", acknowledgeActionButtonLabel: "BG OK"))
     public static let critical = MockAlert(sound: .sound(name: "critical.caf"), identifier: "critical",
-                                           foregroundContent: Alert.Content(title: "Critical Alert: FG Title", body: "Critical Alert: Foreground Body", acknowledgeActionButtonLabel: "Critical FG OK", isCritical: true),
-                                           backgroundContent: Alert.Content(title: "Critical Alert: BG Title", body: "Critical Alert: Background Body", acknowledgeActionButtonLabel: "Critical BG OK", isCritical: true))
+                                           foregroundContent: Alert.Content(title: "Critical Alert: FG Title", body: "Critical Alert: Foreground Body", acknowledgeActionButtonLabel: "Critical FG OK", interruptionLevel: .critical),
+                                           backgroundContent: Alert.Content(title: "Critical Alert: BG Title", body: "Critical Alert: Background Body", acknowledgeActionButtonLabel: "Critical BG OK", interruptionLevel: .critical))
     public static let buzz = MockAlert(sound: .vibrate, identifier: "buzz",
                                        foregroundContent: Alert.Content(title: "Alert: FG Title", body: "FG bzzzt", acknowledgeActionButtonLabel: "Buzz"),
                                        backgroundContent: Alert.Content(title: "Alert: BG Title", body: "BG bzzzt", acknowledgeActionButtonLabel: "Buzz"))
@@ -675,16 +675,20 @@ extension MockCGMManager {
 
         let alertTitle: String
         let glucoseAlertIdentifier: String
+        let interruptionLevel: Alert.InterruptionLevel
         switch glucose.quantity {
         case ...mockSensorState.urgentLowGlucoseThreshold:
             alertTitle = "Urgent Low Glucose Alert"
             glucoseAlertIdentifier = "glucose.value.low.urgent"
+            interruptionLevel = .critical
         case mockSensorState.urgentLowGlucoseThreshold..<mockSensorState.lowGlucoseThreshold:
             alertTitle = "Low Glucose Alert"
             glucoseAlertIdentifier = "glucose.value.low"
+            interruptionLevel = .timeSensitive
         case mockSensorState.highGlucoseThreshold...:
             alertTitle = "High Glucose Alert"
             glucoseAlertIdentifier = "glucose.value.high"
+            interruptionLevel = .timeSensitive
         default:
             return
         }
@@ -693,7 +697,8 @@ extension MockCGMManager {
                                                alertIdentifier: glucoseAlertIdentifier)
         let alertContent = Alert.Content(title: alertTitle,
                                          body: "The glucose measurement received triggered this alert",
-                                         acknowledgeActionButtonLabel: "Dismiss")
+                                         acknowledgeActionButtonLabel: "Dismiss",
+                                         interruptionLevel: interruptionLevel)
         let alert = Alert(identifier: alertIdentifier,
                           foregroundContent: alertContent,
                           backgroundContent: alertContent,

--- a/MockKit/MockCGMManager.swift
+++ b/MockKit/MockCGMManager.swift
@@ -326,7 +326,8 @@ public final class MockCGMManager: TestingCGMManager {
                                            interruptionLevel: .critical)
     public static let buzz = MockAlert(sound: .vibrate, identifier: "buzz",
                                        foregroundContent: Alert.Content(title: "Alert: FG Title", body: "FG bzzzt", acknowledgeActionButtonLabel: "Buzz"),
-                                       backgroundContent: Alert.Content(title: "Alert: BG Title", body: "BG bzzzt", acknowledgeActionButtonLabel: "Buzz"), interruptionLevel: .active)
+                                       backgroundContent: Alert.Content(title: "Alert: BG Title", body: "BG bzzzt", acknowledgeActionButtonLabel: "Buzz"),
+                                       interruptionLevel: .active)
     public static let signalLoss = MockAlert(sound: .sound(name: "critical.caf"),
                                              identifier: "signalLoss",
                                              foregroundContent: Alert.Content(title: "Signal Loss", body: "CGM simulator signal loss", acknowledgeActionButtonLabel: "Dismiss"),

--- a/MockKit/MockCGMManager.swift
+++ b/MockKit/MockCGMManager.swift
@@ -310,6 +310,7 @@ public final class MockCGMManager: TestingCGMManager {
         public let identifier: Alert.AlertIdentifier
         public let foregroundContent: Alert.Content
         public let backgroundContent: Alert.Content
+        public let interruptionLevel: Alert.InterruptionLevel
     }
     let alerts: [Alert.AlertIdentifier: MockAlert] = [
         submarine.identifier: submarine, buzz.identifier: buzz, critical.identifier: critical, signalLoss.identifier: signalLoss
@@ -317,17 +318,20 @@ public final class MockCGMManager: TestingCGMManager {
     
     public static let submarine = MockAlert(sound: .sound(name: "sub.caf"), identifier: "submarine",
                                             foregroundContent: Alert.Content(title: "Alert: FG Title", body: "Alert: Foreground Body", acknowledgeActionButtonLabel: "FG OK"),
-                                            backgroundContent: Alert.Content(title: "Alert: BG Title", body: "Alert: Background Body", acknowledgeActionButtonLabel: "BG OK"))
+                                            backgroundContent: Alert.Content(title: "Alert: BG Title", body: "Alert: Background Body", acknowledgeActionButtonLabel: "BG OK"),
+                                            interruptionLevel: .timeSensitive)
     public static let critical = MockAlert(sound: .sound(name: "critical.caf"), identifier: "critical",
-                                           foregroundContent: Alert.Content(title: "Critical Alert: FG Title", body: "Critical Alert: Foreground Body", acknowledgeActionButtonLabel: "Critical FG OK", interruptionLevel: .critical),
-                                           backgroundContent: Alert.Content(title: "Critical Alert: BG Title", body: "Critical Alert: Background Body", acknowledgeActionButtonLabel: "Critical BG OK", interruptionLevel: .critical))
+                                           foregroundContent: Alert.Content(title: "Critical Alert: FG Title", body: "Critical Alert: Foreground Body", acknowledgeActionButtonLabel: "Critical FG OK"),
+                                           backgroundContent: Alert.Content(title: "Critical Alert: BG Title", body: "Critical Alert: Background Body", acknowledgeActionButtonLabel: "Critical BG OK"),
+                                           interruptionLevel: .critical)
     public static let buzz = MockAlert(sound: .vibrate, identifier: "buzz",
                                        foregroundContent: Alert.Content(title: "Alert: FG Title", body: "FG bzzzt", acknowledgeActionButtonLabel: "Buzz"),
-                                       backgroundContent: Alert.Content(title: "Alert: BG Title", body: "BG bzzzt", acknowledgeActionButtonLabel: "Buzz"))
+                                       backgroundContent: Alert.Content(title: "Alert: BG Title", body: "BG bzzzt", acknowledgeActionButtonLabel: "Buzz"), interruptionLevel: .active)
     public static let signalLoss = MockAlert(sound: .sound(name: "critical.caf"),
                                              identifier: "signalLoss",
                                              foregroundContent: Alert.Content(title: "Signal Loss", body: "CGM simulator signal loss", acknowledgeActionButtonLabel: "Dismiss"),
-                                             backgroundContent: Alert.Content(title: "Signal Loss", body: "CGM simulator signal loss", acknowledgeActionButtonLabel: "Dismiss"))
+                                             backgroundContent: Alert.Content(title: "Signal Loss", body: "CGM simulator signal loss", acknowledgeActionButtonLabel: "Dismiss"),
+                                             interruptionLevel: .critical)
 
     private let lockedMockSensorState = Locked(MockCGMState(isStateValid: true))
     public var mockSensorState: MockCGMState {
@@ -609,6 +613,7 @@ extension MockCGMManager {
                                        foregroundContent: alert.foregroundContent,
                                        backgroundContent: alert.backgroundContent,
                                        trigger: trigger,
+                                       interruptionLevel: alert.interruptionLevel,
                                        sound: alert.sound))
         }
 
@@ -697,12 +702,12 @@ extension MockCGMManager {
                                                alertIdentifier: glucoseAlertIdentifier)
         let alertContent = Alert.Content(title: alertTitle,
                                          body: "The glucose measurement received triggered this alert",
-                                         acknowledgeActionButtonLabel: "Dismiss",
-                                         interruptionLevel: interruptionLevel)
+                                         acknowledgeActionButtonLabel: "Dismiss")
         let alert = Alert(identifier: alertIdentifier,
                           foregroundContent: alertContent,
                           backgroundContent: alertContent,
-                          trigger: .immediate)
+                          trigger: .immediate,
+                          interruptionLevel: interruptionLevel)
 
         delegate.notify { delegate in
             delegate?.issueAlert(alert)

--- a/MockKitUI/MockSupport.swift
+++ b/MockKitUI/MockSupport.swift
@@ -77,8 +77,7 @@ extension MockSupport {
                                                     
                                                     Go to \(appName) Settings > Software Update to complete.
                                                     """, comment: "Alert content body for first software update alert"),
-                                         acknowledgeActionButtonLabel: NSLocalizedString("OK", comment: "Default acknowledgement"),
-                                         interruptionLevel: versionUpdate == .required ? .critical : .active)
+                                         acknowledgeActionButtonLabel: NSLocalizedString("OK", comment: "Default acknowledgement"))
         } else if let lastVersionCheckAlertDate = lastVersionCheckAlertDate,
                   abs(lastVersionCheckAlertDate.timeIntervalSinceNow) > alertCadence {
             alertContent = Alert.Content(title: NSLocalizedString("Update Reminder", comment: "Recurring software update alert title"),
@@ -87,12 +86,12 @@ extension MockSupport {
                                                     
                                                     Go to \(appName) Settings > Software Update to install the latest version.
                                                     """, comment: "Alert content body for recurring software update alert"),
-                                         acknowledgeActionButtonLabel: NSLocalizedString("OK", comment: "Default acknowledgement"),
-                                         interruptionLevel: versionUpdate == .required ? .critical : .active)
+                                         acknowledgeActionButtonLabel: NSLocalizedString("OK", comment: "Default acknowledgement"))
         } else {
             return
         }
-        alertIssuer?.issueAlert(Alert(identifier: alertIdentifier, foregroundContent: alertContent, backgroundContent: alertContent, trigger: .immediate))
+        let interruptionLevel: LoopKit.Alert.InterruptionLevel = versionUpdate == .required ? .critical : .active
+        alertIssuer?.issueAlert(Alert(identifier: alertIdentifier, foregroundContent: alertContent, backgroundContent: alertContent, trigger: .immediate, interruptionLevel: interruptionLevel))
         recordLastAlertDate()
     }
     

--- a/MockKitUI/MockSupport.swift
+++ b/MockKitUI/MockSupport.swift
@@ -78,7 +78,7 @@ extension MockSupport {
                                                     Go to \(appName) Settings > Software Update to complete.
                                                     """, comment: "Alert content body for first software update alert"),
                                          acknowledgeActionButtonLabel: NSLocalizedString("OK", comment: "Default acknowledgement"),
-                                         isCritical: versionUpdate == .required)
+                                         interruptionLevel: versionUpdate == .required ? .critical : .active)
         } else if let lastVersionCheckAlertDate = lastVersionCheckAlertDate,
                   abs(lastVersionCheckAlertDate.timeIntervalSinceNow) > alertCadence {
             alertContent = Alert.Content(title: NSLocalizedString("Update Reminder", comment: "Recurring software update alert title"),
@@ -88,7 +88,7 @@ extension MockSupport {
                                                     Go to \(appName) Settings > Software Update to install the latest version.
                                                     """, comment: "Alert content body for recurring software update alert"),
                                          acknowledgeActionButtonLabel: NSLocalizedString("OK", comment: "Default acknowledgement"),
-                                         isCritical: versionUpdate == .required)
+                                         interruptionLevel: versionUpdate == .required ? .critical : .active)
         } else {
             return
         }


### PR DESCRIPTION
This introduces the notion of three Alert "interruption levels" similar to iOS's
UNNotificationInterruptionLevel (https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel)
as a replacement of the `isCritical` flag.

https://tidepool.atlassian.net/browse/LOOP-3973

LWPR: https://github.com/tidepool-org/LoopWorkspace/pull/734