### PR TITLE
LOOP-4849 Fix bugs around reporting GlucoseCondition states

### DIFF
--- a/MockKit/MockCGMManager.swift
+++ b/MockKit/MockCGMManager.swift
@@ -488,23 +488,46 @@ public final class MockCGMManager: TestingCGMManager {
     }
 
     private func sendCGMReadingResult(_ result: CGMReadingResult) {
-        if case .newData(let samples) = result,
-            let currentValue = samples.first
-        {
-            mockSensorState.currentGlucose = currentValue.quantity
-            mockSensorState.trendType = currentValue.trend
-            mockSensorState.trendRate = currentValue.trendRate
-            mockSensorState.glucoseRangeCategory = glucoseRangeCategory(for: currentValue.quantitySample)
-            issueAlert(for: currentValue)
-        }
-        self.delegate.notify { delegate in
-            delegate?.cgmManager(self, hasNew: result)
+        if case .newData(let samples) = result {
+            if let currentValue = samples.first {
+                mockSensorState.currentGlucose = currentValue.quantity
+                mockSensorState.trendType = currentValue.trend
+                mockSensorState.trendRate = currentValue.trendRate
+                mockSensorState.glucoseRangeCategory = glucoseRangeCategory(for: currentValue.quantitySample)
+                issueAlert(for: currentValue)
+            }
+
+            let samplesWithCondition = samples.map { sample in
+                var condition: GlucoseCondition?
+                if sample.quantity < mockSensorState.cgmLowerLimit {
+                    condition = .belowRange
+                } else if sample.quantity > mockSensorState.cgmUpperLimit {
+                    condition = .aboveRange
+                }
+                return NewGlucoseSample(
+                    date: sample.date,
+                    quantity: sample.quantity,
+                    condition: condition,
+                    trend: sample.trend,
+                    trendRate: sample.trendRate,
+                    isDisplayOnly: sample.isDisplayOnly,
+                    wasUserEntered: sample.wasUserEntered,
+                    syncIdentifier: sample.syncIdentifier
+                )
+            }
+            self.delegate.notify { delegate in
+                delegate?.cgmManager(self, hasNew: .newData(samplesWithCondition))
+            }
+        } else {
+            self.delegate.notify { delegate in
+                delegate?.cgmManager(self, hasNew: result)
+            }
         }
     }
     
     public func glucoseRangeCategory(for glucose: GlucoseSampleValue) -> GlucoseRangeCategory? {
         switch glucose.quantity {
-        case ...mockSensorState.cgmLowerLimit:
+        case ..<mockSensorState.cgmLowerLimit:
             return glucose.wasUserEntered ? .urgentLow : .belowRange
         case mockSensorState.cgmLowerLimit..<mockSensorState.urgentLowGlucoseThreshold:
             return .urgentLow
@@ -512,7 +535,7 @@ public final class MockCGMManager: TestingCGMManager {
             return .low
         case mockSensorState.lowGlucoseThreshold..<mockSensorState.highGlucoseThreshold:
             return .normal
-        case mockSensorState.highGlucoseThreshold..<mockSensorState.cgmUpperLimit:
+        case mockSensorState.highGlucoseThreshold...mockSensorState.cgmUpperLimit:
             return .high
         default:
             return glucose.wasUserEntered ? .high : .aboveRange

--- a/MockKitUI/Views/MockCGMManagerSettingsView.swift
+++ b/MockKitUI/Views/MockCGMManagerSettingsView.swift
@@ -149,8 +149,10 @@ struct MockCGMManagerSettingsView: View {
                     Text(viewModel.lastGlucoseValueFormatted)
                         .font(.title)
                         .fontWeight(.heavy)
-                    Text(viewModel.glucoseUnitString)
-                        .foregroundColor(.secondary)
+                    if viewModel.shouldDisplayUnitsForCurrentGlucose {
+                        Text(viewModel.glucoseUnitString)
+                            .foregroundColor(.secondary)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Bugs fixed:
* Report NewGlucoseValues with GlucoseConditions that respect the configured cgmUpperLimit and cgmLowerLimit
* 40 and 400 are displayable by default.  Only < 40 (typically 39) and >= 400 (typically 401) are out of range.
* Scenario values can specify trend and trendRate