### PR TITLE
LOOP-4116 Limit HK observation for insulin to 24 hours

### DIFF
--- a/LoopKit/InsulinKit/InsulinDeliveryStore.swift
+++ b/LoopKit/InsulinKit/InsulinDeliveryStore.swift
@@ -77,12 +77,15 @@ public class InsulinDeliveryStore: HealthKitSampleStore {
         self.cacheLength = cacheLength
         self.provenanceIdentifier = provenanceIdentifier
 
+        // Only observe HK driven changes from last 24 hours
+        let observationStartOffset = min(cacheLength, .hours(24))
+
         super.init(
             healthStore: healthStore,
             observeHealthKitSamplesFromCurrentApp: true,
             observeHealthKitSamplesFromOtherApps: observeHealthKitSamplesFromOtherApps,
             type: insulinQuantityType,
-            observationStart: (test_currentDate ?? Date()).addingTimeInterval(-cacheLength),
+            observationStart: (test_currentDate ?? Date()).addingTimeInterval(-observationStartOffset),
             observationEnabled: observationEnabled,
             test_currentDate: test_currentDate
         )


### PR DESCRIPTION
Loop was attempting to sync, on startup, 90 days of insulin data from HK to its internal stores.  This particularly causes issues when using simulated data, but even in normal use, it can cause significant delays during Loop startup.  

https://tidepool.atlassian.net/browse/LOOP-4116