### PR TITLE
COASTAL-460: Adds `.nextDate` and `.nextDateRepeating` to Alert facility

### DIFF
--- a/LoopKit/Alert.swift
+++ b/LoopKit/Alert.swift
@@ -22,13 +22,6 @@ public protocol AlertResponder: AnyObject {
     func acknowledgeAlert(alertIdentifier: Alert.AlertIdentifier, completion: @escaping (Error?) -> Void)
 }
 
-/// Protocol for looking up alerts in storage
-public protocol AlertSearcher {
-    /// Look up all issued, but unacknowledged and unretracted, alerts for a given `managerIdentifier`.  This is useful for an Alert issuer to see what alerts are extant (outstanding).
-    /// NOTE: the completion function will be called on a separate queue
-    func lookupOutstandingAlerts(managerIdentifier: String, completion: @escaping (Result<[Alert], Error>) -> Void)
-}
-
 /// Structure that represents an Alert that is issued from a Device.
 public struct Alert: Equatable {
     /// Representation of an alert Trigger

--- a/LoopKit/Alert.swift
+++ b/LoopKit/Alert.swift
@@ -37,10 +37,10 @@ public struct Alert: Equatable {
         /// Only `dayOfMonth`, with values 1-31, `hourOfDay` with values 0-23, and `minuteOfHour` with values 0-59 are supported.
         /// Values outside of these ranges will have undefined behavior.
         public struct TimeSpec: Equatable {
-            public let dayOfMonth: Int?
-            public let hourOfDay: Int?
-            public let minuteOfHour: Int?
-            public init(dayOfMonth: Int? = nil, hourOfDay: Int? = nil, minuteOfHour: Int? = nil) {
+            public let dayOfMonth: Int
+            public let hourOfDay: Int
+            public let minuteOfHour: Int
+            public init(dayOfMonth: Int, hourOfDay: Int, minuteOfHour: Int) {
                 self.dayOfMonth = dayOfMonth
                 self.hourOfDay = hourOfDay
                 self.minuteOfHour = minuteOfHour

--- a/LoopKitTests/AlertTests.swift
+++ b/LoopKitTests/AlertTests.swift
@@ -37,15 +37,15 @@ class AlertTests: XCTestCase {
     }
     
     func testAlertNextMatchingEncodable() {
-        let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .nextDate(matching: DateComponents(day: 1, hour: 2, minute: 3)))
+        let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .nextDate(matching: Alert.Trigger.TimeSpec(dayOfMonth: 1, hourOfDay: 2, minuteOfHour: 3)))
         let str = try? alert.encodeToString()
-    XCTAssertEqual("{\"trigger\":{\"nextDate\":{\"matching\":{\"day\":1,\"minute\":3,\"hour\":2}}},\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"body\":\"body1\"},\"backgroundContent\":{\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"body\":\"body2\"}}", str)
+    XCTAssertEqual("{\"trigger\":{\"nextDate\":{\"matching\":{\"dayOfMonth\":1,\"hourOfDay\":2,\"minuteOfHour\":3}}},\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"body\":\"body1\"},\"backgroundContent\":{\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"body\":\"body2\"}}", str)
     }
     
     func testAlertNextMatchingRepeatingEncodable() {
-        let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .nextDateRepeating(matching: DateComponents(day: 4, hour: 5, minute: 6)))
+        let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .nextDateRepeating(matching: Alert.Trigger.TimeSpec(dayOfMonth: 4, hourOfDay: 5, minuteOfHour: 6)))
         let str = try? alert.encodeToString()
-    XCTAssertEqual("{\"trigger\":{\"nextDateRepeating\":{\"matching\":{\"day\":4,\"minute\":6,\"hour\":5}}},\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"body\":\"body1\"},\"backgroundContent\":{\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"body\":\"body2\"}}", str)
+    XCTAssertEqual("{\"trigger\":{\"nextDateRepeating\":{\"matching\":{\"dayOfMonth\":4,\"hourOfDay\":5,\"minuteOfHour\":6}}},\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"body\":\"body1\"},\"backgroundContent\":{\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"body\":\"body2\"}}", str)
     }
 
     func testAlertSilentSoundEncodable() {
@@ -88,15 +88,15 @@ class AlertTests: XCTestCase {
     }
 
     func testAlertNextMatchingDecodable() {
-        let str = "{\"trigger\":{\"nextDate\":{\"matching\":{\"day\":1,\"minute\":3,\"hour\":2}}},\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"body\":\"body1\"},\"backgroundContent\":{\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"body\":\"body2\"}}"
-        let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .nextDate(matching: DateComponents(day: 1, hour: 2, minute: 3)))
+        let str = "{\"trigger\":{\"nextDate\":{\"matching\":{\"dayOfMonth\":1,\"minuteOfHour\":3,\"hourOfDay\":2}}},\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"body\":\"body1\"},\"backgroundContent\":{\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"body\":\"body2\"}}"
+        let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .nextDate(matching: Alert.Trigger.TimeSpec(dayOfMonth: 1, hourOfDay: 2, minuteOfHour: 3)))
         let alert = try? Alert.decode(from: str)
         XCTAssertEqual(expected, alert)
     }
 
     func testAlertNextMatchingRepeatingDecodable() {
-        let str = "{\"trigger\":{\"nextDateRepeating\":{\"matching\":{\"day\":4,\"minute\":6,\"hour\":5}}},\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"body\":\"body1\"},\"backgroundContent\":{\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"body\":\"body2\"}}"
-        let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .nextDateRepeating(matching: DateComponents(day: 4, hour: 5, minute: 6)))
+        let str = "{\"trigger\":{\"nextDateRepeating\":{\"matching\":{\"dayOfMonth\":4,\"minuteOfHour\":6,\"hourOfDay\":5}}},\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"body\":\"body1\"},\"backgroundContent\":{\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"body\":\"body2\"}}"
+        let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .nextDateRepeating(matching: Alert.Trigger.TimeSpec(dayOfMonth: 4, hourOfDay: 5, minuteOfHour: 6)))
         let alert = try? Alert.decode(from: str)
         XCTAssertEqual(expected, alert)
     }

