### PR TITLE
LOOP-5351 Preset guardrail fixes

### DIFF
--- a/LoopKit/Extensions/Guardrail+Settings.swift
+++ b/LoopKit/Extensions/Guardrail+Settings.swift
@@ -56,19 +56,10 @@ public extension Guardrail where Value == LoopQuantity {
         )
     }
 
-    static func temporaryPresetCorrectionRange(suspendThreshold: GlucoseThreshold?) -> Guardrail<LoopQuantity> {
-        let absoluteLowerBound = suspendThreshold?.quantity ?? Guardrail.suspendThreshold.absoluteBounds.lowerBound
-        let recommendedLowerBound = [
-            absoluteLowerBound,
-            Guardrail.suspendThreshold.recommendedBounds.lowerBound
-        ].compactMap { $0 }.max()!
-
-        return Guardrail(
-            absoluteBounds: absoluteLowerBound...unconstrainedWorkoutCorrectionRange.absoluteBounds.upperBound,
-            recommendedBounds: recommendedLowerBound...unconstrainedWorkoutCorrectionRange.recommendedBounds.upperBound
+    static let temporaryPresetCorrectionRange = Guardrail(
+            absoluteBounds: Guardrail.suspendThreshold.absoluteBounds.lowerBound...unconstrainedWorkoutCorrectionRange.absoluteBounds.upperBound,
+            recommendedBounds: Guardrail.suspendThreshold.recommendedBounds.lowerBound...unconstrainedWorkoutCorrectionRange.recommendedBounds.upperBound
         )
-    }
-
 
     static let premealCorrectionRangeMaximum = LoopQuantity(unit: .milligramsPerDeciliter, doubleValue: 130.0)
 


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-5351

Preset correction guardrail for lower bound stays the same regardless of suspend threshold; we prevent selection of lower values with the minValue param