### PR TITLE
LOOP-4058: More iOS 15 tweaks to the picker for small screens (iPod Touch)

### DIFF
--- a/LoopKitUI/Views/FractionalQuantityPicker.swift
+++ b/LoopKitUI/Views/FractionalQuantityPicker.swift
@@ -124,7 +124,7 @@ public struct FractionalQuantityPicker: View {
             )
             // Ensure whole picker color updates when fraction updates
             .id(whole + fraction)
-            .frame(width: availableWidth / 3.5)
+            .frame(width: availableWidth / 3)
             .overlay(
                 Text(separator)
                     .foregroundColor(Color(.secondaryLabel))
@@ -145,7 +145,7 @@ public struct FractionalQuantityPicker: View {
             )
             // Ensure fractional picker values update when whole value updates
             .id(whole + fraction)
-            .frame(width: availableWidth / 3.5)
+            .frame(width: availableWidth / 3)
             .padding(.trailing, spacing + unitLabelWidth)
             .clipped()
             .compositingGroup()
@@ -189,7 +189,7 @@ public struct FractionalQuantityPicker: View {
         return attributedSeparator.size().width
     }
 
-    var spacing: CGFloat { 8 }
+    var spacing: CGFloat { 4 }
 
     var unitLabelWidth: CGFloat {
         let attributedUnitString = NSAttributedString(

--- a/LoopKitUI/Views/GlucoseRangePicker.swift
+++ b/LoopKitUI/Views/GlucoseRangePicker.swift
@@ -101,7 +101,7 @@ public struct GlucoseRangePicker: View {
             )
             // Ensure the selectable picker values update when either bound changes
             .id(lowerBound...upperBound)
-            .frame(width: availableWidth / 3.5)
+            .frame(width: availableWidth / 3)
             .overlay(
                 Text(separator)
                     .foregroundColor(Color(.secondaryLabel))
@@ -122,7 +122,7 @@ public struct GlucoseRangePicker: View {
             )
             // Ensure the selectable picker values update when either bound changes
             .id(lowerBound...upperBound)
-            .frame(width: availableWidth / 3.5)
+            .frame(width: availableWidth / 3)
             .padding(.trailing, unitLabelWidth)
             .clipped()
             .compositingGroup()
@@ -141,7 +141,7 @@ public struct GlucoseRangePicker: View {
         return attributedSeparator.size().width
     }
 
-    var spacing: CGFloat { 8 }
+    var spacing: CGFloat { 4 }
 
     var unitLabelWidth: CGFloat {
         let attributedUnitString = NSAttributedString(

--- a/LoopKitUI/Views/QuantityPicker.swift
+++ b/LoopKitUI/Views/QuantityPicker.swift
@@ -28,6 +28,8 @@ public struct QuantityPicker: View {
     private let selectableValues: [Double]
     private let formatter: NumberFormatter
 
+    private let unitLabelSpacing: CGFloat = -6
+    
     public init(
         value: Binding<HKQuantity>,
         unit: HKUnit,
@@ -128,7 +130,7 @@ public struct QuantityPicker: View {
                 Text(self.unit.shortLocalizedUnitString())
                     .foregroundColor(.gray)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-                    .offset(x: pickerValueBounds.union(in: geometry).maxX)
+                    .offset(x: pickerValueBounds.union(in: geometry).maxX + unitLabelSpacing)
                     .animation(.default)
             }
         }

--- a/LoopKitUI/Views/ResizeablePicker.swift
+++ b/LoopKitUI/Views/ResizeablePicker.swift
@@ -71,6 +71,8 @@ struct ResizeablePicker<SelectionValue>: UIViewRepresentable where SelectionValu
             result.textAlignment = .center
             result.textColor = UIColor(picker.colorer(picker.data[row]))
             result.accessibilityHint = text
+            result.lineBreakMode = .byClipping
+            result.adjustsFontSizeToFitWidth = true
             return result
         }
         

--- a/LoopKitUI/Views/Settings Editors/SuspendThresholdEditor.swift
+++ b/LoopKitUI/Views/Settings Editors/SuspendThresholdEditor.swift
@@ -109,7 +109,7 @@ public struct SuspendThresholdEditor: View {
                                 bounds: viewModel.guardrail.absoluteBounds.lowerBound...viewModel.maxSuspendThresholdValue
                             )
                             // Prevent the picker from expanding the card's width on small devices
-                            .frame(maxWidth: 220)
+                            .frame(maxWidth: 200)
                         }
                     )
                 }


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-4058
- Don't ellipsize picker views
- Tweak size so that they get a bit more width
- Reduce spacing so they're a bit closer together and closer to the unit label