### PR TITLE
[LOOP-4662] need to round such that the selected value is in the support values

### DIFF
--- a/LoopKit/GlucoseSchedule.swift
+++ b/LoopKit/GlucoseSchedule.swift
@@ -19,7 +19,7 @@ public extension InsulinSensitivitySchedule {
 
         let convertedDailyItems: [RepeatingScheduleValue<Double>] = self.items.map {
             RepeatingScheduleValue(startTime: $0.startTime,
-                                   value: HKQuantity(unit: self.unit, doubleValue: $0.value).doubleValue(for: unit)
+                                   value: HKQuantity(unit: self.unit, doubleValue: $0.value).doubleValue(for: unit, withRounding: true)
             )
         }
 
@@ -36,6 +36,6 @@ public extension InsulinSensitivitySchedule {
     
     func value(for glucoseUnit: HKUnit, at time: Date) -> Double {
         let unconvertedValue = self.value(at: time)
-        return HKQuantity(unit: self.unit, doubleValue: unconvertedValue).doubleValue(for: glucoseUnit)
+        return HKQuantity(unit: self.unit, doubleValue: unconvertedValue).doubleValue(for: glucoseUnit, withRounding: true)
     }
 }

--- a/LoopKitTests/InsulinSensitivityScheduleTests.swift
+++ b/LoopKitTests/InsulinSensitivityScheduleTests.swift
@@ -26,9 +26,9 @@ class InsulinSensitivityScheduleTests: XCTestCase {
             unit: .millimolesPerLiter,
             dailyItems: [
                 RepeatingScheduleValue(startTime: 0,
-                                       value: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: value1).doubleValue(for: .millimolesPerLiter)),
+                                       value: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: value1).doubleValue(for: .millimolesPerLiter, withRounding: true)),
                 RepeatingScheduleValue(startTime: 1000,
-                                       value: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: value2).doubleValue(for: .millimolesPerLiter))
+                                       value: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: value2).doubleValue(for: .millimolesPerLiter, withRounding: true))
             ])
         let date = Date()
         XCTAssertEqual(insulinSensitivityScheduleMGDL!.schedule(for: .millimolesPerLiter), insulinSensitivityScheduleMMOLL!)


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-4662

When glucose units is changed, the insulin sensitivity schedule displays `unsupported value(s)` until new values are selected. This is again a rounding issue of the selected value.