### PR TITLE
LOOP-4202 Adjust target ranges when conflicting with glucose threshold

### DIFF
--- a/LoopKit/TherapySettings.swift
+++ b/LoopKit/TherapySettings.swift
@@ -14,7 +14,7 @@ public struct TherapySettings: Equatable {
 
     public var correctionRangeOverrides: CorrectionRangeOverrides?
 
-    public let overridePresets: [TemporaryScheduleOverridePreset]?
+    public var overridePresets: [TemporaryScheduleOverridePreset]?
 
     public var maximumBasalRatePerHour: Double?
 


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-4202

* Adjusts any glucose targets to avoid conflicts with a raised suspend threshold.
* Updating of individual settings isn't required by Loop, so simplify the `TherapySettingsViewModelDelegate` protocol, and avoid needing multiple calls when multiple settings change. 