--- a/LoopKitTests/AlertTests.swift
+++ b/LoopKitTests/AlertTests.swift
@@ -36,6 +36,18 @@ class AlertTests: XCTestCase {
     XCTAssertEqual("{\"trigger\":{\"repeating\":{\"repeatInterval\":2}},\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"body\":\"body1\"},\"backgroundContent\":{\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"body\":\"body2\"}}", str)
     }
     
+    func testAlertNextMatchingEncodable() {
+        let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .nextDate(matching: DateComponents(day: 1, hour: 2, minute: 3)))
+        let str = try? alert.encodeToString()
+    XCTAssertEqual("{\"trigger\":{\"nextDate\":{\"matching\":{\"day\":1,\"minute\":3,\"hour\":2}}},\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"body\":\"body1\"},\"backgroundContent\":{\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"body\":\"body2\"}}", str)
+    }
+    
+    func testAlertNextMatchingRepeatingEncodable() {
+        let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .nextDateRepeating(matching: DateComponents(day: 4, hour: 5, minute: 6)))
+        let str = try? alert.encodeToString()
+    XCTAssertEqual("{\"trigger\":{\"nextDateRepeating\":{\"matching\":{\"day\":4,\"minute\":6,\"hour\":5}}},\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"body\":\"body1\"},\"backgroundContent\":{\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"body\":\"body2\"}}", str)
+    }
+
     func testAlertSilentSoundEncodable() {
         let alert = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, sound: .silence)
         let str = try? alert.encodeToString()
@@ -71,6 +83,20 @@ class AlertTests: XCTestCase {
     func testAlertRepeatingDecodable() {
         let str = "{\"trigger\":{\"repeating\":{\"repeatInterval\":2}},\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"body\":\"body1\",\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\"},\"backgroundContent\":{\"body\":\"body2\",\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\"}}"
         let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .repeating(repeatInterval: 2.0))
+        let alert = try? Alert.decode(from: str)
+        XCTAssertEqual(expected, alert)
+    }
+
+    func testAlertNextMatchingDecodable() {
+        let str = "{\"trigger\":{\"nextDate\":{\"matching\":{\"day\":1,\"minute\":3,\"hour\":2}}},\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"body\":\"body1\"},\"backgroundContent\":{\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"body\":\"body2\"}}"
+        let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .nextDate(matching: DateComponents(day: 1, hour: 2, minute: 3)))
+        let alert = try? Alert.decode(from: str)
+        XCTAssertEqual(expected, alert)
+    }
+
+    func testAlertNextMatchingRepeatingDecodable() {
+        let str = "{\"trigger\":{\"nextDateRepeating\":{\"matching\":{\"day\":4,\"minute\":6,\"hour\":5}}},\"interruptionLevel\":\"timeSensitive\",\"identifier\":{\"managerIdentifier\":\"managerIdentifier1\",\"alertIdentifier\":\"alertIdentifier1\"},\"foregroundContent\":{\"title\":\"title1\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel1\",\"body\":\"body1\"},\"backgroundContent\":{\"title\":\"title2\",\"acknowledgeActionButtonLabel\":\"acknowledgeActionButtonLabel2\",\"body\":\"body2\"}}"
+        let expected = Alert(identifier: identifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .nextDateRepeating(matching: DateComponents(day: 4, hour: 5, minute: 6)))
         let alert = try? Alert.decode(from: str)
         XCTAssertEqual(expected, alert)
     }


### PR DESCRIPTION
Adds ability to issue an alert that triggers on a specific date and time, given a `DateComponents`.  This effectively gives the facility the same functionality as UNCalendarNotificationTrigger (indeed, that's how it is implemented in Loop) (https://developer.apple.com/documentation/usernotifications/uncalendarnotificationtrigger).

https://tidepool.atlassian.net/browse/COASTAL-460