### PR TITLE
LOOP-3951: adds missing 'info' accessibility label

### DIFF
--- a/LoopKitUI/Views/SettingDescription.swift
+++ b/LoopKitUI/Views/SettingDescription.swift
@@ -50,6 +50,7 @@ public struct SettingDescription<InformationalContent: View>: View {
                     .foregroundColor(.accentColor)
             }
         )
+        .accessibilityLabel("info")
         .padding(.trailing, 4)
     }
 }


### PR DESCRIPTION
Fixes one of the UI tests
https://tidepool.atlassian.net/browse/LOOP-3951