### PR TITLE
[LOOP-5925] Preserve scheduled basal rate in insulin delivery cache

### DIFF
--- a/LoopKit/InsulinKit/CachedInsulinDeliveryObject+CoreDataClass.swift
+++ b/LoopKit/InsulinKit/CachedInsulinDeliveryObject+CoreDataClass.swift
@@ -276,7 +276,7 @@ extension CachedInsulinDeliveryObject {
         self.endDate = entry.endDate
         self.syncIdentifier = entry.syncIdentifier
         self.deliveredUnits = entry.unitsInDeliverableIncrements
-        // A `.basal` dose's rate is its `value`; preserve it as the rate field so the cache reports the exact rate instead of one derived from a quantized delivered total.
+        // A `.basal` dose's rate (used via `.unitsPerHour` accessor) is its `value`; preserve it as the rate field so the cache reports the exact rate instead of one derived from a quantized delivered total.
         self.scheduledBasalRate = entry.scheduledBasalRate ?? (entry.type == .basal ? LoopQuantity(unit: .internationalUnitsPerHour, doubleValue: entry.unitsPerHour) : nil)
         self.programmedTempBasalRate = (entry.type == .tempBasal) ? LoopQuantity(unit: .internationalUnitsPerHour, doubleValue: entry.unitsPerHour) : nil
         self.programmedUnits = (entry.type == .bolus) ? entry.programmedUnits : nil
@@ -303,7 +303,7 @@ extension CachedInsulinDeliveryObject {
         self.endDate = entry.endDate
         self.syncIdentifier = entry.syncIdentifier
         self.deliveredUnits = entry.unitsInDeliverableIncrements
-        // A `.basal` dose's rate is its `value`; preserve it as the rate field so the cache reports the exact rate instead of one derived from a quantized delivered total.
+        // A `.basal` dose's rate is its `value` (used via `.unitsPerHour` accessor); preserve it as the rate field so the cache reports the exact rate instead of one derived from a quantized delivered total.
         self.scheduledBasalRate = entry.scheduledBasalRate ?? (entry.type == .basal ? LoopQuantity(unit: .internationalUnitsPerHour, doubleValue: entry.unitsPerHour) : nil)
         self.programmedTempBasalRate = (entry.type == .tempBasal) ? LoopQuantity(unit: .internationalUnitsPerHour, doubleValue: entry.unitsPerHour) : nil
         self.programmedUnits = (entry.type == .bolus) ? entry.programmedUnits : nil

--- a/LoopKit/InsulinKit/CachedInsulinDeliveryObject+CoreDataClass.swift
+++ b/LoopKit/InsulinKit/CachedInsulinDeliveryObject+CoreDataClass.swift
@@ -276,7 +276,8 @@ extension CachedInsulinDeliveryObject {
         self.endDate = entry.endDate
         self.syncIdentifier = entry.syncIdentifier
         self.deliveredUnits = entry.unitsInDeliverableIncrements
-        self.scheduledBasalRate = entry.scheduledBasalRate
+        // A `.basal` dose's rate is its `value`; preserve it as the rate field so the cache reports the exact rate instead of one derived from a quantized delivered total.
+        self.scheduledBasalRate = entry.scheduledBasalRate ?? (entry.type == .basal ? LoopQuantity(unit: .internationalUnitsPerHour, doubleValue: entry.unitsPerHour) : nil)
         self.programmedTempBasalRate = (entry.type == .tempBasal) ? LoopQuantity(unit: .internationalUnitsPerHour, doubleValue: entry.unitsPerHour) : nil
         self.programmedUnits = (entry.type == .bolus) ? entry.programmedUnits : nil
         self.reason = (entry.type == .bolus) ? .bolus : .basal
@@ -302,7 +303,8 @@ extension CachedInsulinDeliveryObject {
         self.endDate = entry.endDate
         self.syncIdentifier = entry.syncIdentifier
         self.deliveredUnits = entry.unitsInDeliverableIncrements
-        self.scheduledBasalRate = entry.scheduledBasalRate
+        // A `.basal` dose's rate is its `value`; preserve it as the rate field so the cache reports the exact rate instead of one derived from a quantized delivered total.
+        self.scheduledBasalRate = entry.scheduledBasalRate ?? (entry.type == .basal ? LoopQuantity(unit: .internationalUnitsPerHour, doubleValue: entry.unitsPerHour) : nil)
         self.programmedTempBasalRate = (entry.type == .tempBasal) ? LoopQuantity(unit: .internationalUnitsPerHour, doubleValue: entry.unitsPerHour) : nil
         self.programmedUnits = (entry.type == .bolus) ? entry.programmedUnits : nil
         self.reason = (entry.type == .bolus) ? .bolus : .basal

--- a/LoopKitHostedTests/InsulinDeliveryStoreTests.swift
+++ b/LoopKitHostedTests/InsulinDeliveryStoreTests.swift
@@ -20,7 +20,7 @@ class InsulinDeliveryStoreTestsBase: PersistenceControllerTestCase {
                                     decisionId: nil,
                                     deliveredUnits: 0.015,
                                     syncIdentifier: "4B14522E-A7B5-4E73-B76B-5043CD7176B0",
-                                    scheduledBasalRate: nil)
+                                    scheduledBasalRate: LoopQuantity(unit: .internationalUnitsPerHour, doubleValue: 1.8))
     internal let entry2 = DoseEntry(type: .tempBasal,
                                     startDate: Date(timeIntervalSinceNow: -.minutes(2)),
                                     endDate: Date(timeIntervalSinceNow: -.minutes(1.5)),
@@ -202,8 +202,8 @@ class InsulinDeliveryStoreTests: InsulinDeliveryStoreTestsBase {
         XCTAssertEqual(entries[0].type, self.entry1.type)
         XCTAssertEqual(entries[0].startDate, self.entry1.startDate)
         XCTAssertEqual(entries[0].endDate, self.entry1.endDate)
-        XCTAssertEqual(entries[0].value, 0.015)
-        XCTAssertEqual(entries[0].unit, .units)
+        XCTAssertEqual(entries[0].value, 1.8)
+        XCTAssertEqual(entries[0].unit, .unitsPerHour)
         XCTAssertEqual(entries[0].deliveredUnits, 0.015)
         XCTAssertEqual(entries[0].description, self.entry1.description)
         XCTAssertEqual(entries[0].syncIdentifier, self.entry1.syncIdentifier)
@@ -282,8 +282,8 @@ class InsulinDeliveryStoreTests: InsulinDeliveryStoreTestsBase {
         XCTAssertEqual(entries[0].type, self.entry1.type)
         XCTAssertEqual(entries[0].startDate, self.entry1.startDate)
         XCTAssertEqual(entries[0].endDate, self.entry1.endDate)
-        XCTAssertEqual(entries[0].value, 0.015)
-        XCTAssertEqual(entries[0].unit, .units)
+        XCTAssertEqual(entries[0].value, 1.8)
+        XCTAssertEqual(entries[0].unit, .unitsPerHour)
         XCTAssertEqual(entries[0].deliveredUnits, 0.015)
         XCTAssertEqual(entries[0].description, self.entry1.description)
         XCTAssertEqual(entries[0].syncIdentifier, self.entry1.syncIdentifier)
@@ -314,8 +314,8 @@ class InsulinDeliveryStoreTests: InsulinDeliveryStoreTestsBase {
         XCTAssertEqual(entries[0].type, self.entry1.type)
         XCTAssertEqual(entries[0].startDate, self.entry1.startDate)
         XCTAssertEqual(entries[0].endDate, self.entry1.endDate)
-        XCTAssertEqual(entries[0].value, 0.015)
-        XCTAssertEqual(entries[0].unit, .units)
+        XCTAssertEqual(entries[0].value, 1.8)
+        XCTAssertEqual(entries[0].unit, .unitsPerHour)
         XCTAssertEqual(entries[0].deliveredUnits, 0.015)
         XCTAssertEqual(entries[0].description, self.entry1.description)
         XCTAssertEqual(entries[0].syncIdentifier, self.entry1.syncIdentifier)

--- a/LoopKitTests/Persistence/CachedInsulinDeliveryObjectTests.swift
+++ b/LoopKitTests/Persistence/CachedInsulinDeliveryObjectTests.swift
@@ -346,6 +346,34 @@ class CachedInsulinDeliveryObjectOperationsTests: PersistenceControllerTestCase 
         }
     }
 
+    func testCreateFromScheduledBasalEntryPreservesRate() {
+        // A scheduled `.basal` reported without a scheduledBasalRate (e.g. after a PumpEvent
+        // round-trip, which doesn't persist it) must keep its exact rate. Without the fix the
+        // cache stores only the quantized delivered total and the read-back rate drifts.
+        let start = dateFormatter.date(from: "2020-01-02T03:04:05Z")!
+        let entry = DoseEntry(type: .basal,
+                              startDate: start,
+                              endDate: start.addingTimeInterval(180.2), // 3 min 0.2 s → quantized total would drift
+                              value: 1.0,
+                              unit: .unitsPerHour,
+                              decisionId: nil,
+                              deliveredUnits: nil,
+                              syncIdentifier: "scheduled-basal",
+                              scheduledBasalRate: nil,
+                              isMutable: true)
+        cacheStore.managedObjectContext.performAndWait {
+            let object = CachedInsulinDeliveryObject(context: cacheStore.managedObjectContext)
+            object.create(from: entry, by: "Test Providence Identifier", at: start)
+
+            XCTAssertEqual(object.scheduledBasalRate, LoopQuantity(unit: .internationalUnitsPerHour, doubleValue: 1.0))
+
+            let dose = object.dose
+            XCTAssertNotNil(dose)
+            XCTAssertEqual(dose!.unit, .unitsPerHour)
+            XCTAssertEqual(dose!.unitsPerHour, 1.0, accuracy: 1e-9)
+        }
+    }
+
     func testCreateAndUpdateFromEntry() {
         let createEntry = DoseEntry(type: .tempBasal,
                               startDate: dateFormatter.date(from: "2020-02-03T04:05:06Z")!,


### PR DESCRIPTION
Jira: [LOOP-5925](https://tidepool.atlassian.net/browse/LOOP-5925)

## Summary
A live (mutable) scheduled basal shows a rate slightly off from the scheduled rate (e.g. 0.999 / 1.001 U/hr for a 1.0 U/hr basal), snapping back to exact once the dose finalizes.

The exact rate is lost because a `.basal` dose's `scheduledBasalRate` is dropped when it round-trips through the `PumpEvent` Core Data entity (which has no column for it). `CachedInsulinDeliveryObject` then stores only the delivered total quantized to 0.05 U increments (`unitsInDeliverableIncrements`); on read-back with a nil rate it falls back to `unit == .units`, so the displayed rate becomes `delivered_total / elapsed` and drifts until the duration crosses a 0.05 U boundary. (Note: this is the on-device delivery cache — mutable doses are never written to HealthKit.)

For a `.basal` (scheduled basal, as opposed to `.tempBasal`) the rate is intrinsically the dose's `value`, so this preserves it directly: `CachedInsulinDeliveryObject.create(from:)`/`update(from:)` now derive `scheduledBasalRate` from the dose's own rate for `.basal` entries when it isn't already set.

- Display-only — net-insulin/IOB math is unchanged (basal net is always 0).
- No Core Data migration; no change to the pump-event contract.
- An existing `scheduledBasalRate` (e.g. one a pump manager provides) is still preferred when present.

Affects pumps that report explicit scheduled-basal events and aren't served from reservoir data; pumps that rely on LoopKit's basal interpolation were unaffected (those entries already get the rate stamped in `overlayBasal`).

## Test plan
- [x] Added `testCreateFromScheduledBasalEntryPreservesRate` — a mutable 1.0 U/hr `.basal` over a duration that would quantize to a drifting total; asserts the cached rate and round-tripped `dose.unitsPerHour` are exactly 1.0.
- [ ] CI: LoopKit unit tests pass.
- [ ] Verify on-device that a live scheduled basal in the Insulin Delivery Log shows the exact rate.

[LOOP-5925]: https://tidepool.atlassian.net/browse/LOOP-5925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