### PR TITLE
Scenarios without device actions

### DIFF
--- a/LoopTestingKit/DateRelativeBasalEntry.swift
+++ b/LoopTestingKit/DateRelativeBasalEntry.swift
@@ -22,6 +22,6 @@ struct DateRelativeBasalEntry: DateRelativeQuantity, Codable {
 
     func newPumpEvent(relativeTo referenceDate: Date) -> NewPumpEvent {
         let dose = doseEntry(relativeTo: referenceDate)
-        return NewPumpEvent(date: dose.startDate, dose: dose, raw: .newPumpEventIdentifier(), title: "Basal", type: .tempBasal)
+        return NewPumpEvent(date: dose.startDate, dose: dose, raw: .newPumpEventIdentifier(), title: "Temp Basal", type: .tempBasal)
     }
 }

--- a/LoopTestingKit/TestingScenario.swift
+++ b/LoopTestingKit/TestingScenario.swift
@@ -14,7 +14,7 @@ public struct TestingScenario {
     var dateRelativeBasalEntries: [DateRelativeBasalEntry]
     var dateRelativeBolusEntries: [DateRelativeBolusEntry]
     var dateRelativeCarbEntries: [DateRelativeCarbEntry]
-    var deviceActions: [DeviceAction]
+    var deviceActions: [DeviceAction]?
 
     public func instantiate(relativeTo referenceDate: Date = Date()) -> TestingScenarioInstance {
         let glucoseSamples = dateRelativeGlucoseSamples
@@ -29,7 +29,7 @@ public struct TestingScenario {
         let carbEntries = dateRelativeCarbEntries
             .filter { $0.enteredAt(relativeTo: referenceDate) <= referenceDate }
             .map { $0.newCarbEntry(relativeTo: referenceDate) }
-        return TestingScenarioInstance(pastGlucoseSamples: pastGlucoseSamples, futureGlucoseSamples: futureGlucoseSamples, pumpEvents: pumpEvents, carbEntries: carbEntries, deviceActions: deviceActions)
+        return TestingScenarioInstance(pastGlucoseSamples: pastGlucoseSamples, futureGlucoseSamples: futureGlucoseSamples, pumpEvents: pumpEvents, carbEntries: carbEntries, deviceActions: deviceActions ?? [])
     }
 
     public mutating func stepBackward(by offset: TimeInterval) {


### PR DESCRIPTION
Accidentally made `[deviceAction]` non-optional. However, it needs to be optional to load pre-existing scenarios without any modifications.