### PR TITLE
LOOP-5088 Avoid blocking threads during glucose/insulin storage

### DIFF
--- a/LoopKit Example/Managers/DeviceDataManager.swift
+++ b/LoopKit Example/Managers/DeviceDataManager.swift
@@ -55,7 +55,7 @@ class DeviceDataManager {
             observationStart: Date().addingTimeInterval(-observationInterval),
             observationEnabled: false)
 
-        glucoseStore = GlucoseStore(
+        glucoseStore = await GlucoseStore(
             healthKitSampleStore: glucoseSampleStore,
             cacheStore: cacheStore,
             provenanceIdentifier: HKSource.default().bundleIdentifier)

--- a/LoopKit Example/Managers/DeviceDataManager.swift
+++ b/LoopKit Example/Managers/DeviceDataManager.swift
@@ -13,7 +13,7 @@ import LoopAlgorithm
 
 class DeviceDataManager {
 
-    init() {
+    init() async {
         healthStore = HKHealthStore()
         let cacheStore = PersistenceController(directoryURL: FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!)
 
@@ -40,7 +40,7 @@ class DeviceDataManager {
             observationStart: Date().addingTimeInterval(-observationInterval),
             observationEnabled: false)
 
-        doseStore = DoseStore(
+        doseStore = await DoseStore(
             healthKitSampleStore: doseSampleStore,
             cacheStore: cacheStore,
             longestEffectDuration: ExponentialInsulinModelPreset.rapidActingAdult.effectDuration,

--- a/LoopKit Example/MasterViewController.swift
+++ b/LoopKit Example/MasterViewController.swift
@@ -228,8 +228,6 @@ class MasterViewController: UITableViewController {
                         return "dataManager is nil"
                     }
 
-                    let group = DispatchGroup()
-
                     var unitVolume = 150.0
 
                     reservoir: for index in sequence(first: TimeInterval(hours: -6), next: { $0 + .minutes(5) }) {
@@ -238,20 +236,6 @@ class MasterViewController: UITableViewController {
                         }
 
                         unitVolume -= (drand48() * 2.0)
-
-//                        group.enter()
-//                        dataManager.doseStore.addReservoirValue(unitVolume, at: Date(timeIntervalSinceNow: index)) { (_, _, _, error) in
-//                            group.leave()
-//                        }
-                    }
-
-                    group.enter()
-                    dataManager.glucoseStore.addGlucoseSamples([NewGlucoseSample(date: Date(), quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 101), condition: nil, trend: nil, trendRate: nil, isDisplayOnly: false, wasUserEntered: false, syncIdentifier: UUID().uuidString)], completion: { (result) in
-                        group.leave()
-                    })
-
-                    group.notify(queue: .main) {
-                        completionHandler("Completed")
                     }
 
                     return "Generating…"

--- a/LoopKit Example/MasterViewController.swift
+++ b/LoopKit Example/MasterViewController.swift
@@ -19,8 +19,10 @@ class MasterViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
-            dataManager = DeviceDataManager()
+        Task {
+            if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil {
+                dataManager = await DeviceDataManager()
+            }
         }
     }
 

--- a/LoopKit.xcodeproj/project.pbxproj
+++ b/LoopKit.xcodeproj/project.pbxproj
@@ -677,6 +677,7 @@
 		C10DF6E02C2CA4270076DA10 /* PeripheralManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10DF6DB2C2CA4270076DA10 /* PeripheralManager.swift */; };
 		C10DF6E32C2CB7FF0076DA10 /* OSLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10DF6E22C2CB7FF0076DA10 /* OSLog.swift */; };
 		C10DF6E72C2CBA0D0076DA10 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10DF6E62C2CBA0D0076DA10 /* Data.swift */; };
+		C11A17482CB713C10019C517 /* Model.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = B41E10512C3D314600E186F7 /* Model.xcdatamodeld */; };
 		C13FF4262C5ADC8100FD2869 /* DiscoveredFob+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13FF4252C5ADC8100FD2869 /* DiscoveredFob+UI.swift */; };
 		C140E0522602908A000A4FF7 /* SettingsPresentationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = C140E0512602908A000A4FF7 /* SettingsPresentationMode.swift */; };
 		C1475B33264C30800040C7B1 /* LoopKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43BA7154201E484D0058961E /* LoopKitUI.framework */; };
@@ -4430,6 +4431,7 @@
 				C17F39CB23CD2D2F00FA1113 /* DeviceLogEntryType.swift in Sources */,
 				A9E675AF22713F4700E25293 /* PumpEventType.swift in Sources */,
 				C1614F062AAFC36200F636E5 /* CgmEvent.swift in Sources */,
+				C11A17482CB713C10019C517 /* Model.xcdatamodeld in Sources */,
 				C1A174ED23DEAD6A0034DF11 /* DeviceLogEntry+CoreDataProperties.swift in Sources */,
 				A9E675B222713F4700E25293 /* GlucoseRangeSchedule.swift in Sources */,
 				A9E675B322713F4700E25293 /* PersistedPumpEvent.swift in Sources */,

--- a/LoopKit/DeviceManager/DeviceLog/PersistentDeviceLog.swift
+++ b/LoopKit/DeviceManager/DeviceLog/PersistentDeviceLog.swift
@@ -12,7 +12,7 @@ import os.log
 
 
 // Using a framework specific class will search the framework's bundle for model files.
-class PersistentContainer: NSPersistentContainer { }
+class PersistentContainer: NSPersistentContainer, @unchecked Sendable { }
 
 public class PersistentDeviceLog {
 

--- a/LoopKit/GlucoseKit/GlucoseStore.swift
+++ b/LoopKit/GlucoseKit/GlucoseStore.swift
@@ -434,7 +434,7 @@ extension GlucoseStore {
     }
 
 
-    private func saveSamplesToHealthKit() async {
+    func saveSamplesToHealthKit() async {
         guard let hkSampleStore else {
             return
         }
@@ -556,6 +556,15 @@ extension GlucoseStore {
         }
     }
 
+    public func getSyncGlucoseSamples(start: Date? = nil, end: Date? = nil) async throws -> [StoredGlucoseSample] {
+        try await withCheckedThrowingContinuation { continuation in
+            getSyncGlucoseSamples(start: start, end: end) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+
+
     /// Store glucose samples in Watch extension
     public func setSyncGlucoseSamples(_ objects: [StoredGlucoseSample], completion: @escaping (Error?) -> Void) {
         queue.async {
@@ -583,6 +592,19 @@ extension GlucoseStore {
             completion(nil)
         }
     }
+
+    public func setSyncGlucoseSamples(_ objects: [StoredGlucoseSample]) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            setSyncGlucoseSamples(objects) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
 }
 
 // MARK: - Cache Management
@@ -619,6 +641,19 @@ extension GlucoseStore {
         }
     }
 
+    public func purgeAllGlucoseSamples(healthKitPredicate: NSPredicate) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            purgeAllGlucoseSamples(healthKitPredicate: healthKitPredicate) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
+
     private func purgeExpiredCachedGlucoseObjects() {
         purgeCachedGlucoseObjects(before: earliestCacheDate)
     }
@@ -636,6 +671,18 @@ extension GlucoseStore {
             }
             self.handleUpdatedGlucoseData()
             completion(nil)
+        }
+    }
+
+    public func purgeCachedGlucoseObjects(before date: Date? = nil) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            purgeCachedGlucoseObjects(before: date) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
         }
     }
 

