### PR TITLE
Remove @State default value to fix Xcode 27 build

### DIFF
--- a/LoopKitUI/Views/Presets/CreatePresetNameAndScheduledEdit.swift
+++ b/LoopKitUI/Views/Presets/CreatePresetNameAndScheduledEdit.swift
@@ -55,9 +55,9 @@ struct CreatePresetNameAndScheduledEdit: View {
     ) {
         self._preset = preset
         self._path = path
-        self.isDurationPickerExpanded = isDurationPickerExpanded
         self.selectedRepeatOption = preset.wrappedValue.repeatOptions == .none ? .never : .weekly
         self.onCancel = onCancel
+        self.isDurationPickerExpanded = isDurationPickerExpanded
     }
 
     var body: some View {

--- a/LoopKitUI/Views/Presets/CreatePresetNameAndScheduledEdit.swift
+++ b/LoopKitUI/Views/Presets/CreatePresetNameAndScheduledEdit.swift
@@ -38,7 +38,7 @@ struct CreatePresetNameAndScheduledEdit: View {
     @Binding var preset: NewCustomPreset
     @Binding var path: NavigationPath
     
-    @State private var isDurationPickerExpanded = false
+    @State private var isDurationPickerExpanded: Bool
 
     @FocusState private var isTextFieldFocused: Bool
 
@@ -55,9 +55,9 @@ struct CreatePresetNameAndScheduledEdit: View {
     ) {
         self._preset = preset
         self._path = path
+        self.isDurationPickerExpanded = isDurationPickerExpanded
         self.selectedRepeatOption = preset.wrappedValue.repeatOptions == .none ? .never : .weekly
         self.onCancel = onCancel
-        self.isDurationPickerExpanded = isDurationPickerExpanded
     }
 
     var body: some View {


### PR DESCRIPTION
In Xcode 27, `@State` is a macro rather than a property wrapper. A `@State` property that has both a declaration-site default and an init assignment now fails to compile ("used before being initialized"), because assigning it in init counts as using self before all stored properties are set.