### PR TITLE
adds ability to generate a fake critical Alert delayed by 60 seconds

### DIFF
--- a/MockKitUI/View Controllers/IssueAlertTableViewController.swift
+++ b/MockKitUI/View Controllers/IssueAlertTableViewController.swift
@@ -24,6 +24,7 @@ final class IssueAlertTableViewController: UITableViewController {
         case issueLater
         case buzz
         case critical
+        case criticalDelayed
         case retract // should be kept at the bottom of the list
 
         var description: String {
@@ -35,6 +36,7 @@ final class IssueAlertTableViewController: UITableViewController {
             case .retract: return "Retract any alert above"
             case .buzz: return "Issue an immediate vibrate alert"
             case .critical: return "Issue a critical immediate alert"
+            case .criticalDelayed: return "Issue a \"delayed \(delay) seconds\" critical alert"
             }
         }
         
@@ -44,6 +46,7 @@ final class IssueAlertTableViewController: UITableViewController {
             case .retract: return .immediate
             case .critical: return .immediate
             case .delayed: return .delayed(interval: delay)
+            case .criticalDelayed: return .delayed(interval: delay)
             case .repeating: return .repeating(repeatInterval: delay)
             case .issueLater: return .immediate
             case .buzz: return .immediate
@@ -60,7 +63,7 @@ final class IssueAlertTableViewController: UITableViewController {
         var identifier: Alert.AlertIdentifier {
             switch self {
             case .buzz: return MockCGMManager.buzz.identifier
-            case .critical: return MockCGMManager.critical.identifier
+            case .critical, .criticalDelayed: return MockCGMManager.critical.identifier
             default: return MockCGMManager.submarine.identifier
             }
         }


### PR DESCRIPTION
This is particularly helpful when one wants to see how critical alerts (and the various iOS settings involved) behave in iOS, since the other one is "immediate" only.