--- a/LoopKit/HealthKitSampleStore.swift
+++ b/LoopKit/HealthKitSampleStore.swift
@@ -21,6 +21,7 @@ public protocol HKHealthStoreProtocol {
     func save(_ objects: [HKObject]) async throws
     func save(_ object: HKObject, withCompletion completion: @escaping (Bool, Error?) -> Void)
     func deleteObjects(of objectType: HKObjectType, predicate: NSPredicate, withCompletion completion: @escaping (Bool, Int, Error?) -> Void)
+    func deleteObjects(of objectType: HKObjectType, predicate: NSPredicate) async throws -> Int
 
     func cachedPreferredUnits(for quantityTypeIdentifier: HKQuantityTypeIdentifier) async -> HKUnit?
 }
@@ -239,6 +240,7 @@ public class HealthKitSampleStore {
 
     // Observation will not start until this is called. Pass nil to receive all the matching samples and recently deleted objects
     func setInitialQueryAnchor(_ anchor: HKQueryAnchor?) {
+        print("Set initial query anchor: \(anchor)")
         queryAnchor = anchor
     }
 

--- a/LoopKit/HealthKitSampleStore.swift
+++ b/LoopKit/HealthKitSampleStore.swift
@@ -240,7 +240,6 @@ public class HealthKitSampleStore {
 
     // Observation will not start until this is called. Pass nil to receive all the matching samples and recently deleted objects
     func setInitialQueryAnchor(_ anchor: HKQueryAnchor?) {
-        print("Set initial query anchor: \(anchor)")
         queryAnchor = anchor
     }
 

--- a/LoopKit/HealthKitSampleStore.swift
+++ b/LoopKit/HealthKitSampleStore.swift
@@ -18,6 +18,7 @@ public protocol HKHealthStoreProtocol {
 #endif
     func authorizationStatus(for type: HKObjectType) -> HKAuthorizationStatus
     func save(_ objects: [HKObject], withCompletion completion: @escaping (Bool, Error?) -> Void)
+    func save(_ objects: [HKObject]) async throws
     func save(_ object: HKObject, withCompletion completion: @escaping (Bool, Error?) -> Void)
     func deleteObjects(of objectType: HKObjectType, predicate: NSPredicate, withCompletion completion: @escaping (Bool, Int, Error?) -> Void)
 

--- a/LoopKit/InsulinKit/DoseStore.swift
+++ b/LoopKit/InsulinKit/DoseStore.swift
@@ -133,8 +133,8 @@ public final class DoseStore {
         provenanceIdentifier: String = HKSource.default().bundleIdentifier,
         onReady: ((DoseStoreError?) -> Void)? = nil,
         test_currentDate: Date? = nil
-    ) {
-        self.insulinDeliveryStore = InsulinDeliveryStore(
+    ) async {
+        self.insulinDeliveryStore = await InsulinDeliveryStore(
             healthKitSampleStore: healthKitSampleStore,
             cacheStore: cacheStore,
             cacheLength: cacheLength,
@@ -837,11 +837,7 @@ extension DoseStore {
             self.log.debug("Adding dose to insulin delivery store: %@", String(describing: dose))
         }
 
-        try await withCheckedThrowingContinuation { continuation in
-            self.insulinDeliveryStore.addDoseEntries(doses, from: self.device, syncVersion: self.syncVersion, resolveMutable: resolveMutable) { (result) in
-                continuation.resume(with: result)
-            }
-        }
+        try await insulinDeliveryStore.addDoseEntries(doses, from: self.device, syncVersion: self.syncVersion, resolveMutable: resolveMutable)
     }
 
     /// Fetches a timeline of doses, filling in gaps between delivery changes with the scheduled basal delivery

--- a/LoopKit/InsulinKit/InsulinDeliveryStore.swift
+++ b/LoopKit/InsulinKit/InsulinDeliveryStore.swift
@@ -555,7 +555,6 @@ extension InsulinDeliveryStore {
 
 
     private func saveEntriesToHealthKit(_ sampleObjects: [(HKQuantitySample, CachedInsulinDeliveryObject)]) {
-        dispatchPrecondition(condition: .onQueue(queue))
 
         guard storeSamplesToHealthKit, !sampleObjects.isEmpty, let hkSampleStore else {
             return

--- a/LoopKit/Persistence/PersistenceController.swift
+++ b/LoopKit/Persistence/PersistenceController.swift
@@ -292,6 +292,14 @@ extension PersistenceController {
             }
         }
     }
+
+    func fetchAnchor(key: String) async -> HKQueryAnchor? {
+        await withCheckedContinuation { continuation in
+            fetchAnchor(key: key) { anchor in
+                continuation.resume(returning: anchor)
+            }
+        }
+    }
 }
 
 fileprivate extension FileManager {

--- a/LoopKitHostedTests/CarbStoreHKQueryTests.swift
+++ b/LoopKitHostedTests/CarbStoreHKQueryTests.swift
@@ -16,8 +16,8 @@ class CarbStoreHKQueryTestsBase: PersistenceControllerTestCase {
     var authorizationStatus: HKAuthorizationStatus = .notDetermined
     var hkSampleStore: HealthKitSampleStore!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
 
         mockHealthStore = HKHealthStoreMock()
         mockHealthStore.authorizationStatus = authorizationStatus
@@ -31,27 +31,21 @@ class CarbStoreHKQueryTestsBase: PersistenceControllerTestCase {
                               cacheStore: cacheStore,
                               cacheLength: .hours(24),
                               provenanceIdentifier: Bundle.main.bundleIdentifier!)
-
-        let semaphore = DispatchSemaphore(value: 0)
-        cacheStore.onReady { (error) in
-            semaphore.signal()
-        }
-        semaphore.wait()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         carbStore = nil
         mockHealthStore = nil
 
-        super.tearDown()
+        try await super.tearDown()
     }
     
 }
 
 class CarbStoreHKQueryTestsAuthorized: CarbStoreHKQueryTestsBase {
-    override func setUp() {
+    override func setUp() async throws {
         authorizationStatus = .sharingAuthorized
-        super.setUp()
+        try await super.setUp()
     }
 
     func testObserverQueryStartup() {

--- a/LoopKitHostedTests/InsulinDeliveryStoreTests.swift
+++ b/LoopKitHostedTests/InsulinDeliveryStoreTests.swift
@@ -49,8 +49,8 @@ class InsulinDeliveryStoreTestsBase: PersistenceControllerTestCase {
     var hkSampleStore: HealthKitSampleStore!
     var authorizationStatus: HKAuthorizationStatus = .notDetermined
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
 
         mockHealthStore = HKHealthStoreMock()
 
@@ -59,38 +59,28 @@ class InsulinDeliveryStoreTestsBase: PersistenceControllerTestCase {
         hkSampleStore.anchoredObjectQueryType = MockHKAnchoredObjectQuery.self
 
         mockHealthStore.authorizationStatus = authorizationStatus
-        insulinDeliveryStore = InsulinDeliveryStore(healthKitSampleStore: hkSampleStore,
+
+        insulinDeliveryStore = await InsulinDeliveryStore(healthKitSampleStore: hkSampleStore,
                                                     cacheStore: cacheStore,
                                                     cacheLength: .hours(1),
                                                     provenanceIdentifier: HKSource.default().bundleIdentifier)
 
-        let semaphore = DispatchSemaphore(value: 0)
-        cacheStore.onReady { error in
-            XCTAssertNil(error)
-            semaphore.signal()
-        }
-        semaphore.wait()
     }
 
-    override func tearDown() {
-        let semaphore = DispatchSemaphore(value: 0)
-        insulinDeliveryStore.purgeAllDoseEntries(healthKitPredicate: HKQuery.predicateForObjects(from: HKSource.default())) { error in
-            XCTAssertNil(error)
-            semaphore.signal()
-        }
-        semaphore.wait()
 
+    override func tearDown() async throws {
+        try await insulinDeliveryStore.purgeDoseEntriesForSource(HKSource.default())
         insulinDeliveryStore = nil
         mockHealthStore = nil
 
-        super.tearDown()
+        try await super.tearDown()
     }
 }
 
 class InsulinDeliveryStoreTestsAuthorized: InsulinDeliveryStoreTestsBase {
-    override func setUp() {
+    override func setUp() async throws {
         authorizationStatus = .sharingAuthorized
-        super.setUp()
+        try await super.setUp()
     }
     
     func testObserverQueryStartup() {
@@ -108,7 +98,7 @@ class InsulinDeliveryStoreTestsAuthorized: InsulinDeliveryStoreTestsBase {
 class InsulinDeliveryStoreTests: InsulinDeliveryStoreTestsBase {
     // MARK: - HealthKitSampleStore
 
-    func testHealthKitQueryAnchorPersistence() {
+    func testHealthKitQueryAnchorPersistence() async {
 
         XCTAssert(hkSampleStore.authorizationRequired);
         XCTAssertNil(hkSampleStore.observerQuery);
@@ -118,7 +108,7 @@ class InsulinDeliveryStoreTests: InsulinDeliveryStoreTestsBase {
         mockHealthStore.authorizationStatus = .sharingAuthorized
         hkSampleStore.authorizationIsDetermined()
 
-        waitForExpectations(timeout: 3)
+        await fulfillment(of: [mockHealthStore.observerQueryStartedExpectation!], timeout: 3)
 
         XCTAssertNotNil(mockHealthStore.observerQuery)
 
@@ -135,7 +125,7 @@ class InsulinDeliveryStoreTests: InsulinDeliveryStoreTestsBase {
         // This simulates a signal marking the arrival of new HK Data.
         mockObserverQuery.updateHandler?(mockObserverQuery, observerQueryCompletionHandler, nil)
 
-        wait(for: [mockHealthStore.anchorQueryStartedExpectation!])
+        await fulfillment(of: [mockHealthStore.anchorQueryStartedExpectation!])
 
         let currentAnchor = HKQueryAnchor(fromValue: 5)
 
@@ -143,7 +133,7 @@ class InsulinDeliveryStoreTests: InsulinDeliveryStoreTestsBase {
         mockAnchoredObjectQuery.resultsHandler?(mockAnchoredObjectQuery, [], [], currentAnchor, nil)
 
         // Wait for observerQueryCompletionExpectation
-        waitForExpectations(timeout: 3)
+        await fulfillment(of: [observerQueryCompletionExpectation])
 
         XCTAssertNotNil(hkSampleStore.queryAnchor)
 
@@ -156,17 +146,17 @@ class InsulinDeliveryStoreTests: InsulinDeliveryStoreTestsBase {
         newSampleStore.anchoredObjectQueryType = MockHKAnchoredObjectQuery.self
 
         // Create a new glucose store, and ensure it uses the last query anchor
-        let _ = InsulinDeliveryStore(healthKitSampleStore: newSampleStore,
+        mockHealthStore.observerQueryStartedExpectation = expectation(description: "new observer query started")
+        let _ = await InsulinDeliveryStore(healthKitSampleStore: newSampleStore,
                                      cacheStore: cacheStore,
                                      provenanceIdentifier: HKSource.default().bundleIdentifier)
 
-        mockHealthStore.observerQueryStartedExpectation = expectation(description: "new observer query started")
 
         mockHealthStore.authorizationStatus = .sharingAuthorized
         newSampleStore.authorizationIsDetermined()
 
         // Wait for observerQueryCompletionExpectation
-        waitForExpectations(timeout: 3)
+        await fulfillment(of: [mockHealthStore.observerQueryStartedExpectation!])
 
         mockHealthStore.anchorQueryStartedExpectation = expectation(description: "new anchored object query started")
 
@@ -176,7 +166,7 @@ class InsulinDeliveryStoreTests: InsulinDeliveryStoreTestsBase {
         mockObserverQuery2.updateHandler?(mockObserverQuery2, {}, nil)
 
         // Wait for anchorQueryStartedExpectation
-        waitForExpectations(timeout: 3)
+        await fulfillment(of: [mockHealthStore.anchorQueryStartedExpectation!])
 
         // Assert new carb store is querying with the last anchor that our HealthKit mock returned
         let mockAnchoredObjectQuery2 = mockHealthStore.anchoredObjectQuery as! MockHKAnchoredObjectQuery
@@ -189,17 +179,7 @@ class InsulinDeliveryStoreTests: InsulinDeliveryStoreTestsBase {
     // MARK: - Fetching
 
     func testGetDoseEntries() async throws {
-        let addDoseEntriesCompletion = expectation(description: "addDoseEntries")
-        insulinDeliveryStore.addDoseEntries([entry1, entry2, entry3], from: device, syncVersion: 2) { result in
-            switch result {
-            case .failure(let error):
-                XCTFail("Unexpected failure: \(error)")
-            case .success:
-                break
-            }
-            addDoseEntriesCompletion.fulfill()
-        }
-        await fulfillment(of: [addDoseEntriesCompletion], timeout: 30)
+        try await insulinDeliveryStore.addDoseEntries([entry1, entry2, entry3], from: device, syncVersion: 2)
 
         var entries = try await insulinDeliveryStore.getDoseEntries()
         XCTAssertEqual(entries.count, 3)
@@ -252,73 +232,31 @@ class InsulinDeliveryStoreTests: InsulinDeliveryStoreTestsBase {
         XCTAssertEqual(entries[1].syncIdentifier, self.entry2.syncIdentifier)
         XCTAssertEqual(entries[1].scheduledBasalRate, self.entry2.scheduledBasalRate)
 
-        let purgeCachedInsulinDeliveryObjectsCompletion = expectation(description: "purgeCachedInsulinDeliveryObjects")
-        insulinDeliveryStore.purgeCachedInsulinDeliveryObjects() { error in
-            XCTAssertNil(error)
-            purgeCachedInsulinDeliveryObjectsCompletion.fulfill()
-        }
-        await fulfillment(of: [purgeCachedInsulinDeliveryObjectsCompletion], timeout: 30)
+        await insulinDeliveryStore.purgeCachedInsulinDeliveryObjects()
 
         entries = try await insulinDeliveryStore.getDoseEntries()
         XCTAssertEqual(entries.count, 0)
     }
 
-    func testLastBasalEndDate() {
-        let getLastImmutableBasalEndDate1Completion = expectation(description: "getLastImmutableBasalEndDate1")
-        insulinDeliveryStore.getLastImmutableBasalEndDate() { lastBasalEndDate in
-            XCTAssertNil(lastBasalEndDate)
-            getLastImmutableBasalEndDate1Completion.fulfill()
-        }
-        waitForExpectations(timeout: 30)
+    func testLastBasalEndDate() async throws {
+        var lastBasalEndDate = await insulinDeliveryStore.getLastImmutableBasalEndDate()
+        XCTAssertNil(lastBasalEndDate)
 
-        let addDoseEntriesCompletion = expectation(description: "addDoseEntries")
-        insulinDeliveryStore.addDoseEntries([entry1, entry2, entry3], from: device, syncVersion: 2) { result in
-            switch result {
-            case .failure(let error):
-                XCTFail("Unexpected failure: \(error)")
-            case .success:
-                break
-            }
-            addDoseEntriesCompletion.fulfill()
-        }
-        waitForExpectations(timeout: 30)
+        try await insulinDeliveryStore.addDoseEntries([entry1, entry2, entry3], from: device, syncVersion: 2)
 
-        let getLastImmutableBasalEndDate2Completion = expectation(description: "getLastImmutableBasalEndDate2")
-        insulinDeliveryStore.getLastImmutableBasalEndDate() { lastBasalEndDate in
-            XCTAssertEqual(lastBasalEndDate, self.entry2.endDate)
-            getLastImmutableBasalEndDate2Completion.fulfill()
-        }
-        waitForExpectations(timeout: 30)
+        lastBasalEndDate = await insulinDeliveryStore.getLastImmutableBasalEndDate()
+        XCTAssertEqual(lastBasalEndDate, self.entry2.endDate)
 
-        let purgeCachedInsulinDeliveryObjectsCompletion = expectation(description: "purgeCachedInsulinDeliveryObjects")
-        insulinDeliveryStore.purgeCachedInsulinDeliveryObjects() { error in
-            XCTAssertNil(error)
-            purgeCachedInsulinDeliveryObjectsCompletion.fulfill()
-        }
-        waitForExpectations(timeout: 30)
+        await insulinDeliveryStore.purgeCachedInsulinDeliveryObjects()
 
-        let getLastImmutableBasalEndDate3Completion = expectation(description: "getLastImmutableBasalEndDate3")
-        insulinDeliveryStore.getLastImmutableBasalEndDate() { lastBasalEndDate in
-            XCTAssertNil(lastBasalEndDate)
-            getLastImmutableBasalEndDate3Completion.fulfill()
-        }
-        waitForExpectations(timeout: 30)
+        lastBasalEndDate = await insulinDeliveryStore.getLastImmutableBasalEndDate()
+        XCTAssertNil(lastBasalEndDate)
     }
 
     // MARK: - Modification
 
     func testAddDoseEntries() async throws {
-        let addDoseEntries1Completion = expectation(description: "addDoseEntries1")
-        insulinDeliveryStore.addDoseEntries([entry1, entry2, entry3], from: device, syncVersion: 2) { result in
-            switch result {
-            case .failure(let error):
-                XCTFail("Unexpected failure: \(error)")
-            case .success:
-                break
-            }
-            addDoseEntries1Completion.fulfill()
-        }
-        await fulfillment(of: [addDoseEntries1Completion], timeout: 30)
+        try await insulinDeliveryStore.addDoseEntries([entry1, entry2, entry3], from: device, syncVersion: 2)
 
         var entries = try await insulinDeliveryStore.getDoseEntries()
         XCTAssertEqual(entries.count, 3)
@@ -350,17 +288,7 @@ class InsulinDeliveryStoreTests: InsulinDeliveryStoreTestsBase {
         XCTAssertEqual(entries[2].syncIdentifier, self.entry2.syncIdentifier)
         XCTAssertEqual(entries[2].scheduledBasalRate, self.entry2.scheduledBasalRate)
 
-        let addDoseEntries2Completion = expectation(description: "addDoseEntries2")
-        insulinDeliveryStore.addDoseEntries([entry3, entry1, entry2], from: device, syncVersion: 2) { result in
-            switch result {
-            case .failure(let error):
-                XCTFail("Unexpected failure: \(error)")
-            case .success:
-                break
-            }
-            addDoseEntries2Completion.fulfill()
-        }
-        await fulfillment(of: [addDoseEntries2Completion], timeout: 30)
+        try await insulinDeliveryStore.addDoseEntries([entry3, entry1, entry2], from: device, syncVersion: 2)
 
         entries = try await insulinDeliveryStore.getDoseEntries()
         XCTAssertEqual(entries.count, 3)
@@ -393,42 +321,23 @@ class InsulinDeliveryStoreTests: InsulinDeliveryStoreTestsBase {
         XCTAssertEqual(entries[2].scheduledBasalRate, self.entry2.scheduledBasalRate)
     }
 
-    func testAddDoseEntriesEmpty() {
-        let addDoseEntriesCompletion = expectation(description: "addDoseEntries")
-        insulinDeliveryStore.addDoseEntries([], from: device, syncVersion: 2) { result in
-            switch result {
-            case .failure(let error):
-                XCTFail("Unexpected failure: \(error)")
-            case .success:
-                break
-            }
-            addDoseEntriesCompletion.fulfill()
-        }
-        waitForExpectations(timeout: 30)
+    func testAddDoseEntriesEmpty() async throws {
+        try await insulinDeliveryStore.addDoseEntries([], from: device, syncVersion: 2)
     }
 
-    func testAddDoseEntriesNotification() {
+    func testAddDoseEntriesNotification() async throws {
         let doseEntriesDidChangeCompletion = expectation(description: "doseEntriesDidChange")
         let observer = NotificationCenter.default.addObserver(forName: InsulinDeliveryStore.doseEntriesDidChange, object: insulinDeliveryStore, queue: nil) { notification in
             doseEntriesDidChangeCompletion.fulfill()
         }
 
-        let addDoseEntriesCompletion = expectation(description: "addDoseEntries")
-        insulinDeliveryStore.addDoseEntries([entry1, entry2, entry3], from: device, syncVersion: 2) { result in
-            switch result {
-            case .failure(let error):
-                XCTFail("Unexpected failure: \(error)")
-            case .success:
-                break
-            }
-            addDoseEntriesCompletion.fulfill()
-        }
-        wait(for: [doseEntriesDidChangeCompletion, addDoseEntriesCompletion], timeout: 30, enforceOrder: true)
+        try await insulinDeliveryStore.addDoseEntries([entry1, entry2, entry3], from: device, syncVersion: 2)
+        await fulfillment(of: [doseEntriesDidChangeCompletion], timeout: 30)
 
         NotificationCenter.default.removeObserver(observer)
     }
 
-    func testManuallyEnteredDoses() {
+    func testManuallyEnteredDoses() async throws {
         let manualEntry = DoseEntry(type: .bolus,
                                     startDate: Date(timeIntervalSinceNow: -.minutes(15)),
                                     endDate: Date(timeIntervalSinceNow: -.minutes(10)),
@@ -438,81 +347,25 @@ class InsulinDeliveryStoreTests: InsulinDeliveryStoreTestsBase {
                                     syncIdentifier: "C0AB1CBD-6B36-4113-9D49-709A022B2451",
                                     manuallyEntered: true)
 
-        let addDoseEntriesCompletion = expectation(description: "addDoseEntries")
-        insulinDeliveryStore.addDoseEntries([entry1, manualEntry, entry2, entry3], from: device, syncVersion: 2) { result in
-            switch result {
-            case .failure(let error):
-                XCTFail("Unexpected failure: \(error)")
-            case .success:
-                break
-            }
-            addDoseEntriesCompletion.fulfill()
-        }
-        waitForExpectations(timeout: 30)
+        try await insulinDeliveryStore.addDoseEntries([entry1, manualEntry, entry2, entry3], from: device, syncVersion: 2)
 
-        let getManuallyEnteredDoses1Completion = expectation(description: "getManuallyEnteredDoses1")
-        insulinDeliveryStore.getManuallyEnteredDoses(since: .distantPast) { result in
-            switch result {
-            case .failure(let error):
-                XCTFail("Unexpected failure: \(error)")
-            case .success(let entries):
-                XCTAssertEqual(entries.count, 1)
-                XCTAssertEqual(entries[0], manualEntry)
-            }
-            getManuallyEnteredDoses1Completion.fulfill()
-        }
-        waitForExpectations(timeout: 30)
+        var entries = try await insulinDeliveryStore.getManuallyEnteredDoses(since: .distantPast)
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries[0], manualEntry)
 
-        let getManuallyEnteredDoses2Completion = expectation(description: "getManuallyEnteredDoses2")
-        insulinDeliveryStore.getManuallyEnteredDoses(since: Date(timeIntervalSinceNow: -.minutes(12))) { result in
-            switch result {
-            case .failure(let error):
-                XCTFail("Unexpected failure: \(error)")
-            case .success(let entries):
-                XCTAssertEqual(entries.count, 0)
-            }
-            getManuallyEnteredDoses2Completion.fulfill()
-        }
-        waitForExpectations(timeout: 30)
+        entries = try await insulinDeliveryStore.getManuallyEnteredDoses(since: Date(timeIntervalSinceNow: -.minutes(12)))
+        XCTAssertEqual(entries.count, 0)
 
-        let deleteAllManuallyEnteredDoses1Completion = expectation(description: "deleteAllManuallyEnteredDoses1")
-        insulinDeliveryStore.deleteAllManuallyEnteredDoses(since: Date(timeIntervalSinceNow: -.minutes(12))) { error in
-            XCTAssertNil(error)
-            deleteAllManuallyEnteredDoses1Completion.fulfill()
-        }
-        waitForExpectations(timeout: 30)
+        try await insulinDeliveryStore.deleteAllManuallyEnteredDoses(since: Date(timeIntervalSinceNow: -.minutes(12)))
 
-        let getManuallyEnteredDoses3Completion = expectation(description: "getManuallyEnteredDoses3")
-        insulinDeliveryStore.getManuallyEnteredDoses(since: .distantPast) { result in
-            switch result {
-            case .failure(let error):
-                XCTFail("Unexpected failure: \(error)")
-            case .success(let entries):
-                XCTAssertEqual(entries.count, 1)
-                XCTAssertEqual(entries[0], manualEntry)
-            }
-            getManuallyEnteredDoses3Completion.fulfill()
-        }
-        waitForExpectations(timeout: 30)
+        entries = try await insulinDeliveryStore.getManuallyEnteredDoses(since: .distantPast)
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries[0], manualEntry)
 
-        let deleteAllManuallyEnteredDose2Completion = expectation(description: "deleteAllManuallyEnteredDose2")
-        insulinDeliveryStore.deleteAllManuallyEnteredDoses(since: Date(timeIntervalSinceNow: -.minutes(20))) { error in
-            XCTAssertNil(error)
-            deleteAllManuallyEnteredDose2Completion.fulfill()
-        }
-        waitForExpectations(timeout: 30)
+        try await insulinDeliveryStore.deleteAllManuallyEnteredDoses(since: Date(timeIntervalSinceNow: -.minutes(20)))
 
-        let getManuallyEnteredDoses4Completion = expectation(description: "getManuallyEnteredDoses4")
-        insulinDeliveryStore.getManuallyEnteredDoses(since: .distantPast) { result in
-            switch result {
-            case .failure(let error):
-                XCTFail("Unexpected failure: \(error)")
-            case .success(let entries):
-                XCTAssertEqual(entries.count, 0)
-            }
-            getManuallyEnteredDoses4Completion.fulfill()
-        }
-        waitForExpectations(timeout: 30)
+        entries = try await insulinDeliveryStore.getManuallyEnteredDoses(since: .distantPast)
+        XCTAssertEqual(entries.count, 0)
     }
 
     // MARK: - Cache Management
@@ -522,28 +375,12 @@ class InsulinDeliveryStoreTests: InsulinDeliveryStoreTestsBase {
     }
 
     func testPurgeAllDoseEntries() async throws {
-        let addDoseEntriesCompletion = expectation(description: "addDoseEntries")
-        insulinDeliveryStore.addDoseEntries([entry1, entry2, entry3], from: device, syncVersion: 2) { result in
-            switch result {
-            case .failure(let error):
-                XCTFail("Unexpected failure: \(error)")
-            case .success:
-                break
-            }
-            addDoseEntriesCompletion.fulfill()
-        }
-        await fulfillment(of: [addDoseEntriesCompletion], timeout: 30)
+        try await insulinDeliveryStore.addDoseEntries([entry1, entry2, entry3], from: device, syncVersion: 2)
 
         var entries = try await insulinDeliveryStore.getDoseEntries()
         XCTAssertEqual(entries.count, 3)
 
-        let purgeAllDoseEntriesCompletion = expectation(description: "purgeAllDoseEntries")
-        insulinDeliveryStore.purgeAllDoseEntries(healthKitPredicate: HKQuery.predicateForObjects(from: HKSource.default())) { error in
-            XCTAssertNil(error)
-            purgeAllDoseEntriesCompletion.fulfill()
-
-        }
-        await fulfillment(of: [purgeAllDoseEntriesCompletion], timeout: 30)
+        try await insulinDeliveryStore.purgeDoseEntriesForSource(HKSource.default())
 
         entries = try await insulinDeliveryStore.getDoseEntries()
         XCTAssertEqual(entries.count, 0)
@@ -559,86 +396,39 @@ class InsulinDeliveryStoreTests: InsulinDeliveryStoreTestsBase {
                                      syncIdentifier: "7530B8CA-827A-4DE8-ADE3-9E10FF80A4A9",
                                      scheduledBasalRate: nil)
 
-        let addDoseEntriesCompletion = expectation(description: "addDoseEntries")
-        insulinDeliveryStore.addDoseEntries([entry1, entry2, entry3, expiredEntry], from: device, syncVersion: 2) { result in
-            switch result {
-            case .failure(let error):
-                XCTFail("Unexpected failure: \(error)")
-            case .success:
-                break
-            }
-            addDoseEntriesCompletion.fulfill()
-        }
-        await fulfillment(of: [addDoseEntriesCompletion], timeout: 30)
+        try await insulinDeliveryStore.addDoseEntries([entry1, entry2, entry3, expiredEntry], from: device, syncVersion: 2)
 
         let entries = try await insulinDeliveryStore.getDoseEntries()
         XCTAssertEqual(entries.count, 3)
     }
 
     func testPurgeCachedInsulinDeliveryObjects() async throws {
-        let addDoseEntriesCompletion = expectation(description: "addDoseEntries")
-        insulinDeliveryStore.addDoseEntries([entry1, entry2, entry3], from: device, syncVersion: 2) { result in
-            switch result {
-            case .failure(let error):
-                XCTFail("Unexpected failure: \(error)")
-            case .success:
-                break
-            }
-            addDoseEntriesCompletion.fulfill()
-        }
-        await fulfillment(of: [addDoseEntriesCompletion], timeout: 30)
+        try await insulinDeliveryStore.addDoseEntries([entry1, entry2, entry3], from: device, syncVersion: 2)
 
         var entries = try await insulinDeliveryStore.getDoseEntries()
         XCTAssertEqual(entries.count, 3)
 
-        let purgeCachedInsulinDeliveryObjects1Completion = expectation(description: "purgeCachedInsulinDeliveryObjects1")
-        insulinDeliveryStore.purgeCachedInsulinDeliveryObjects(before: Date(timeIntervalSinceNow: -.minutes(5))) { error in
-            XCTAssertNil(error)
-            purgeCachedInsulinDeliveryObjects1Completion.fulfill()
-
-        }
-        await fulfillment(of: [purgeCachedInsulinDeliveryObjects1Completion], timeout: 30)
+        await insulinDeliveryStore.purgeCachedInsulinDeliveryObjects(before: Date(timeIntervalSinceNow: -.minutes(5)))
 
         entries = try await insulinDeliveryStore.getDoseEntries()
         XCTAssertEqual(entries.count, 2)
 
-        let purgeCachedInsulinDeliveryObjects2Completion = expectation(description: "purgeCachedInsulinDeliveryObjects2")
-        insulinDeliveryStore.purgeCachedInsulinDeliveryObjects() { error in
-            XCTAssertNil(error)
-            purgeCachedInsulinDeliveryObjects2Completion.fulfill()
-
-        }
-        await fulfillment(of: [purgeCachedInsulinDeliveryObjects2Completion], timeout: 30)
+        await insulinDeliveryStore.purgeCachedInsulinDeliveryObjects()
 
         entries = try await insulinDeliveryStore.getDoseEntries()
         XCTAssertEqual(entries.count, 0)
     }
 
-    func testPurgeCachedInsulinDeliveryObjectsNotification() {
-        let addDoseEntriesCompletion = expectation(description: "addDoseEntries")
-        insulinDeliveryStore.addDoseEntries([entry1, entry2, entry3], from: device, syncVersion: 2) { result in
-            switch result {
-            case .failure(let error):
-                XCTFail("Unexpected failure: \(error)")
-            case .success:
-                break
-            }
-            addDoseEntriesCompletion.fulfill()
-        }
-        waitForExpectations(timeout: 30)
+    func testPurgeCachedInsulinDeliveryObjectsNotification() async throws {
+        try await insulinDeliveryStore.addDoseEntries([entry1, entry2, entry3], from: device, syncVersion: 2)
 
         let doseEntriesDidChangeCompletion = expectation(description: "doseEntriesDidChange")
         let observer = NotificationCenter.default.addObserver(forName: InsulinDeliveryStore.doseEntriesDidChange, object: insulinDeliveryStore, queue: nil) { notification in
             doseEntriesDidChangeCompletion.fulfill()
         }
 
-        let purgeCachedInsulinDeliveryObjectsCompletion = expectation(description: "purgeCachedInsulinDeliveryObjects")
-        insulinDeliveryStore.purgeCachedInsulinDeliveryObjects() { error in
-            XCTAssertNil(error)
-            purgeCachedInsulinDeliveryObjectsCompletion.fulfill()
-
-        }
-        wait(for: [doseEntriesDidChangeCompletion, purgeCachedInsulinDeliveryObjectsCompletion], timeout: 30, enforceOrder: true)
+        await insulinDeliveryStore.purgeCachedInsulinDeliveryObjects()
+        await fulfillment(of: [doseEntriesDidChangeCompletion], timeout: 30)
 
         NotificationCenter.default.removeObserver(observer)
     }
@@ -698,23 +488,23 @@ class InsulinDeliveryStoreQueryTests: PersistenceControllerTestCase {
     var queryAnchor: InsulinDeliveryStore.QueryAnchor!
     var limit: Int!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
 
-        insulinDeliveryStore = InsulinDeliveryStore(cacheStore: cacheStore,
+        insulinDeliveryStore = await InsulinDeliveryStore(cacheStore: cacheStore,
                                                     provenanceIdentifier: HKSource.default().bundleIdentifier)
         completion = expectation(description: "Completion")
         queryAnchor = InsulinDeliveryStore.QueryAnchor()
         limit = Int.max
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         limit = nil
         queryAnchor = nil
         completion = nil
         insulinDeliveryStore = nil
 
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func testDoseEmptyWithDefaultQueryAnchor() {

--- a/LoopKitHostedTests/InsulinDeliveryStoreTests.swift
+++ b/LoopKitHostedTests/InsulinDeliveryStoreTests.swift
@@ -223,7 +223,10 @@ class InsulinDeliveryStoreTests: InsulinDeliveryStoreTestsBase {
         XCTAssertEqual(entries[2].syncIdentifier, self.entry2.syncIdentifier)
         XCTAssertEqual(entries[2].scheduledBasalRate, self.entry2.scheduledBasalRate)
 
-        entries = try await insulinDeliveryStore.getDoseEntries(start: Date(timeIntervalSinceNow: -.minutes(3.75)), end: Date(timeIntervalSinceNow: -.minutes(1.75)))
+        let start = entry3.startDate.addingTimeInterval(.minutes(0.25))
+        let end = entry2.startDate.addingTimeInterval(.minutes(0.25))
+
+        entries = try await insulinDeliveryStore.getDoseEntries(start: start, end: end)
         XCTAssertEqual(entries.count, 2)
         XCTAssertEqual(entries[0].type, self.entry3.type)
         XCTAssertEqual(entries[0].startDate, self.entry3.startDate)

--- a/LoopKitTests/CarbStoreTests.swift
+++ b/LoopKitTests/CarbStoreTests.swift
@@ -15,8 +15,8 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
     var healthStore: HKHealthStoreMock!
     var carbStore: CarbStore!
     
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
 
         healthStore = HKHealthStoreMock()
 
@@ -29,22 +29,16 @@ class CarbStorePersistenceTests: PersistenceControllerTestCase, CarbStoreDelegat
             provenanceIdentifier: Bundle.main.bundleIdentifier!)
         carbStore.delegate = self
 
-        let semaphore = DispatchSemaphore(value: 0)
-        cacheStore.onReady { (error) in
-            semaphore.signal()
-        }
-        semaphore.wait()
-
     }
     
-    override func tearDown() {
+    override func tearDown() async throws {
         carbStore.delegate = nil
         carbStore = nil
         healthStore = nil
         
         carbStoreHasUpdatedCarbDataHandler = nil
         
-        super.tearDown()
+        try await super.tearDown()
     }
     
     // MARK: - CarbStoreDelegate
@@ -1016,8 +1010,8 @@ class CarbStoreQueryTests: PersistenceControllerTestCase {
     var queryAnchor: CarbStore.QueryAnchor!
     var limit: Int!
     
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
 
         let healthStore = HKHealthStoreMock()
 
@@ -1029,24 +1023,18 @@ class CarbStoreQueryTests: PersistenceControllerTestCase {
             cacheLength: .hours(24),
             provenanceIdentifier: Bundle.main.bundleIdentifier!)
 
-        let semaphore = DispatchSemaphore(value: 0)
-        cacheStore.onReady { (error) in
-            semaphore.signal()
-        }
-        semaphore.wait()
-
         completion = expectation(description: "Completion")
         queryAnchor = CarbStore.QueryAnchor()
         limit = Int.max
     }
     
-    override func tearDown() {
+    override func tearDown() async throws {
         limit = nil
         queryAnchor = nil
         completion = nil
         carbStore = nil
 
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func testEmptyWithDefaultQueryAnchor() {
@@ -1256,8 +1244,8 @@ class CarbStoreCriticalEventLogTests: PersistenceControllerTestCase {
     var outputStream: MockOutputStream!
     var progress: Progress!
     
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
 
         let objects = [SyncCarbObject(absorptionTime: nil, createdByCurrentApp: true, foodType: nil, grams: 11, startDate: dateFormatter.date(from: "2100-01-02T03:08:00Z")!, uuid: nil, provenanceIdentifier: Bundle.main.bundleIdentifier!, syncIdentifier: nil, syncVersion: nil, userCreatedDate: nil, userUpdatedDate: nil, userDeletedDate: nil, operation: .create, addedDate: dateFormatter.date(from: "2100-01-02T03:08:00Z")!, supercededDate: nil),
                        SyncCarbObject(absorptionTime: nil, createdByCurrentApp: true, foodType: nil, grams: 12, startDate: dateFormatter.date(from: "2100-01-02T03:10:00Z")!, uuid: nil, provenanceIdentifier: Bundle.main.bundleIdentifier!, syncIdentifier: nil, syncVersion: nil, userCreatedDate: nil, userUpdatedDate: nil, userDeletedDate: nil, operation: .create, addedDate: dateFormatter.date(from: "2100-01-02T03:10:00Z")!, supercededDate: nil),
@@ -1290,10 +1278,10 @@ class CarbStoreCriticalEventLogTests: PersistenceControllerTestCase {
         progress = Progress()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         carbStore = nil
 
-        super.tearDown()
+        try await super.tearDown()
     }
     
     func testExportProgressTotalUnitCount() {

--- a/LoopKitTests/DoseStoreTests.swift
+++ b/LoopKitTests/DoseStoreTests.swift
@@ -28,7 +28,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
 
     let doseStoreDelegate = DoseStoreDelegateMock()
 
-    func defaultStore(testingDate: Date? = nil, basalRateSchedule: BasalRateSchedule? = nil) -> DoseStore {
+    func defaultStore(testingDate: Date? = nil, basalRateSchedule: BasalRateSchedule? = nil) async -> DoseStore {
 
         let healthStore = HKHealthStoreMock()
 
@@ -64,7 +64,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
 
         doseStoreDelegate.basal = basal
 
-        let doseStore = DoseStore(
+        let doseStore = await DoseStore(
             healthKitSampleStore: sampleStore,
             cacheStore: cacheStore,
             longestEffectDuration: .hours(4),
@@ -73,12 +73,6 @@ class DoseStoreTests: PersistenceControllerTestCase {
             test_currentDate: testingDate
         )
         doseStore.delegate = doseStoreDelegate
-
-        let semaphore = DispatchSemaphore(value: 0)
-        cacheStore.onReady { (error) in
-            semaphore.signal()
-        }
-        semaphore.wait()
 
         return doseStore
     }
@@ -168,7 +162,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
         let doseStoreDelegate = DoseStoreDelegateMock()
         doseStoreDelegate.basal = basal
 
-        let doseStore = DoseStore(
+        let doseStore = await DoseStore(
             healthKitSampleStore: sampleStore,
             cacheStore: cacheStore,
             longestEffectDuration: .hours(4),
@@ -301,7 +295,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
         let doseStoreDelegate = DoseStoreDelegateMock()
         doseStoreDelegate.basal = basal
 
-        let doseStore = DoseStore(
+        let doseStore = await DoseStore(
             healthKitSampleStore: sampleStore,
             cacheStore: cacheStore,
             longestEffectDuration: .hours(4),
@@ -470,7 +464,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
         let doseStoreInitialization = expectation(description: "Expect DoseStore to finish initialization")
 
         // 1. Create a DoseStore
-        let doseStore = DoseStore(
+        let doseStore = await DoseStore(
             cacheStore: cacheStore,
             longestEffectDuration: .hours(4),
             syncVersion: 1,
@@ -526,7 +520,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
         let start = testingDate("2018-12-12 17:00:00 +0000")
         let now = start.addingTimeInterval(.minutes(20))
 
-        let doseStore = defaultStore(testingDate: now)
+        let doseStore = await defaultStore(testingDate: now)
 
         doseStore.insulinDeliveryStore.test_lastImmutableBasalEndDate = start
 
@@ -576,7 +570,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
         let doseStart = f("2018-12-12 16:45:00 +0000")
         let currentTime = doseStart.addingTimeInterval(.minutes(2))
 
-        let doseStore = defaultStore(testingDate: currentTime)
+        let doseStore = await defaultStore(testingDate: currentTime)
 
         doseStore.insulinDeliveryStore.test_lastImmutableBasalEndDate = doseStart //.addingTimeInterval(.minutes(-2))
 
@@ -600,7 +594,7 @@ class DoseStoreTests: PersistenceControllerTestCase {
 
     func testLaggingPumpReconciliationWithReservoir() async throws {
         let now = testingDate("2024-06-04 17:20:16 +0000")
-        let doseStore = defaultStore(testingDate: now)
+        let doseStore = await defaultStore(testingDate: now)
 
         let pumpEvents = [
             NewPumpEvent(
@@ -1111,31 +1105,25 @@ class DoseStoreQueryTests: PersistenceControllerTestCase {
     var queryAnchor: DoseStore.QueryAnchor!
     var limit: Int!
     
-    override func setUp() {
-        super.setUp()
-        
-        doseStore = DoseStore(cacheStore: cacheStore,
+    override func setUp() async throws {
+        try await super.setUp()
+
+        doseStore = await DoseStore(cacheStore: cacheStore,
                               longestEffectDuration: insulinModel.effectDuration,
                               provenanceIdentifier: Bundle.main.bundleIdentifier!)
-
-        let semaphore = DispatchSemaphore(value: 0)
-        cacheStore.onReady { (error) in
-            semaphore.signal()
-        }
-        semaphore.wait()
 
         completion = expectation(description: "Completion")
         queryAnchor = DoseStore.QueryAnchor()
         limit = Int.max
     }
     
-    override func tearDown() {
+    override func tearDown() async throws {
         limit = nil
         queryAnchor = nil
         completion = nil
         doseStore = nil
         
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func testPumpEventEmptyWithDefaultQueryAnchor() {
@@ -1303,8 +1291,8 @@ class DoseStoreCriticalEventLogTests: PersistenceControllerTestCase {
     var outputStream: MockOutputStream!
     var progress: Progress!
     
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
 
         let persistedDate = dateFormatter.date(from: "2100-01-02T03:00:00Z")!
         let url = URL(string: "http://a.b.com")!
@@ -1316,29 +1304,23 @@ class DoseStoreCriticalEventLogTests: PersistenceControllerTestCase {
 
         let semaphore = DispatchSemaphore(value: 0)
 
-        doseStore = DoseStore(cacheStore: cacheStore,
+        doseStore = await DoseStore(cacheStore: cacheStore,
                               longestEffectDuration: insulinModel.effectDuration,
                               provenanceIdentifier: Bundle.main.bundleIdentifier!, onReady: { error in
                                     semaphore.signal()
                                 }
         )
 
-        semaphore.wait()
-
-        Task {
-            try await doseStore.addPumpEvents(events: events)
-            semaphore.signal()
-        }
-        semaphore.wait()
+        try await doseStore.addPumpEvents(events: events)
 
         outputStream = MockOutputStream()
         progress = Progress()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         doseStore = nil
 
-        super.tearDown()
+        try await super.tearDown()
     }
     
     func testExportProgressTotalUnitCount() {
@@ -1406,8 +1388,8 @@ class DoseStoreEffectTests: PersistenceControllerTestCase {
 
     let dateFormatter = ISO8601DateFormatter.localTimeDate()
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         let healthStore = HKHealthStoreMock()
         let exponentialInsulinModel: InsulinModel = ExponentialInsulinModelPreset.rapidActingAdult
         let startDate = dateFormatter.date(from: "2015-07-13T12:00:00")!
@@ -1419,7 +1401,7 @@ class DoseStoreEffectTests: PersistenceControllerTestCase {
             type: HealthKitSampleStore.insulinQuantityType,
             observationEnabled: false)
 
-        doseStore = DoseStore(
+        doseStore = await DoseStore(
             healthKitSampleStore: sampleStore,
             cacheStore: cacheStore,
             longestEffectDuration: exponentialInsulinModel.effectDuration,
@@ -1428,10 +1410,10 @@ class DoseStoreEffectTests: PersistenceControllerTestCase {
         )
     }
     
-    override func tearDown() {
+    override func tearDown() async throws {
         doseStore = nil
         
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func loadGlucoseEffectFixture(_ resourceName: String) -> [GlucoseEffect] {

--- a/LoopKitTests/Extensions/HKHealthStoreMock.swift
+++ b/LoopKitTests/Extensions/HKHealthStoreMock.swift
@@ -42,6 +42,7 @@ class MockHKAnchoredObjectQuery: HKAnchoredObjectQuery {
 
 class HKHealthStoreMock: HKHealthStoreProtocol {
 
+
     func stop(_ query: HKQuery) {
     }
 
@@ -125,6 +126,15 @@ class HKHealthStoreMock: HKHealthStoreProtocol {
             completion(self.deleteError == nil, 0, self.deleteError)
         }
     }
+
+    func deleteObjects(of objectType: HKObjectType, predicate: NSPredicate) async throws -> Int {
+        self.deleteObjectsHandler?(objectType, predicate, self.deleteError == nil, 0, self.deleteError)
+        if let deleteError {
+            throw deleteError
+        }
+        return 0
+    }
+
 
     func setSaveHandler(_ saveHandler: ((_ objects: [HKObject], _ success: Bool, _ error: Error?) -> Void)?) {
         queue.sync {

--- a/LoopKitTests/Extensions/HKHealthStoreMock.swift
+++ b/LoopKitTests/Extensions/HKHealthStoreMock.swift
@@ -41,6 +41,7 @@ class MockHKAnchoredObjectQuery: HKAnchoredObjectQuery {
 
 
 class HKHealthStoreMock: HKHealthStoreProtocol {
+
     func stop(_ query: HKQuery) {
     }
 
@@ -101,6 +102,16 @@ class HKHealthStoreMock: HKHealthStoreProtocol {
             completion(self.saveError == nil, self.saveError)
         }
     }
+
+    func save(_ objects: [HKObject]) async throws {
+        try queue.sync {
+            self.saveHandler?(objects, self.saveError == nil, self.saveError)
+            if let error = self.saveError {
+                throw error
+            }
+        }
+    }
+
 
     func delete(_ objects: [HKObject], withCompletion completion: @escaping (Bool, Error?) -> Void) {
         queue.async {

--- a/LoopKitTests/GlucoseStoreTests.swift
+++ b/LoopKitTests/GlucoseStoreTests.swift
@@ -20,7 +20,7 @@ class GlucoseStoreTests: PersistenceControllerTestCase {
         try await super.setUp()
         
         healthStore = HKHealthStoreMock()
-        glucoseStore = GlucoseStore(cacheStore: cacheStore,
+        glucoseStore = await GlucoseStore(cacheStore: cacheStore,
                                     provenanceIdentifier: Bundle.main.bundleIdentifier!)
     }
     
@@ -101,7 +101,7 @@ class GlucoseStoreRemoteDataServiceQueryTests: PersistenceControllerTestCase {
     override func setUp() async throws {
         try await super.setUp()
 
-        glucoseStore = GlucoseStore(cacheStore: cacheStore,
+        glucoseStore = await GlucoseStore(cacheStore: cacheStore,
                                     provenanceIdentifier: Bundle.main.bundleIdentifier!)
 
         completion = expectation(description: "Completion")
@@ -316,7 +316,7 @@ class GlucoseStoreCriticalEventLogExportTests: PersistenceControllerTestCase {
                        NewGlucoseSample(date: dateFormatter.date(from: "2100-01-02T03:06:00Z")!, quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 114), condition: nil, trend: .up, trendRate: HKQuantity(unit: .milligramsPerDeciliterPerMinute, doubleValue: 1.0), isDisplayOnly: false, wasUserEntered: false, syncIdentifier: "FF1C4F01-3558-4FB2-957E-FA1522C4735E", syncVersion: 4),
                        NewGlucoseSample(date: dateFormatter.date(from: "2100-01-02T03:02:00Z")!, quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 400), condition: .aboveRange, trend: .upUpUp, trendRate: HKQuantity(unit: .milligramsPerDeciliterPerMinute, doubleValue: 1.0), isDisplayOnly: false, wasUserEntered: false, syncIdentifier: "71B699D7-0E8F-4B13-B7A1-E7751EB78E74", syncVersion: 5)]
 
-        glucoseStore = GlucoseStore(cacheStore: cacheStore,
+        glucoseStore = await GlucoseStore(cacheStore: cacheStore,
                                     provenanceIdentifier: Bundle.main.bundleIdentifier!)
 
         try await glucoseStore.addNewGlucoseSamples(samples: samples)

--- a/LoopKitTests/Persistence/CachedCarbObjectTests.swift
+++ b/LoopKitTests/Persistence/CachedCarbObjectTests.swift
@@ -29,12 +29,7 @@ class CachedCarbObjectTests: PersistenceControllerTestCase {
 
 class CachedCarbObjectEncodableTests: PersistenceControllerTestCase {
     func testEncodable() throws {
-        let semaphore = DispatchSemaphore(value: 0)
-
-        cacheStore.onReady { error in
-            semaphore.signal()
-        }
-        semaphore.wait()
+        
         cacheStore.managedObjectContext.performAndWait {
             let cachedCarbObject = CachedCarbObject(context: cacheStore.managedObjectContext)
             cachedCarbObject.absorptionTime = 18000

--- a/LoopKitTests/Persistence/PersistenceControllerTestCase.swift
+++ b/LoopKitTests/Persistence/PersistenceControllerTestCase.swift
@@ -12,26 +12,29 @@ class PersistenceControllerTestCase: XCTestCase {
  
     var cacheStore: PersistenceController!
 
-    override func setUp() {
-        super.setUp()
-
+    override func setUp() async throws {
+        try await super.setUp()
 
         let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
 
         cacheStore = PersistenceController(directoryURL: URL(fileURLWithPath: dir.absoluteString, isDirectory: true).appendingPathComponent(UUID().uuidString, isDirectory: true))
 
-        let semaphore = DispatchSemaphore(value: 0)
-        cacheStore.onReady { error in
-            semaphore.signal()
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) -> Void in
+            cacheStore.onReady { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
         }
-        semaphore.wait()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         cacheStore.tearDown()
         cacheStore = nil
 
-        super.tearDown()
+        try await super.tearDown()
     }
 
     deinit {

--- a/LoopKitUI/Views/Settings Editors/InsulinModelSelection.swift
+++ b/LoopKitUI/Views/Settings Editors/InsulinModelSelection.swift
@@ -207,7 +207,7 @@ public struct InsulinModelSelection: View {
                 InsulinMath.longestInsulinActivityDuration
             )
         )
-        let effects = [bolus].glucoseEffects(longestEffectDuration: .hours(6), insulinSensitivityTimeline: isfTimeline)
+        let effects = [bolus].glucoseEffects(insulinSensitivityHistory: isfTimeline)
         return LoopMath.predictGlucose(startingAt: startingGlucoseSample, effects: effects)
     }
 


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-5088

DispatchGroup.wait() calls were being used to synchronize storing to HealthKit when glucose and insulin data were being stored in Loop. These locks were being held inside of the managedObjectContext queue, so while they were held, all accesses to data stores would be blocked. Normally that's a short period of time, and it's released before any trouble can happen. But HealthKit does involve XPC communication to the `healthd` daemon, which, depending on how busy it is can take a while.

When new data is stored in Loop, many other processes kick off, like running a new loop, updating displays, etc, that all fetch data from the data stores. Now that we are using more async code, we are able to run more of those queries in parallel. Some of those queries end up blocking threads as well, via managedObjectContext.performAndWait() as the managedObjectContext is busy with hk storage. When enough threads are blocked, it can block other tasks/blocks from from being run, including tasks like handling xpc responses from healthd, which completes the circle to create deadlock.

By not holding a blocking these threads, by using async calls to healthkit, we allow other tasks to make progress, and avoid the deadlock.