### PR TITLE
COASTAL-651: Adds PersistedAlertStore for looking up outstanding alerts

### DIFF
--- a/LoopKit/Alert.swift
+++ b/LoopKit/Alert.swift
@@ -22,7 +22,7 @@ public protocol AlertResponder: AnyObject {
     func acknowledgeAlert(alertIdentifier: Alert.AlertIdentifier, completion: @escaping (Error?) -> Void) -> Void
 }
 
-public struct PersistedAlert {
+public struct PersistedAlert: Equatable {
     public let alert: Alert
     public let issuedDate: Date
     public let retractedDate: Date?

--- a/LoopKit/Alert.swift
+++ b/LoopKit/Alert.swift
@@ -22,6 +22,26 @@ public protocol AlertResponder: AnyObject {
     func acknowledgeAlert(alertIdentifier: Alert.AlertIdentifier, completion: @escaping (Error?) -> Void) -> Void
 }
 
+public struct PersistedAlert {
+    public let alert: Alert
+    public let issuedDate: Date
+    public let retractedDate: Date?
+    public let acknowledgedDate: Date?
+    public init(alert: Alert, issuedDate: Date, retractedDate: Date?, acknowledgedDate: Date?) {
+        self.alert = alert
+        self.issuedDate = issuedDate
+        self.retractedDate = retractedDate
+        self.acknowledgedDate = acknowledgedDate
+    }
+}
+
+/// Protocol for looking up alerts persisted in storage
+public protocol PersistedAlertStore {
+    /// Look up all issued, but unretracted, alerts for a given `managerIdentifier`.  This is useful for an Alert issuer to see what alerts are extant (outstanding).
+    /// NOTE: the completion function may be called on a different queue than the caller.  Callers must be prepared for this.
+    func lookupOutstandingAlerts(managerIdentifier: String, completion: @escaping (Swift.Result<[PersistedAlert], Error>) -> Void)
+}
+
 /// Structure that represents an Alert that is issued from a Device.
 public struct Alert: Equatable {
     /// Representation of an alert Trigger

--- a/LoopKit/Alert.swift
+++ b/LoopKit/Alert.swift
@@ -39,7 +39,11 @@ public struct PersistedAlert: Equatable {
 public protocol PersistedAlertStore {
     /// Look up all issued, but unretracted, alerts for a given `managerIdentifier`.  This is useful for an Alert issuer to see what alerts are extant (outstanding).
     /// NOTE: the completion function may be called on a different queue than the caller.  Callers must be prepared for this.
-    func lookupOutstandingAlerts(managerIdentifier: String, completion: @escaping (Swift.Result<[PersistedAlert], Error>) -> Void)
+    func lookupAllUnretracted(managerIdentifier: String, completion: @escaping (Swift.Result<[PersistedAlert], Error>) -> Void)
+
+    /// Look up all issued, but unretracted, and unacknowledged, alerts for a given `managerIdentifier`.  This is useful for an Alert issuer to see what alerts are extant (outstanding).
+    /// NOTE: the completion function may be called on a different queue than the caller.  Callers must be prepared for this.
+    func lookupAllUnacknowledgedUnretracted(managerIdentifier: String, completion: @escaping (Swift.Result<[PersistedAlert], Error>) -> Void)
 }
 
 /// Structure that represents an Alert that is issued from a Device.

--- a/LoopKit/DeviceManager/DeviceManager.swift
+++ b/LoopKit/DeviceManager/DeviceManager.swift
@@ -8,7 +8,7 @@
 import Foundation
 import UserNotifications
 
-public protocol DeviceManagerDelegate: AlertIssuer {    
+public protocol DeviceManagerDelegate: AlertIssuer, PersistedAlertStore {    
     func deviceManager(_ manager: DeviceManager, logEventForDeviceIdentifier deviceIdentifier: String?, type: DeviceLogEntryType, message: String, completion: ((Error?) -> Void)?)
 }
 

--- a/LoopKit/DeviceManager/PumpManagerStatus.swift
+++ b/LoopKit/DeviceManager/PumpManagerStatus.swift
@@ -70,7 +70,6 @@ public struct PumpManagerStatus: Equatable {
 
     public var deliveryIsUncertain: Bool
 
-
     public init(
         timeZone: TimeZone,
         device: HKDevice,


### PR DESCRIPTION
Adds ability to query CoreData for all outstanding (i.e. "unretracted") alerts from a given `managerIdentifier`.

https://tidepool.atlassian.net/browse/COASTAL-651

LWPR: https://github.com/tidepool-org/LoopWorkspace/pull/780