### PR TITLE
LOOP-4665 Fix trimmed method to drop doses that are completely out of range

### DIFF
--- a/LoopKit/InsulinKit/DoseStore.swift
+++ b/LoopKit/InsulinKit/DoseStore.swift
@@ -984,7 +984,7 @@ extension DoseStore {
             chronological: true
             ).compactMap({ $0.dose })
         let normalizedDoses = doses.filterDateRange(start, nil).reconciled()
-        return normalizedDoses.map { $0.trimmed(from: start) }
+        return normalizedDoses.compactMap { $0.trimmed(from: start) }
     }
 
 
@@ -1091,7 +1091,10 @@ extension DoseStore {
                     let endOfReservoirData = self.lastStoredReservoirValue?.endDate ?? .distantPast
                     let startOfReservoirData = reservoirDoses.first?.startDate ?? filteredStart
                     let mutableDoses = try self.getNormalizedMutablePumpEventDoseEntries(start: endOfReservoirData)
-                    doses = insulinDeliveryDoses.map({ $0.trimmed(to: startOfReservoirData) }) + reservoirDoses + mutableDoses.map({ $0.trimmed(from: endOfReservoirData) })
+                    doses =
+                        insulinDeliveryDoses.compactMap({ $0.trimmed(to: startOfReservoirData) }) +
+                        reservoirDoses +
+                        mutableDoses.compactMap({ $0.trimmed(from: endOfReservoirData) })
                 } else {
                     // Deduplicates doses by syncIdentifier
                     doses = insulinDeliveryDoses.appendedUnion(with: try self.getNormalizedPumpEventDoseEntries(start: filteredStart, end: end))

--- a/LoopKit/InsulinKit/InsulinMath.swift
+++ b/LoopKit/InsulinKit/InsulinMath.swift
@@ -12,7 +12,11 @@ import LoopAlgorithm
 
 extension DoseEntry {
 
-    public func trimmed(from start: Date? = nil, to end: Date? = nil, syncIdentifier: String? = nil) -> DoseEntry {
+    public func trimmed(from start: Date? = nil, to end: Date? = nil, syncIdentifier: String? = nil) -> DoseEntry? {
+
+        guard startDate < end ?? .distantFuture, endDate > start ?? .distantPast else {
+            return nil
+        }
 
         let originalDuration = endDate.timeIntervalSince(startDate)
 
@@ -38,6 +42,7 @@ extension DoseEntry {
         newDose.value = trimmedValue
         newDose.deliveredUnits = trimmedDeliveredUnits
         newDose.syncIdentifier = syncIdentifier
+
         return newDose
     }
 }
@@ -197,8 +202,8 @@ extension Collection where Element == DoseEntry {
                     let endDate = Swift.min(last.endDate, dose.startDate)
 
                     // Ignore 0-duration doses
-                    if endDate > last.startDate {
-                        reconciled.append(last.trimmed(from: nil, to: endDate, syncIdentifier: last.syncIdentifier))
+                    if let dose = last.trimmed(from: nil, to: endDate, syncIdentifier: last.syncIdentifier) {
+                        reconciled.append(dose)
                     }
                 } else if var suspend = lastSuspend, dose.type == .tempBasal {
                     // Handle missing resume. Basal following suspend, with no resume.

--- a/LoopKitTests/DoseStoreTests.swift
+++ b/LoopKitTests/DoseStoreTests.swift
@@ -826,6 +826,10 @@ class DoseStoreTests: PersistenceControllerTestCase {
 
         let doses = try await doseStore.getNormalizedDoseEntries(start: now.addingTimeInterval(-.hours(6)), end: now)
         XCTAssertEqual(3, doses.count)
+
+        XCTAssertEqual(0.02, doses[0].deliveredUnits!, accuracy: 0.01) // First temp basal
+        XCTAssertEqual(0.41, doses[1].deliveredUnits!, accuracy: 0.01) // Part of second temp
+        XCTAssertEqual(0.75, doses[2].deliveredUnits!, accuracy: 0.01) // Reservoir
     }
 
 

--- a/LoopKitTests/InsulinMathTests.swift
+++ b/LoopKitTests/InsulinMathTests.swift
@@ -584,7 +584,7 @@ class InsulinMathTests: XCTestCase {
 
         // Last temp ends at 2015-10-15T22:29:50
         let endDate = dateFormatter.date(from: "2015-10-15T22:25:50")!
-        let trimmed = input.map { $0.trimmed(to: endDate) }
+        let trimmed = input.compactMap { $0.trimmed(to: endDate) }
 
         print(input, "\n\n\n")
         print(trimmed)
@@ -599,7 +599,7 @@ class InsulinMathTests: XCTestCase {
 
         // Last temp ends at 2015-10-15T22:29:50
         let endDate = dateFormatter.date(from: "2015-10-15T22:25:50")!
-        let trimmed = input.map { $0.trimmed(to: endDate) }
+        let trimmed = input.compactMap { $0.trimmed(to: endDate) }
 
         XCTAssertTrue(trimmed.last!.isMutable)
     }


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-4665

When switching to reservoir data, some cached doses were being returned from getNormalizedDoseEntries that were completely in the span of time that reservoir data was being used. Their dose amounts were 0, but it was still confusing to debug why there were 0 duration, 0 volume doses in the data.

Note: for some reason there are a lot of whitespace changes in DoseStoreTests.swifts.  You can use the ignore-whitespace option when viewing the diff. 