### PR TITLE
[QAE-486]Automate Test: Closed Loop Bolus ID's

### DIFF
--- a/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
+++ b/LoopKitUI/Views/Settings Editors/TherapySettingsView.swift
@@ -127,6 +127,7 @@ public struct TherapySettingsView: View {
         Button(action: dismissAction) {
             Text(LocalizedString("Done", comment: "Text for dismiss button"))
                 .bold()
+                .accessibilityIdentifier("button_done")
         }
     }
     

--- a/MockKitUI/View Controllers/MockCGMManagerSettingsViewController.swift
+++ b/MockKitUI/View Controllers/MockCGMManagerSettingsViewController.swift
@@ -255,6 +255,7 @@ final class MockCGMManagerSettingsViewController: UITableViewController {
                 }
             case .signalLoss:
                 cell.textLabel?.text = "Signal Loss"
+                cell.accessibilityIdentifier = "cell_SignalLoss"
                 if case .signalLoss = cgmManager.dataSource.model {
                     cell.accessoryType = .checkmark
                 }


### PR DESCRIPTION
Added accessibility identifiers for:
-Therapy Settings: Done button
-Cgm Manager settings: Signal Loss cell
Both identifiers required for associated ticket