### PR TITLE
LOOP-5122 Onboarding provider is plugin host

### DIFF
--- a/LoopKitUI/OnboardingUI.swift
+++ b/LoopKitUI/OnboardingUI.swift
@@ -119,13 +119,6 @@ public protocol ServiceProvider: AnyObject {
 
     /// The descriptor list of available services.
     var availableServices: [ServiceDescriptor] { get }
-
-    /// Onboard the service with the specified identifier.
-    ///
-    /// - Parameters:
-    ///     - identifier: The identifier of the service to onboard.
-    /// - Returns: Either a conforming view controller to onboard the service, a newly onboarded service, or an error.
-    func onboardService(withIdentifier identifier: String) -> Result<OnboardingResult<ServiceViewController, Service>, Error>
 }
 
 public protocol TherapySettingsProvider {

--- a/LoopKitUI/OnboardingUI.swift
+++ b/LoopKitUI/OnboardingUI.swift
@@ -136,7 +136,7 @@ public protocol SupportProvider: AnyObject {
     var availableSupports: [SupportUI] { get }
 }
 
-public protocol OnboardingProvider: NotificationAuthorizationProvider, HealthStoreAuthorizationProvider, BluetoothProvider, CGMManagerProvider, PumpManagerProvider, StatefulPluggableProvider, ServiceProvider, TherapySettingsProvider, SupportProvider {
+public protocol OnboardingProvider: NotificationAuthorizationProvider, HealthStoreAuthorizationProvider, BluetoothProvider, CGMManagerProvider, PumpManagerProvider, StatefulPluggableProvider, ServiceProvider, TherapySettingsProvider, SupportProvider, PluginHost {
     var allowDebugFeatures: Bool { get }   // NOTE: DEBUG FEATURES - DEBUG AND TEST ONLY
 }
 


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-5122

Require OnboardingProvider to conform to PluginHost so onboarding plugins can use it for setting up services.