### PR TITLE
[LOOP-1114] Handle required version update at the app layer

### DIFF
--- a/LoopKit/Notification/LoopNotificationCategory.swift
+++ b/LoopKit/Notification/LoopNotificationCategory.swift
@@ -24,4 +24,5 @@ public enum LoopNotificationCategory: String {
     case remoteCarbsFailure
     case missedMeal
     case presetReminder
+    case requiredUpdate
 }

--- a/MockKitUI/MockSupport.swift
+++ b/MockKitUI/MockSupport.swift
@@ -36,7 +36,10 @@ public class MockSupport: SupportUI {
     }
    
     public func checkVersion(bundleIdentifier: String, currentVersion: String) async -> VersionUpdate? {
-        maybeIssueAlert(versionUpdate ?? .noUpdateNeeded)
+        let update = versionUpdate ?? .noUpdateNeeded
+        if update != .required {
+            maybeIssueAlert(update)
+        }
         return versionUpdate
     }
     


### PR DESCRIPTION
MockSupport no longer issues its own alert for .required version updates. Instead, it returns the enum value so Loop can handle it with a blocking modal and critical notification. Adds requiredUpdate notification category.