### PR TITLE
[LOOP-4640] update demo placeholder background colour

### DIFF
--- a/LoopKitUI/Resources/Assets.xcassets/demo-background.colorset/Contents.json
+++ b/LoopKitUI/Resources/Assets.xcassets/demo-background.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xF0",
+          "red" : "0xEF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x48",
+          "green" : "0x19",
+          "red" : "0x2A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LoopKitUI/Views/DemoPlaceHolderView.swift
+++ b/LoopKitUI/Views/DemoPlaceHolderView.swift
@@ -17,7 +17,7 @@ public struct DemoPlaceHolderView: View {
     
     public var body: some View {
         ZStack {
-            Color.accentColor.opacity(0.1).ignoresSafeArea()
+            Color(frameworkColor: "demo-background").ignoresSafeArea()
 
             VStack {
                 Image(frameworkImage: "DemoPlaceholderImage")


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-4640

We discussed this recently and this is the simple implementation. However, this colour is intended to be the branded (accent) background colour. The only place it is used currently is the demo placeholder view and it seems that this colour is best for both DIY and Tidepool, since the image on the demo placeholder view already uses the Tidepool colours. 

The long term solution (for which there is no need currently) could be to include a new public `accent-background` colour to the app colour palette (mirroring how the current `accent` colour is implemented).