### PR TITLE
COASTAL-625: Relax requirement that HUDProvider needs to provide LevelHUDView

### DIFF
--- a/LoopKitUI/HUDProvider.swift
+++ b/LoopKitUI/HUDProvider.swift
@@ -22,7 +22,7 @@ public protocol HUDProvider: AnyObject  {
     typealias HUDViewRawState = [String: Any]
 
     // Creates the initial view (typically reservoir volume) to be shown in Loop HUD.
-    func createHUDView() -> LevelHUDView?
+    func createHUDView() -> BaseHUDView?
 
     // Returns the action that should be taken when the view is tapped
     func didTapOnHUDView(_ view: BaseHUDView, allowDebugFeatures: Bool) -> HUDTapAction?

--- a/LoopKitUI/PumpManagerUI.swift
+++ b/LoopKitUI/PumpManagerUI.swift
@@ -71,7 +71,7 @@ public protocol PumpManagerUI: DeviceManagerUI, PumpStatusIndicator, PumpManager
     func hudProvider(bluetoothProvider: BluetoothProvider, colorPalette: LoopUIColorPalette, allowedInsulinTypes: [InsulinType]) -> HUDProvider?
 
     // Instantiates HUD view (typically reservoir volume) from the raw state returned by hudViewRawState
-    static func createHUDView(rawValue: HUDProvider.HUDViewRawState) -> LevelHUDView?
+    static func createHUDView(rawValue: HUDProvider.HUDViewRawState) -> BaseHUDView?
 }
 
 public protocol PumpManagerOnboardingDelegate: AnyObject {

--- a/MockKitUI/MockHUDProvider.swift
+++ b/MockKitUI/MockHUDProvider.swift
@@ -48,14 +48,14 @@ final class MockHUDProvider: NSObject, HUDProvider {
         return rawValue
     }
 
-    func createHUDView() -> LevelHUDView? {
+    func createHUDView() -> BaseHUDView? {
         reservoirView = ReservoirVolumeHUDView.instantiate()
         updateReservoirView()
     
         return reservoirView
     }
 
-    static func createHUDView(rawValue: HUDViewRawState) -> LevelHUDView? {
+    static func createHUDView(rawValue: HUDViewRawState) -> BaseHUDView? {
         guard let pumpReservoirCapacity = rawValue["pumpReservoirCapacity"] as? Double else {
             return nil
         }

--- a/MockKitUI/MockPumpManager+UI.swift
+++ b/MockKitUI/MockPumpManager+UI.swift
@@ -51,7 +51,7 @@ extension MockPumpManager: PumpManagerUI {
         return MockHUDProvider(pumpManager: self, allowedInsulinTypes: allowedInsulinTypes)
     }
 
-    public static func createHUDView(rawValue: HUDProvider.HUDViewRawState) -> LevelHUDView? {
+    public static func createHUDView(rawValue: HUDProvider.HUDViewRawState) -> BaseHUDView? {
         return MockHUDProvider.createHUDView(rawValue: rawValue)
     }
     


### PR DESCRIPTION
LevelHUDView is for providing a view that displays a thermometer level, which not all Pumps may provide.  This relaxes the requirement and just requires returning a BaseHUDView.

https://tidepool.atlassian.net/browse/COASTAL-625